### PR TITLE
Fix control wrong map in `P1cheat`

### DIFF
--- a/PROJECTS/ROLLER/func2.c
+++ b/PROJECTS/ROLLER/func2.c
@@ -3835,20 +3835,20 @@ void load_fatal_config()
       getconfigvalue(pData2, "Names", &names_on, 0, 2);
 
       // Read keyboard mappings
-      getconfigvalueuc(pData2, "P1left",      (uint8*)&userkey[0], 0, 139);
-      getconfigvalueuc(pData2, "P1right",     (uint8*)&userkey[1], 0, 139);
-      getconfigvalueuc(pData2, "P1up",        (uint8*)&userkey[2], 0, 139);
-      getconfigvalueuc(pData2, "P1down",      (uint8*)&userkey[3], 0, 139);
-      getconfigvalueuc(pData2, "P1upgear",    (uint8*)&userkey[4], 0, 139);
-      getconfigvalueuc(pData2, "P1downgear",  (uint8*)&userkey[5], 0, 139);
-      getconfigvalueuc(pData2, "P1cheat",     (uint8*)&userkey[12], 0, 139);
-      getconfigvalueuc(pData2, "P2left",      (uint8*)&userkey[6], 0, 139);
-      getconfigvalueuc(pData2, "P2right",     (uint8*)&userkey[7], 0, 139);
-      getconfigvalueuc(pData2, "P2up",        (uint8*)&userkey[8], 0, 139);
-      getconfigvalueuc(pData2, "P2down",      (uint8*)&userkey[9], 0, 139);
-      getconfigvalueuc(pData2, "P2upgear",    (uint8*)&userkey[10], 0, 139);
-      getconfigvalueuc(pData2, "P2downgear",  (uint8*)&userkey[11], 0, 139);
-      getconfigvalueuc(pData2, "P2cheat",     (uint8*)&userkey[13], 0, 139);
+      getconfigvalueuc(pData2, "P1left",      (uint8*)&userkey[USERKEY_P1LEFT], 0, 139);
+      getconfigvalueuc(pData2, "P1right",     (uint8*)&userkey[USERKEY_P1RIGHT], 0, 139);
+      getconfigvalueuc(pData2, "P1up",        (uint8*)&userkey[USERKEY_P1UP], 0, 139);
+      getconfigvalueuc(pData2, "P1down",      (uint8*)&userkey[USERKEY_P1DOWN], 0, 139);
+      getconfigvalueuc(pData2, "P1upgear",    (uint8*)&userkey[USERKEY_P1UPGEAR], 0, 139);
+      getconfigvalueuc(pData2, "P1downgear",  (uint8*)&userkey[USERKEY_P1DOWNGEAR], 0, 139);
+      getconfigvalueuc(pData2, "P1cheat",     (uint8*)&userkey[USERKEY_P1CHEAT], 0, 139);
+      getconfigvalueuc(pData2, "P2left",      (uint8*)&userkey[USERKEY_P2LEFT], 0, 139);
+      getconfigvalueuc(pData2, "P2right",     (uint8*)&userkey[USERKEY_P2RIGHT], 0, 139);
+      getconfigvalueuc(pData2, "P2up",        (uint8*)&userkey[USERKEY_P2UP], 0, 139);
+      getconfigvalueuc(pData2, "P2down",      (uint8*)&userkey[USERKEY_P2DOWN], 0, 139);
+      getconfigvalueuc(pData2, "P2upgear",    (uint8*)&userkey[USERKEY_P2UPGEAR], 0, 139);
+      getconfigvalueuc(pData2, "P2downgear",  (uint8*)&userkey[USERKEY_P2DOWNGEAR], 0, 139);
+      getconfigvalueuc(pData2, "P2cheat",     (uint8*)&userkey[USERKEY_P2CHEAT], 0, 139);
 
       // Read joystick config
       getconfigvalue(pData2, "Joy1X", &iTemp, 0, 1);


### PR DESCRIPTION
The `USERKEY_P1CHEAT` is `6` in the enum mapping, the `load_fatal_config` is reading the `12`

```C
typedef enum
{
  USERKEY_P1LEFT = 0,
  USERKEY_P1RIGHT = 1,
  USERKEY_P1UP = 2,
  USERKEY_P1DOWN = 3,
  USERKEY_P1UPGEAR = 4,
  USERKEY_P1DOWNGEAR = 5,
  USERKEY_P1CHEAT = 6,
  USERKEY_P2LEFT = 7,
  USERKEY_P2RIGHT = 8,
  USERKEY_P2UP = 9,
  USERKEY_P2DOWN = 10,
  USERKEY_P2UPGEAR = 11,
  USERKEY_P2DOWNGEAR = 12,
  USERKEY_P2CHEAT = 13
} eUserKey;
```