### PR TITLE
Phase 4: GPU text rendering

### DIFF
--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -919,6 +919,13 @@ void select_screen()
         menu_render_fade_wait(mr, fade_redraw_bg, mr);
         fade_music_finish(0);
         palette_brightness = 0;
+        // Zero pal_addr so software screens see a black palette
+        // (GPU fade-out doesn't touch pal_addr, but fade_palette(0) expects it zeroed)
+        for (int i = 0; i < 256; i++) {
+          pal_addr[i].byR = 0;
+          pal_addr[i].byB = 0;
+          pal_addr[i].byG = 0;
+        }
       }
       if (game_type != 4 && game_type != 3)
         stopmusic();

--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -1023,31 +1023,31 @@ void select_screen()
       menu_render_sprite(mr, 6, 3, 52, 334, 0, pal_addr);
     } else {
       menu_render_sprite(mr, 6, 1, 52, 334, 0, pal_addr);
-      front_text(front_vga[2], "~", font2_ascii, font2_offsets, sel_posns[iMenuSelection].x, sel_posns[iMenuSelection].y, 0x8Fu, 0);
+      menu_render_text(mr, 2, "~", font2_ascii, font2_offsets, sel_posns[iMenuSelection].x, sel_posns[iMenuSelection].y, 0x8Fu, 0, pal_addr);
     }
     if (game_type == 1) {
-      front_text(front_vga[2], language_buffer, font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u);
+      menu_render_text(mr, 2, language_buffer, font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u, pal_addr);
       if (Race)
-        front_text(front_vga[2], &language_buffer[128], font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u);
+        menu_render_text(mr, 2, &language_buffer[128], font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u, pal_addr);
       else
-        front_text(front_vga[2], &language_buffer[64], font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u);
+        menu_render_text(mr, 2, &language_buffer[64], font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u, pal_addr);
     } else {
-      front_text(front_vga[2], &language_buffer[256], font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u);
-      front_text(front_vga[2], &language_buffer[320], font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u);
+      menu_render_text(mr, 2, &language_buffer[256], font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u, pal_addr);
+      menu_render_text(mr, 2, &language_buffer[320], font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u, pal_addr);
     }
-    front_text(front_vga[2], &language_buffer[192], font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], config_buffer, font2_ascii, font2_offsets, sel_posns[2].x + 132, sel_posns[2].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], &language_buffer[384], font2_ascii, font2_offsets, sel_posns[4].x + 132, sel_posns[4].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], &language_buffer[448], font2_ascii, font2_offsets, sel_posns[5].x + 132, sel_posns[5].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], &language_buffer[512], font2_ascii, font2_offsets, sel_posns[6].x + 132, sel_posns[6].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], &config_buffer[640], font2_ascii, font2_offsets, sel_posns[7].x + 132, sel_posns[7].y + 7, 0x8Fu, 2u);
+    menu_render_text(mr, 2, &language_buffer[192], font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, config_buffer, font2_ascii, font2_offsets, sel_posns[2].x + 132, sel_posns[2].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, &language_buffer[384], font2_ascii, font2_offsets, sel_posns[4].x + 132, sel_posns[4].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, &language_buffer[448], font2_ascii, font2_offsets, sel_posns[5].x + 132, sel_posns[5].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, &language_buffer[512], font2_ascii, font2_offsets, sel_posns[6].x + 132, sel_posns[6].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, &config_buffer[640], font2_ascii, font2_offsets, sel_posns[7].x + 132, sel_posns[7].y + 7, 0x8Fu, 2u, pal_addr);
     if (game_type == 1) {
       menu_render_sprite(mr, 14, (TrackLoad - 1) / 8, 500, 300, 0, pal_addr);
       if (TrackLoad <= 0) {
         if (TrackLoad)
-          front_text(front_vga[2], "EDITOR", font2_ascii, font2_offsets, 190, 350, 0x8Fu, 0);
+          menu_render_text(mr, 2, "EDITOR", font2_ascii, font2_offsets, 190, 350, 0x8Fu, 0, pal_addr);
         else
-          front_text(front_vga[2], "TRACK ZERO", font2_ascii, font2_offsets, 190, 350, 0x8Fu, 0);
+          menu_render_text(mr, 2, "TRACK ZERO", font2_ascii, font2_offsets, 190, 350, 0x8Fu, 0, pal_addr);
       } else if (TrackLoad >= 17) {
         menu_render_sprite(mr, 13, TrackLoad - 17, 190, 356, 0, pal_addr);
       } else {
@@ -1060,8 +1060,8 @@ void select_screen()
         if (competitors == 2)
           NoOfLaps = iCurLaps / 2;
         sprintf(buffer, "%s: %i", &language_buffer[4544], NoOfLaps);
-        front_text(front_vga[15], buffer, font1_ascii, font1_offsets, 420, 16, 0x8Fu, 1u);
-        front_text(front_vga[15], &language_buffer[4608], font1_ascii, font1_offsets, 420, 34, 0x8Fu, 1u);
+        menu_render_text(mr, 15, buffer, font1_ascii, font1_offsets, 420, 16, 0x8Fu, 1u, pal_addr);
+        menu_render_text(mr, 15, &language_buffer[4608], font1_ascii, font1_offsets, 420, 34, 0x8Fu, 1u, pal_addr);
         if (RecordCars[TrackLoad] < 0) {
           sprintf(buffer, "%s", RecordNames[TrackLoad]);
         } else {
@@ -1097,7 +1097,7 @@ void select_screen()
           //  iSeconds,
           //  (unsigned int)(llRecordLap % 100));
         }
-        front_text(front_vga[15], buffer, font1_ascii, font1_offsets, 420, 52, 0x8Fu, 1u);
+        menu_render_text(mr, 15, buffer, font1_ascii, font1_offsets, 420, 52, 0x8Fu, 1u, pal_addr);
       }
     } else if (iBlockIdx >= CAR_DESIGN_AUTO) {
       if (iBlockIdx == CAR_DESIGN_F1WACK)
@@ -1137,9 +1137,9 @@ void select_screen()
         break;
     }
     if (iBlockIdx < CAR_DESIGN_AUTO)
