### PR TITLE
Parse command line arguments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,8 @@ root = true
 
 [*.{c,c++,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
 
+charset = utf-8
+
 # Visual C++ Code Style settings
 
 cpp_generate_documentation_comments = xml

--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -1028,7 +1028,7 @@ int main(int argc, const char **argv, const char **envp)
   const char *whiplash_root = NULL;
   const char *midi_root = NULL;
 
-  for (int i = 1; i < argc; i++) {
+  for (int i = 1; i < argc;) {
     int consumed = -1;
     if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
       print_usage(stdout, argv[0]);

--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -1007,17 +1007,58 @@ void draw_road(uint8 *pScrPtr, int iCarIdx, unsigned int uiViewMode, int iCopyIm
   }
 }
 
+static void print_usage(FILE *f, const char *argv0)
+{
+  fprintf(f, "usage: %s [--data-root DIR]\n\n");
+  fprintf(f, "options:\n");
+  fprintf(f, " -h, --help             show this help message and exit\n");
+  fprintf(f, " --whiplash-root DIR    specify Whiplash data directory\n");
+  fprintf(f, " --midi-root DIR        specify midi data directory\n");
+}
+
 //-------------------------------------------------------------------------------------------------
 //00011930
 int main(int argc, const char **argv, const char **envp)
 {
-  char *szDirectory; // eax
   int iMemBlocksIdx2; // eax
   int iMemBlocksIdx; // edx
   int nGameFlags; // edx
   int16 nCarIdx; // bx
+  int consumed = 0;
+  const char *whiplash_root = NULL;
+  const char *midi_root = NULL;
+
+  for (int i = 1; i < argc; i++) {
+    int consumed = -1;
+    if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+      print_usage(stdout, argv[0]);
+      return 0;
+    } else if (strcmp(argv[i], "--whiplash-root") == 0) {
+      if (i + 1 < argc) {
+        whiplash_root = argv[i + 1];
+        consumed = 2;
+      } else {
+        fprintf(stderr, "ERROR: '--whiplash-root' needs an argument\n");
+        return 1;
+      }
+    } else if (strcmp(argv[i], "--midi-root") == 0) {
+      if (i + 1 < argc) {
+        midi_root = argv[i + 1];
+        consumed = 2;
+      } else {
+        fprintf(stderr, "ERROR: '--midi-root' needs an argument\n");
+        return 1;
+      }
+    }
+    if (consumed < 0) {
+      fprintf(stderr, "ERROR: Unknown argument '%s'\n");
+      print_usage(stderr, argv[0]);
+      return 1;
+    }
+    i += consumed;
+  }
   
-  if (InitSDL(data_root) != 0) {
+  if (InitSDL(whiplash_root, midi_root) != 0) {
     return 1;
   }
 
@@ -1042,9 +1083,8 @@ int main(int argc, const char **argv, const char **envp)
   textures_off = 0;
   frontend_on = -1;
   claim_key_int();
-  szDirectory = (char *)*argv;
   max_mem = 0;                                  // Initialize memory tracking
-  setdirectory(szDirectory);
+  setdirectory(whiplash_root);
   iMemBlocksIdx2 = 0;
   do {
     iMemBlocksIdx = (int16)iMemBlocksIdx2++;  // Clear all memory block pointers

--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -1017,7 +1017,9 @@ int main(int argc, const char **argv, const char **envp)
   int nGameFlags; // edx
   int16 nCarIdx; // bx
   
-  InitSDL();
+  if (InitSDL(data_root) != 0) {
+    return 1;
+  }
 
   //gssCommsSetCommandBase(0x686C6361u);          // Initialize communication system with base command
   oldmode = readmode();                         // Save current video mode

--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -533,40 +533,40 @@ char my_name[14];         //0016FF12
 // Replace accented characters with non-accented equivalents in the font table - add by ROLLER
 void font_ascii_replace_accent(char *font)
 {
-  font[0xc7] = font['C']; // «
-  font[0xe7] = font['c']; // Á
+  font[0xc7] = font['C']; // √á
+  font[0xe7] = font['c']; // √ß
 
-  font[0xc0] = font['A']; // ¿
-  font[0xc1] = font['A']; // ¡
-  font[0xc2] = font['A']; // ¬
-  font[0xc3] = font['A']; // √
-  font[0xe0] = font['a']; // ‡
-  font[0xe1] = font['a']; // ·
-  font[0xe2] = font['a']; // ‚
-  font[0xe3] = font['a']; // „
+  font[0xc0] = font['A']; // √Ä
+  font[0xc1] = font['A']; // √Å
+  font[0xc2] = font['A']; // √Ç
+  font[0xc3] = font['A']; // √É
+  font[0xe0] = font['a']; // √†
+  font[0xe1] = font['a']; // √°
+  font[0xe2] = font['a']; // √¢
+  font[0xe3] = font['a']; // √£
 
-  font[0xd3] = font['O']; // ”
-  font[0xd5] = font['O']; // ’
-  font[0xf3] = font['o']; // Û
-  font[0xf5] = font['o']; // ı
+  font[0xd3] = font['O']; // √ì
+  font[0xd5] = font['O']; // √ï
+  font[0xf3] = font['o']; // √≥
+  font[0xf5] = font['o']; // √µ
 
-  font[0xcd] = font['I']; // Õ
-  font[0xed] = font['i']; // Ì
+  font[0xcd] = font['I']; // √ç
+  font[0xed] = font['i']; // √≠
 
-  font[0xd9] = font['U']; // Ÿ
-  font[0xda] = font['U']; // ⁄
-  font[0xfa] = font['u']; // ˙
-  font[0xf9] = font['u']; // ˘
+  font[0xd9] = font['U']; // √ô
+  font[0xda] = font['U']; // √ö
+  font[0xfa] = font['u']; // √∫
+  font[0xf9] = font['u']; // √π
 
-  font[0xc9] = font['E']; // …
-  font[0xc8] = font['E']; // »
-  font[0xc9] = font['E']; //  
-  font[0xe9] = font['e']; // È
-  font[0xe8] = font['e']; // Ë
-  font[0xea] = font['e']; // Í
+  font[0xc9] = font['E']; // √â
+  font[0xc8] = font['E']; // √à
+  font[0xc9] = font['E']; // √ä
+  font[0xe9] = font['e']; // √©
+  font[0xe8] = font['e']; // √®
+  font[0xea] = font['e']; // √™
 
-  font[0xd1] = font['N']; // —
-  font[0xf1] = font['n']; // Ò
+  font[0xd1] = font['N']; // √ë
+  font[0xf1] = font['n']; // √±
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/func2.c
+++ b/PROJECTS/ROLLER/func2.c
@@ -1879,38 +1879,29 @@ void DisplayFree()
 void setdirectory(const char *szAppPath)
 {
   char szLocalDir[256];
-  char *p = szLocalDir;
-  const char *s = szAppPath;
 
-  // Copy the path into localPath, 2 bytes at a time
-  while (true) {
-    *p++ = *s;
-    if (*s == '\0') break;
-    *p++ = *(s + 1);
-    s += 2;
-    if (*(s - 1) == '\0') break;
+  if (szAppPath) {
+    strncpy(szLocalDir, szAppPath, sizeof(szLocalDir));
+    szLocalDir[sizeof(szLocalDir) - 1] = '\0';
+  } else {
+    getcwd(szLocalDir, sizeof(szLocalDir));
+    szLocalDir[sizeof(szLocalDir) - 1] = '\0';
   }
+
+  // Trim trailing slashes
+  size_t lenLocalDir = strlen(szLocalDir);
+  while (lenLocalDir > 0 && szLocalDir[lenLocalDir - 1] == '/' || szLocalDir[lenLocalDir - 1] == '\\') {
+    lenLocalDir -= 1;
+  }
+  szLocalDir[lenLocalDir] = '\0';
 
 #ifdef IS_WINDOWS
   // Set current drive based on first letter of path (e.g., 'C' -> drive 3)
   char cDriveLetter = szLocalDir[0] & 0xDF; // Convert to uppercase
-  int iDrive = (int)(cDriveLetter - '@');  // 'A' => 1, 'C' => 3, etc.
+  int iDrive = (int)(cDriveLetter - 'A' + 1);  // 'A' => 1, 'C' => 3, etc.
   //dos_setdrive(iDrive, 0);
   _chdrive(iDrive);
 #endif
-
-  // Find last backslash in the path
-  char *szLastSlash = strrchr(szLocalDir, '\\');
-  if (!szLastSlash)
-    szLastSlash = strrchr(szLocalDir, '/'); //linux compatibility
-  if (szLastSlash && *(szLastSlash - 1) == ':') {
-    szLastSlash++;  // skip over ":"
-  }
-
-  // trim filename
-  if (szLastSlash) {
-    *szLastSlash = '\0';
-  }
 
   // set dir to szLocalDir
   chdir(szLocalDir);

--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -923,7 +923,7 @@ void apply_pan_u8(Uint8 *raw, int length, float pan)
   float right_gain = (pan >= 0) ? 1.0f : 1.0f + pan;
 
   for (int i = 0; i < frames; i++) {
-      // Convert from unsigned (0–255) to signed (-128…127)
+      // Convert from unsigned (0â€“255) to signed (-128â€¦127)
     int l = (int)raw[2 * i] - 128;
     int r = (int)raw[2 * i + 1] - 128;
 
@@ -935,7 +935,7 @@ void apply_pan_u8(Uint8 *raw, int length, float pan)
     if (l > 127) l = 127; if (l < -128) l = -128;
     if (r > 127) r = 127; if (r < -128) r = -128;
 
-    // Convert back to unsigned (0–255)
+    // Convert back to unsigned (0â€“255)
     raw[2 * i] = (Uint8)(l + 128);
     raw[2 * i + 1] = (Uint8)(r + 128);
   }

--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -250,8 +250,8 @@ void ToggleFullscreen()
 int InitSDL()
 {
   if (!SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO | SDL_INIT_JOYSTICK)) {
-    SDL_Log("Couldn't initialize SDL: %s", SDL_GetError());
-    return SDL_APP_FAILURE;
+    ErrorBoxExit("Couldn't initialize SDL: %s", SDL_GetError());
+    return 1;
   }
 
   // Change to the base path of the application
@@ -270,8 +270,8 @@ int InitSDL()
   g_pTimerMutex = SDL_CreateMutex();
 
   if (!SDL_CreateWindowAndRenderer("ROLLER", 640, 400, SDL_WINDOW_RESIZABLE, &s_pWindow, &s_pRenderer)) {
-    SDL_Log("Couldn't create window/renderer: %s", SDL_GetError());
-    return SDL_APP_FAILURE;
+    ErrorBoxExit("Couldn't create window/renderer: %s", SDL_GetError());
+    return 1;
   }
   s_pWindowTexture = SDL_CreateTexture(s_pRenderer, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, 640, 400);
   SDL_SetTextureScaleMode(s_pWindowTexture, SDL_SCALEMODE_NEAREST);
@@ -310,7 +310,7 @@ int InitSDL()
     SDL_Log("Failed to initialize WildMidi. Please check your configuration file ./midi/wildmidi.cfg.");
   }
 
-  return SDL_APP_SUCCESS;
+  return 0;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/roller.h
+++ b/PROJECTS/ROLLER/roller.h
@@ -21,7 +21,7 @@ extern int g_iNumTracks;
 //-------------------------------------------------------------------------------------------------
 
 // functions added by ROLLER
-int InitSDL();
+int InitSDL(const char *data_root, const char *midi_root);
 void ShutdownSDL();
 void UpdateSDL();
 void UpdateSDLWindow();

--- a/PROJECTS/ROLLER/sound.c
+++ b/PROJECTS/ROLLER/sound.c
@@ -3349,7 +3349,7 @@ void startmusic(int iSong)
         .iLength = musiclength,
       };
       MIDIInitSong(&InitSong);
-      fre(&musicbuffer);
+      fre((void **)&musicbuffer);
 
       // Play the song in the MIDI system
       MIDIStartSong();


### PR DESCRIPTION
By parsing the arguments, I can change the data root directory by passing `--whiplash-root <WHIPLAS-DATA-ROOT>`
The current code `chdir`s in `InitSDL` and `setdirectory`.

I also fix a few other things:
- fix error with Linux gcc
- `SDL_APP_*` macros are return codes for SDL main callbacks (`SDL_AppInit`, `SDL_AppIterate`, `SDL_AppEvent` and `SDL_AppQuit`)
- Convert all sources to utf-8 using iconv

I also added a `--midi-root` argument to specify the midi root. It default to location of the exe + `/midi`