### PR TITLE
Abort if `FATDATA` does not exist and autoselect language when `config.ini` is not found.

### DIFF
--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -240,6 +240,11 @@ int InitSDL()
     SDL_free((void *)home_dir);
   }
 
+  // check if the ./FATDATA/FATAL.INI to ensure the game can run
+  if (!ROLLERfexists("./FATDATA/FATAL.INI")) {
+    ErrorBoxExit("The folder FATDATA does not exist.\nROLLER requires the FATDATA folder assets from a retail copy of the game.");
+  }
+
   g_pTimerMutex = SDL_CreateMutex();
 
   if (!SDL_CreateWindowAndRenderer("ROLLER", 640, 400, SDL_WINDOW_RESIZABLE, &s_pWindow, &s_pRenderer)) {

--- a/PROJECTS/ROLLER/sound.c
+++ b/PROJECTS/ROLLER/sound.c
@@ -1484,13 +1484,48 @@ void devicespecificuninit()
 
 //-------------------------------------------------------------------------------------------------
 
+void autoselectsoundlanguage() // Add by ROLLER to auto-select languagename when config.ini is not found
+{
+  SDL_Log("autoselectsoundlanguage: config.ini not found");
+
+  // Set default language as English
+  sscanf(lang[0], "%s", languagename);
+  language = 0;
+  SoundCard = 1; // Set SoundCard to 1 to indicate sound is available
+
+  for (int i = 0; i < languages; i++) {
+    char audioFileName[32];
+    char textFileName[32];
+
+    const char *szTextExt = (char *)TextExt + i * 4;
+    const char *szLangExt = (const char *)SampleExt + i * 4;
+
+    snprintf(textFileName, sizeof(textFileName), "./CONFIG.%s", szTextExt); // e.g., CONFIG.ENG, CONFIG.FRA, CONFIG.GER, CONFIG.BPO, CONFIG.SAS.
+    snprintf(audioFileName, sizeof(audioFileName), "./GO.%s", szLangExt); // e.g., GO.RAW, GO.RFR, GO.RGE, GO.RBP, GO.RSS.
+
+    //SDL_Log("lang[%i]: %s", i, lang[i]);
+    //SDL_Log("textFileName[%i]: %s", i, textFileName);
+    //SDL_Log("audioFileName[%i]: %s", i, audioFileName);
+    if (ROLLERfexists(textFileName) && ROLLERfexists(audioFileName)) {
+      sscanf(lang[i], "%s", languagename);
+      language = i;
+      SDL_Log("autoselectsoundlanguage: select language[%i]: %s - %s %s", language, languagename, szTextExt, szLangExt);
+      break;
+    }
+  }
+}
+
 void readsoundconfig(void)
 {
   FILE *fp = ROLLERfopen("../config.ini", "rb");
   char *pBuffer = NULL;
   long iSize;
 
-  if (!fp) return;
+  if (!fp) 
+  {
+    autoselectsoundlanguage(); // Add by ROLLER to auto-select languagename
+    return;
+  }
 
   // Determine file size
   fseek(fp, 0, SEEK_END);


### PR DESCRIPTION
* Add `FATDATA/FATAL.INI` check in the `InitSDL`.
* Add `autoselectsoundlanguage` when `config.ini` is not found.