### PR TITLE
Use `font_ascii_replace_accent` to update `font6_ascii` and `ascii_conv3` in BR version

### DIFF
--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -530,6 +530,46 @@ uint8 oldkeys[14];        //0016FF04
 char my_name[14];         //0016FF12
 
 //-------------------------------------------------------------------------------------------------
+// Replace accented characters with non-accented equivalents in the font table - add by ROLLER
+void font_ascii_replace_accent(char *font)
+{
+  font[0xc7] = font['C']; // Ç
+  font[0xe7] = font['c']; // ç
+
+  font[0xc0] = font['A']; // À
+  font[0xc1] = font['A']; // Á
+  font[0xc2] = font['A']; // Â
+  font[0xc3] = font['A']; // Ã
+  font[0xe0] = font['a']; // à
+  font[0xe1] = font['a']; // á
+  font[0xe2] = font['a']; // â
+  font[0xe3] = font['a']; // ã
+
+  font[0xd3] = font['O']; // Ó
+  font[0xd5] = font['O']; // Õ
+  font[0xf3] = font['o']; // ó
+  font[0xf5] = font['o']; // õ
+
+  font[0xcd] = font['I']; // Í
+  font[0xed] = font['i']; // í
+
+  font[0xd9] = font['U']; // Ù
+  font[0xda] = font['U']; // Ú
+  font[0xfa] = font['u']; // ú
+  font[0xf9] = font['u']; // ù
+
+  font[0xc9] = font['E']; // É
+  font[0xc8] = font['E']; // È
+  font[0xc9] = font['E']; // Ê
+  font[0xe9] = font['e']; // é
+  font[0xe8] = font['e']; // è
+  font[0xea] = font['e']; // ê
+
+  font[0xd1] = font['N']; // Ñ
+  font[0xf1] = font['n']; // ñ
+}
+
+//-------------------------------------------------------------------------------------------------
 //0003F5B0
 void title_screens()
 {
@@ -576,6 +616,8 @@ void title_screens()
     memcpy(font2_ascii, font2_ascii_br, 256);
     memcpy(font3_ascii, font3_ascii_br, 256);
     memcpy(font4_ascii, font4_ascii_br, 256);
+    font_ascii_replace_accent((char *)font6_ascii);
+    font_ascii_replace_accent((char *)ascii_conv3);
   } 
 }
 

--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -341,6 +341,12 @@ void UpdateDebugLoop()
     int value = 0;
     int font = 0;
 
+    int _scr_size = scr_size; // Backup scr_size
+
+    LoadPanel(); // Load rev_vga array
+    scr_size = 64; // scale text size
+    screen_pointer = scrbuf; // Set screen pointer to scrbuf
+
     strcpy(text, "Debug font ascii");
 
     while (debugEnable) {
@@ -377,6 +383,22 @@ void UpdateDebugLoop()
 
       uint8 color_white = 0x8Fu;
       uint8 color_red = 0xE7u;
+
+      // Mini text print
+      scr_size = 64; // scale text size
+      mini_prt_centre(rev_vga[0], "0123456789", 320, 240 - 8);
+      prt_centrecol(rev_vga[1], "0123456789", 320, 240, color_white);
+      scr_size = 128; // scale text size
+      mini_prt_centre(rev_vga[0], "ABCDEFGHIJKLMNOPQRSTUVWXYZ", 320 / 2, (240 + 8) / 2);
+      prt_centrecol(rev_vga[1], "ABCDEFGHIJKLMNOPQRSTUVWXYZ", 320 / 2, (240 + 24) / 2, color_white);
+
+      // Mini text print with config_buffer
+      //mini_prt_centre(rev_vga[0], &config_buffer[value * 64], 320 / 2, (240 + 40) / 2); // This fail with `-`
+
+      prt_centrecol(rev_vga[1], &config_buffer[value * 64], 320 / 2, (240 + 56) / 2, color_white);
+      scr_size = 256; // scale text size
+      prt_centrecol(rev_vga[1], &config_buffer[value * 64], 320 / 4, (240 + 72) / 4, color_white);
+
 
       sprintf(buffer, "%s", text);
       front_text((tBlockHeader *)front_vga_font, buffer, font_ascii, font_offsets, 0, size / 2, color_white, 0);
@@ -432,6 +454,8 @@ void UpdateDebugLoop()
     fre((void **)&front_vga_font3);
     fre((void **)&front_vga_font2);
     fre((void **)&front_vga_font1);
+
+    scr_size = _scr_size; // Restore scr_size
   }
 }
 #endif


### PR DESCRIPTION
I was not able to find the correct table in the BR version for the `font6_ascii` and `ascii_conv3`.

This PR have a simple workaround to replace accented characters with non-accented equivalents in the font table.

