### PR TITLE
prevent flickering while forcing max draw and extend to entire track

### DIFF
--- a/PROJECTS/ROLLER/loadtrak.c
+++ b/PROJECTS/ROLLER/loadtrak.c
@@ -419,12 +419,12 @@ void loadtrack(int iTrackIdx, int iPreviewMode)
 
         //added by ROLLER to force maximum draw distance
         if (g_bForceMaxDraw) {
-          iDrawOrder1 = 255;
-          iForwardExtraStart = 255;
-          iDrawOrder3 = 255;
-          iDrawOrderBackward = 255;
-          iBackwardExtraStart2 = 255;
-          iBackwardExtraChunks = 255;
+          iDrawOrder1 = TRAK_LEN - 1;
+          iForwardExtraStart = -1;
+          iDrawOrder3 = 0;
+          iDrawOrderBackward = TRAK_LEN - 1;
+          iBackwardExtraStart2 = -1;
+          iBackwardExtraChunks = 0;
         }
 
         if (bMinimalMode) {

--- a/PROJECTS/ROLLER/loadtrak.h
+++ b/PROJECTS/ROLLER/loadtrak.h
@@ -8,10 +8,10 @@
 typedef struct
 {
   int16 nForwardExtraStart;
-  uint8 byForwardMainChunks;
+  int16 byForwardMainChunks;
   uint8 byForwardExtraChunks;
   int16 nBackwardExtraStart;
-  uint8 byBackwardMainChunks;
+  int16 byBackwardMainChunks;
   uint8 byBackwardExtraChunks;
 } tTrakView;
 


### PR DESCRIPTION
Extra chunks must be disabled in order to prevent `mid_sec` having a value. This forces all chunks to be main chunks, thus preventing flickering. Main chunks can be the entire length as long as struct members are more than 8 bits.