### PR TITLE
Fix language selection extension.

### DIFF
--- a/PROJECTS/ROLLER/func2.c
+++ b/PROJECTS/ROLLER/func2.c
@@ -4363,7 +4363,7 @@ void load_language_file(const char *szFilename, int iUseConfigBuffer)
   szExt = strstr(szFilename, ".eng");
 
   // get translation text extension string based on language index
-  szTextExt = (char *)TextExt[language];
+  szTextExt = (char *)TextExt + language * 4;
 
   // copy this text extension after the ".eng" part in the filename
   szFileExt = szExt + 1;  // skip the dot

--- a/PROJECTS/ROLLER/sound.c
+++ b/PROJECTS/ROLLER/sound.c
@@ -3694,7 +3694,7 @@ void convertname(char *szFilename)
   if (language != 0) {
     char *szExt = strstr(szFilename, ".RAW");
     if (szExt) {
-      const char *szLangExt = (const char *)SampleExt[language];
+      const char *szLangExt = (const char *)SampleExt + language * 4;
       strcpy(szExt + 1, szLangExt);
 
       FILE *fp = ROLLERfopen(szFilename, "rb");


### PR DESCRIPTION
I was trying to make sound samples to work, and found a issue related to the language selection in the `convertname` method.

Is needed to move the `SampleExt` by `language * 4` to select the correct extension.

And the same issue happens in the `load_language_file` in the `TextExt` needed to move by `language * 4` to select the correct extension.