-      front_text(front_vga[15], &language_buffer[4160], font1_ascii, font1_offsets, 400, 200, 0xE7u, 1u);
+      menu_render_text(mr, 15, &language_buffer[4160], font1_ascii, font1_offsets, 400, 200, 0xE7u, 1u, pal_addr);
     if (iQuitConfirmed)
-      front_text(front_vga[15], &language_buffer[3456], font1_ascii, font1_offsets, 400, 250, 0xE7u, 1u);
+      menu_render_text(mr, 15, &language_buffer[3456], font1_ascii, font1_offsets, 400, 250, 0xE7u, 1u, pal_addr);
     show_received_mesage();
     menu_render_end_frame(mr);
     if (switch_same > 0) {

--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -1015,6 +1015,20 @@ void select_screen()
     check_cars();
 
     MenuRenderer *mr = GetMenuRenderer();
+    if (!front_fade) {
+      front_fade = -1;
+      menu_render_begin_fade(mr, 1, 32);
+      menu_render_fade_wait(mr, fade_redraw_bg, mr);
+      palette_brightness = 32;
+      frames = 0;
+      if (network_on) {
+        while (broadcast_mode)
+          UpdateSDL();
+        broadcast_mode = -1;
+        while (broadcast_mode)
+          UpdateSDL();
+      }
+    }
     menu_render_begin_frame(mr);
     menu_render_background(mr, 0);
     menu_render_sprite(mr, 1, 0, head_x, head_y, 0, pal_addr);
@@ -1224,23 +1238,6 @@ void select_screen()
         LoadCarTextures = iLoadCarTextures_1;
       }
       switch_sets = 0;
-    }
-    if (!front_fade) {
-      front_fade = -1;
-      {
-        MenuRenderer *mr = GetMenuRenderer();
-        menu_render_begin_fade(mr, 1, 32);
-        menu_render_fade_wait(mr, fade_redraw_bg, mr);
-        palette_brightness = 32;
-      }
-      frames = 0;
-      if (network_on) {
-        while (broadcast_mode)
-          UpdateSDL();
-        broadcast_mode = -1;
-        while (broadcast_mode)
-          UpdateSDL();
-      }
     }
     print_data = 0;
     while (1) {

--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -1274,6 +1274,20 @@ void select_screen()
               while (ppCartexVgaToFree_2 != (void **)&cartex_vga[16]);
               remove_mapsels();
             }
+            // GPU fade-out before leaving main menu to sub-menus
+            // (main menu is GPU-rendered, scrbuf is stale, so software
+            // fade_palette(0) in sub-menus would flash stale content)
+            {
+              MenuRenderer *mr2 = GetMenuRenderer();
+              menu_render_begin_fade(mr2, 0, 32);
+              menu_render_fade_wait(mr2, fade_redraw_bg, mr2);
+              palette_brightness = 0;
+              for (int i = 0; i < 256; i++) {
+                pal_addr[i].byR = 0;
+                pal_addr[i].byB = 0;
+                pal_addr[i].byG = 0;
+              }
+            }
             fre((void **)&front_vga[3]);
             fre((void **)&front_vga[13]);
             fre((void **)&front_vga[14]);

