### PR TITLE
Center the joystick axes after loading FATAL.INI

### DIFF
--- a/PROJECTS/ROLLER/func2.c
+++ b/PROJECTS/ROLLER/func2.c
@@ -3881,6 +3881,8 @@ void load_fatal_config()
         JAXmax = iTemp2[0];
         if (iTemp2[0] < JAXmin)
           x1ok = 0;
+        // centering added by ROLLER
+        g_rollerJoyPos.iJ1XAxis = (JAXmax - JAXmin) / 2;
       }
       if (y1ok) {
         JAYmin = 10000;
@@ -3893,6 +3895,8 @@ void load_fatal_config()
         JAYmax = iTemp2[0];
         if (iTemp2[0] < JAYmin)
           y1ok = 0;
+        // centering added by ROLLER
+        g_rollerJoyPos.iJ1YAxis = (JAYmax - JAYmin) / 2;
       }
       if (x2ok) {
         JBXmin = 10000;
@@ -3905,6 +3909,8 @@ void load_fatal_config()
         JBXmax = iTemp2[0];
         if (iTemp2[0] < JBXmin)
           x2ok = 0;
+        // centering added by ROLLER
+        g_rollerJoyPos.iJ2XAxis = (JBXmax - JBXmin) / 2;
       }
       if (y2ok) {
         JBYmin = 10000;
@@ -3917,6 +3923,8 @@ void load_fatal_config()
         JBYmax = iTemp2[0];
         if (iTemp2[0] < JBYmin)
           y2ok = 0;
+        // centering added by ROLLER
+        g_rollerJoyPos.iJ2YAxis = (JBYmax - JBYmin) / 2;
       }
       if (JAXmin == JAXmax)
         JAXmax = JAXmin + 1;


### PR DESCRIPTION
The joystick axes in g_rollerJoyPos are 0 by default, which can cause problems because the values are expected to be in the 0-10000 range. This PR sets them to a neutral value in load_fatal_config based on the calibrated min/max values, so they don't they don't appear to be held in the upper-left position until the first relevant SDL event arrives. 