### PR TITLE
Remove `ErrorBoxExit` in `ROLLERopen`

### DIFF
--- a/PROJECTS/ROLLER/func3.c
+++ b/PROJECTS/ROLLER/func3.c
@@ -2853,7 +2853,7 @@ int load_champ(int iSlot)
   int iNonCompetitorFlags; // eax
   //int iArraySize; // esi
   //int iByteOffset; // eax
-  int iFlags; // ebp
+  int iFlags = 0; // ebp
   int iFlagCheck; // ecx
   int *piStatsPointer; // edx
   int iNetType; // eax
@@ -2884,7 +2884,7 @@ int load_champ(int iSlot)
   int iModemPortValue; // eax
   int iModemCallValue; // eax
   int iModemBaudValue; // eax
-  char *pszPhonePtr; // edx
+  char *pszPhonePtr = '\0'; // edx
   //int j; // eax
   //char byPhoneChar1; // bl
   //char *pszPhoneCharPtr; // edx

--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -842,13 +842,6 @@ FILE *ROLLERfopen(const char *szFile, const char *szMode)
   if (pFile) return pFile;
 
   pFile = fopen(szLower, szMode);
-
-  if (!pFile) {
-    char szErrorMsg[128];
-    snprintf(szErrorMsg, sizeof(szErrorMsg), "The file %s could not be opened.", szFile);
-    ErrorBoxExit(szErrorMsg);
-  }
-
   return pFile;
 }
 
@@ -872,13 +865,6 @@ int ROLLERopen(const char *szFile, int iOpenFlags)
   if (iHandle != -1) return iHandle;
 
   iHandle = open(szLower, iOpenFlags);
-
-  if (iHandle == -1) {
-    char szErrorMsg[128];
-    snprintf(szErrorMsg, sizeof(szErrorMsg), "The file %s could not be opened.", szFile);
-    ErrorBoxExit(szErrorMsg);
-  }
-
   return iHandle;
 }
 


### PR DESCRIPTION
When using a different language the `ROLLERopen` abort the application because some files does not exists in other language.

<img width="635" height="288" alt="image" src="https://github.com/user-attachments/assets/fef9cad2-a961-41b3-b99d-e0d518efd250" />

I remove the `ErrorBoxExit` in the `ROLLERopen` and `ROLLERfopen`.

And that fix the issue:

<img width="644" height="460" alt="image" src="https://github.com/user-attachments/assets/3d1e35ea-567b-4bc0-b0d2-74c42204073e" />