--- a/PROJECTS/ROLLER/menu_render.c
+++ b/PROJECTS/ROLLER/menu_render.c
@@ -159,6 +159,37 @@ static void RecordDraw(MenuRenderer *r, SDL_GPUTexture *texture,
     cmd->uniforms.replaceFromR = -1.0f;
 }
 
+static void RecordDrawWithColorReplace(MenuRenderer *r, SDL_GPUTexture *texture,
+                                       float alphaMul, uint8 fromIdx, uint8 toIdx,
+                                       const tColor *pal)
+{
+    if (r->vertexCount == 0 || r->drawCommandCount >= MAX_DRAW_COMMANDS) return;
+
+    DrawCommand *cmd = &r->drawCommands[r->drawCommandCount++];
+    cmd->texture = texture;
+    cmd->vertexOffset = r->vertexCount - 6;
+    cmd->vertexCount = 6;
+    memset(&cmd->uniforms, 0, sizeof(cmd->uniforms));
+    cmd->uniforms.alphaMul = alphaMul;
+
+    // No transparency discard — glyphs use alpha channel
+    cmd->uniforms.transparentR = cmd->uniforms.transparentG = cmd->uniforms.transparentB = -1.0f;
+
+    // Color replacement: fromIdx -> toIdx
+    if (pal) {
+        const tColor *fc = &pal[fromIdx];
+        cmd->uniforms.replaceFromR = ColorToFloat(fc->byR);
+        cmd->uniforms.replaceFromG = ColorToFloat(fc->byG);
+        cmd->uniforms.replaceFromB = ColorToFloat(fc->byB);
+        const tColor *tc = &pal[toIdx];
+        cmd->uniforms.replaceToR = ColorToFloat(tc->byR);
+        cmd->uniforms.replaceToG = ColorToFloat(tc->byG);
+        cmd->uniforms.replaceToB = ColorToFloat(tc->byB);
+    } else {
+        cmd->uniforms.replaceFromR = -1.0f;
+    }
+}
+
 static void ReplayDraws(MenuRenderer *r, SDL_GPURenderPass *renderPass)
 {
     float proj[16];
@@ -516,6 +547,110 @@ void menu_render_sprite(MenuRenderer *r, int slot, int blockIdx, int x, int y,
     if (!mt->texture) return;
     EmitQuad(r, (float)x, (float)y, (float)mt->width, (float)mt->height, 0, 0, 1, 1);
     RecordDraw(r, mt->texture, 1.0f, transparentIdx, pal);
+}
+
+//---------------------------------------------------------------------------
+// Text rendering
+//---------------------------------------------------------------------------
+
+void menu_render_text(MenuRenderer *r, int fontSlot, const char *text,
+                      const uint8 *mappingTable, int *charVOffsets,
+                      int x, int y, uint8 colorReplace, int alignment,
+                      const tColor *pal)
+{
+    if (!text || fontSlot < 0 || fontSlot >= MAX_SLOTS || !r->slotTextures[fontSlot])
+        return;
+
+    // Pass 1: measure width
+    int totalWidth = 0;
+    for (const char *p = text; *p; p++) {
+        if (*p == '\n') continue;
+        uint8 idx = mappingTable[(uint8)*p];
+        if (idx == 0xFF) { totalWidth += 8; continue; }
+        if (idx < r->slotTextureCount[fontSlot])
+            totalWidth += r->slotTextures[fontSlot][idx].width + 1;
+    }
+    if (totalWidth > 0) totalWidth--;
+
+    // Apply alignment
+    int curX = x;
+    if (alignment == 1) curX = x - totalWidth / 2;
+    else if (alignment == 2) curX = x - totalWidth;
+
+    // Pass 2: render glyphs
+    for (const char *p = text; *p; p++) {
+        if (*p == '\n') continue;
+        uint8 idx = mappingTable[(uint8)*p];
+        if (idx == 0xFF) { curX += 8; continue; }
+        if (idx >= r->slotTextureCount[fontSlot]) continue;
+
+        MenuTexture *g = &r->slotTextures[fontSlot][idx];
+        if (!g->texture) continue;
+
+        int cy = y + (charVOffsets ? charVOffsets[idx] : 0);
+
+        EmitQuad(r, (float)curX, (float)cy, (float)g->width, (float)g->height,
+                 0, 0, 1, 1);
+        RecordDrawWithColorReplace(r, g->texture, 1.0f, 0x8F, colorReplace, pal);
+
+        curX += g->width + 1;
+    }
+}
+
+void menu_render_scaled_text(MenuRenderer *r, int fontSlot, const char *text,
+                             const char *mappingTable, int *charVOffsets,
+                             int x, int y, char colorReplace,
+                             unsigned int alignment, int clipLeft, int clipRight,
+                             const tColor *pal)
+{
+    if (!text || fontSlot < 0 || fontSlot >= MAX_SLOTS || !r->slotTextures[fontSlot])
+        return;
+
+    // Measure unscaled width
+    int totalWidth = 0;
+    for (const char *p = text; *p; p++) {
+        uint8 idx = (uint8)mappingTable[(uint8)*p];
+        if (idx < r->slotTextureCount[fontSlot])
+            totalWidth += r->slotTextures[fontSlot][idx].width + 1;
+    }
+    if (totalWidth > 0) totalWidth--;
+
+    // Scale factor
+    int avail = clipRight - clipLeft;
+    float scale = 1.0f;
+    if (totalWidth > avail && avail > 0)
+        scale = (float)avail / (float)totalWidth;
+
+    float scaledWidth = totalWidth * scale;
+
+    // Alignment
+    float startX = (float)x;
+    if (alignment == 1) startX = x - scaledWidth / 2.0f;
+    else if (alignment == 2) startX = x - scaledWidth;
+
+    // Render scaled glyphs
+    float curX = startX;
+    for (const char *p = text; *p; p++) {
+        if (*p == '\n') continue;
+        uint8 idx = (uint8)mappingTable[(uint8)*p];
+        if (idx == 0xFF) { curX += 8 * scale; continue; }
+        if (idx >= r->slotTextureCount[fontSlot]) continue;
+
+        MenuTexture *g = &r->slotTextures[fontSlot][idx];
+        if (!g->texture) { curX += scale; continue; }
+
+        float cw = g->width * scale;
+        float ch = g->height * scale;
+        int cy = y + (charVOffsets ? charVOffsets[idx] : 0);
+
+        if (curX + cw >= clipLeft && curX <= clipRight) {
+            EmitQuad(r, curX, (float)cy, cw, ch, 0, 0, 1, 1);
+            RecordDrawWithColorReplace(r, g->texture, 1.0f, 0x8F,
+                                       (uint8)colorReplace, pal);
+        }
+
+        curX += cw + scale;
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/menu_render.c
+++ b/PROJECTS/ROLLER/menu_render.c
@@ -172,8 +172,10 @@ static void RecordDrawWithColorReplace(MenuRenderer *r, SDL_GPUTexture *texture,
     memset(&cmd->uniforms, 0, sizeof(cmd->uniforms));
     cmd->uniforms.alphaMul = alphaMul;
 
-    // No transparency discard — glyphs use alpha channel
-    cmd->uniforms.transparentR = cmd->uniforms.transparentG = cmd->uniforms.transparentB = -1.0f;
+    // Enable alpha-based transparency discard (shader checks transparentR >= 0)
+    cmd->uniforms.transparentR = 0.0f;
+    cmd->uniforms.transparentG = 0.0f;
+    cmd->uniforms.transparentB = 0.0f;
 
     // Color replacement: fromIdx -> toIdx
     if (pal) {

--- a/PROJECTS/ROLLER/menu_render.h
+++ b/PROJECTS/ROLLER/menu_render.h
@@ -40,6 +40,18 @@ int menu_render_fade_active(MenuRenderer *renderer);
 void menu_render_fade_wait(MenuRenderer *renderer,
                            void (*redraw_fn)(void *ctx), void *ctx);
 
+// Text rendering
+void menu_render_text(MenuRenderer *renderer, int fontSlot, const char *text,
+                      const uint8 *mappingTable, int *charVOffsets,
+                      int x, int y, uint8 colorReplace, int alignment,
+                      const tColor *palette);
+void menu_render_scaled_text(MenuRenderer *renderer, int fontSlot,
+                             const char *text, const char *mappingTable,
+                             int *charVOffsets, int x, int y,
+                             char colorReplace, unsigned int alignment,
+                             int clipLeft, int clipRight,
+                             const tColor *palette);
+
 // 3D preview compositing
 void menu_render_preview(MenuRenderer *renderer, const uint8 *previewBuf,
                          int width, int height, int destX, int destY,


### PR DESCRIPTION
## Summary
- Implement `menu_render_text` and `menu_render_scaled_text` with per-glyph GPU quad emission
- Wire GPU text rendering into the main menu, replacing `front_text`/`scale_text` calls
- Fix glyph transparency via alpha discard in the pixel shader
- Fix fade timing to prevent visual flashes during screen transitions

## Plan
`docs/plans/2026-03-17-menu-gpu-rendering.md` — Phase 4

## Stack
- Phase 1 (merged): GPU bootstrap
- Phase 2: Renderer skeleton + shaders
- Phase 3: Main menu integration + fades
- **Phase 4** (this PR): Text rendering
- Phase 5: Remaining menu screens
- Phase 6: 3D preview meshes
- Phase 7: GPU/software mode switching