### PR TITLE
Toggle added to prevent AI cheat boost on start

### DIFF
--- a/PROJECTS/ROLLER/control.c
+++ b/PROJECTS/ROLLER/control.c
@@ -1239,7 +1239,7 @@ void Accelerate(tCar *pCar)
           fPower = fPower + 32.0f;
         } else if (iGearAyMax == -1) {
           fPower = fCarComplexityFactor * 2.0f + fPower;
-        } else if (pCar->fTotalRaceTime >= 20.0f || human_control[pCar->iDriverIdx]) {
+        } else if (pCar->fTotalRaceTime >= 20.0f || human_control[pCar->iDriverIdx] || g_bAINoCheatStart) {  // Last check added by ROLLER
           fPower = (fHealthFactor + fCarComplexityFactor + fGravityFactor) * 0.5f + fPower;
         } else {
           fPower = (fHealthFactor + fCarComplexityFactor + fGravityFactor) / (float)(pCar->byRacePosition / 15 + 1) + fPower;

--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -64,6 +64,7 @@ SDL_JoystickID g_joyId1 = 0;
 SDL_JoystickID g_joyId2 = 0;
 bool g_bPaletteSet = false;
 bool g_bForceMaxDraw = false; //TODO: figure out why this causes some flickering, also load from INI file
+bool g_bAINoCheatStart = true;  //  Set true to not give AI cars an advantage during race start
 uint8 testbuf[4096];
 static uint8 *s_pRGBBuffer = NULL;
 static uint8 *s_pDebugBuffer = NULL;

--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -64,7 +64,7 @@ SDL_JoystickID g_joyId1 = 0;
 SDL_JoystickID g_joyId2 = 0;
 bool g_bPaletteSet = false;
 bool g_bForceMaxDraw = false; //TODO: figure out why this causes some flickering, also load from INI file
-bool g_bAINoCheatStart = true;  //  Set true to not give AI cars an advantage during race start
+bool g_bAINoCheatStart = false;  //  Set true to not give AI cars an advantage during race start
 uint8 testbuf[4096];
 static uint8 *s_pRGBBuffer = NULL;
 static uint8 *s_pDebugBuffer = NULL;

--- a/PROJECTS/ROLLER/roller.h
+++ b/PROJECTS/ROLLER/roller.h
@@ -14,6 +14,7 @@ extern SDL_Gamepad *g_pController2;
 extern tJoyPos g_rollerJoyPos;
 extern bool g_bPaletteSet;
 extern bool g_bForceMaxDraw;
+extern bool g_bAINoCheatStart;
 extern uint8 testbuf[4096];
 extern bool g_bRepeat;
 extern int g_iNumTracks;


### PR DESCRIPTION
Toggle g_bAINoCheatStart in roller.c [wasn't sure about naming convention].
Set to true to force AI to use car stats also on the first 20 seconds of the race to get realistic start behaviour.