### PR TITLE
Add `SDL_SetWindowPosition` to move to current display

### DIFF
--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -142,6 +142,14 @@ int InitSDL()
   SDL_Surface *pIcon = IMG_Load("roller.ico");
   SDL_SetWindowIcon(s_pWindow, pIcon);
 
+  // Move the window to the display where the mouse is currently located
+  float mouseX, mouseY;
+  SDL_GetGlobalMouseState(&mouseX, &mouseY);
+  int displayIndex = SDL_GetDisplayForPoint(&(SDL_Point) { mouseX, mouseY });
+  int sdl_window_centered = SDL_WINDOWPOS_CENTERED_DISPLAY(displayIndex);
+  SDL_SetWindowPosition(s_pWindow, sdl_window_centered, sdl_window_centered);
+
+  // Initialize game controllers
   SDL_InitSubSystem(SDL_INIT_GAMEPAD);
 
   // Open game controllers


### PR DESCRIPTION
Move the window to the display where the mouse is currently located to support multiple displays.