### PR TITLE
Add `UpdateSDLAudioEvents` to fix exception when Audio device is remove or added

### DIFF
--- a/PROJECTS/ROLLER/roller.h
+++ b/PROJECTS/ROLLER/roller.h
@@ -21,6 +21,7 @@ int InitSDL();
 void ShutdownSDL();
 void UpdateSDL();
 void UpdateSDLWindow();
+void UpdateSDLAudioEvents(SDL_Event e);
 
 bool MIDI_Init(const char *config_file);
 void MIDIDigi_PlayBuffer(uint8 *midi_buffer, uint32 midi_length);


### PR DESCRIPTION
This PR is related to fix the issue: #53