### PR TITLE
Miscellaneous SDL fixes

### DIFF
--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -329,8 +329,10 @@ void ShutdownSDL()
   SDL_DestroyTexture(s_pWindowTexture);
   SDL_DestroyTexture(s_pDebugTexture);
 
-  free(s_pRGBBuffer);
-  free(s_pDebugBuffer);
+  if (s_pRGBBuffer) free(s_pRGBBuffer);
+  if (s_pDebugBuffer) free(s_pDebugBuffer);
+
+  SDL_Quit();
 }
 
 uint8 songId = 4;

--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -258,7 +258,6 @@ int InitSDL()
   const char *home_dir = SDL_GetBasePath();
   if (home_dir) {
     chdir(home_dir);
-    SDL_free((void *)home_dir);
   }
 
   ROLLERGetAudioInfo();


### PR DESCRIPTION
SDL_Quit was never called which is harmless on most modern systems, but it's still a good practice to call SDL_Quit before exit. I also removed the SDL_free after SDL_GetBasePath which is no longer necessary in SDL3.
