### PR TITLE
Phase 5: Convert remaining menu screens to GPU

### DIFF
--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -6392,6 +6392,20 @@ void NetworkWait()
   front_vga[15] = (tBlockHeader *)load_picture("font1.bm");
   iContinueLoop = -1;
   setpal("result.pal");
+  // Restore palette for GPU rendering
+  {
+    extern tColor palette[];
+    memcpy(pal_addr, palette, 256 * sizeof(tColor));
+    palette_brightness = 32;
+    MenuRenderer *mr = GetMenuRenderer();
+    if (mr) {
+      menu_render_load_blocks(mr, 0, front_vga[0], palette);
+      menu_render_load_blocks(mr, 1, front_vga[1], palette);
+      menu_render_load_blocks(mr, 2, front_vga[2], palette);
+      menu_render_load_blocks(mr, 3, front_vga[3], palette);
+      menu_render_load_blocks(mr, 15, front_vga[15], palette);
+    }
+  }
   if (network_on) {
     while (1) {
       UpdateSDL();
@@ -6440,11 +6454,14 @@ void NetworkWait()
       }
     LABEL_26:
       check_cars();
-      display_picture(scrbuf, front_vga[0]);    // Main network lobby display loop - show waiting screen
+      {                                           // RENDER FRAME (GPU)
+      MenuRenderer *mr = GetMenuRenderer();
+      menu_render_begin_frame(mr);
+      menu_render_background(mr, 0);             // Main network lobby display loop - show waiting screen
       sprintf(buffer, "%s: %i", &language_buffer[64], players);
-      front_text(front_vga[1], buffer, font2_ascii, font2_offsets, 16, 4, 0x8Fu, 0);
+      menu_render_text(mr, 1, buffer, font2_ascii, font2_offsets, 16, 4, 0x8Fu, 0, pal_addr);
       sprintf(buffer, "%s: %i", &language_buffer[256], TrackLoad);
-      front_text(front_vga[1], buffer, font2_ascii, font2_offsets, 16, 24, 0x8Fu, 0);
+      menu_render_text(mr, 1, buffer, font2_ascii, font2_offsets, 16, 24, 0x8Fu, 0, pal_addr);
       if (game_type)                          // Display game type text based on current mode
       {
         if ((unsigned int)game_type <= 1) {
@@ -6455,11 +6472,11 @@ void NetworkWait()
       } else {
         sprintf(buffer, "%s", &language_buffer[3648]);
       }
-      front_text(front_vga[1], buffer, font2_ascii, font2_offsets, 200, 4, 0x8Fu, 1u);
+      menu_render_text(mr, 1, buffer, font2_ascii, font2_offsets, 200, 4, 0x8Fu, 1u, pal_addr);
       if (players_waiting == network_on)      // Show flashing "Ready to start" message when all players connected
       {
         if ((frames & 0xFu) < 8)
-          front_text(front_vga[1], &language_buffer[4800], font2_ascii, font2_offsets, 200, 22, 0x8Fu, 1u);
+          menu_render_text(mr, 1, &language_buffer[4800], font2_ascii, font2_offsets, 200, 22, 0x8Fu, 1u, pal_addr);
         if (time_to_start)
           iContinueLoop = 0;
       }
@@ -6471,28 +6488,28 @@ void NetworkWait()
         iTextYPos = 49;
         do {                                       // Show flashing indicator for player1, solid for others
           if (player_started[iPlayerIndex] && (!iPlayerDisplayLoop && (frames & 0xFu) < 8 || iPlayerDisplayLoop > 0))
-            display_block(scrbuf, front_vga[2], 0, 13, iY, 0);
+            menu_render_sprite(mr, 2, 0, 13, iY, 0, pal_addr);
           sprintf(buffer, "%i", iPlayerDisplayLoop + 1);
           iCarSpriteYOffset = 22 * iPlayerDisplayLoop;
-          front_text(front_vga[1], buffer, font2_ascii, font2_offsets, 33, iTextYPos, 0x8Fu, 0);
+          menu_render_text(mr, 1, buffer, font2_ascii, font2_offsets, 33, iTextYPos, 0x8Fu, 0, pal_addr);
           sprintf(buffer, "%s", szCurrentPlayerName);
-          front_text(front_vga[1], buffer, font2_ascii, font2_offsets, 85, iTextYPos, 0x8Fu, 0);
+          menu_render_text(mr, 1, buffer, font2_ascii, font2_offsets, 85, iTextYPos, 0x8Fu, 0, pal_addr);
           iCarType = Players_Cars[iPlayerIndex];
           if (iCarType >= 0)                  // Display car company name and sprite if valid car selected
           {
             sprintf(buffer, "%s", CompanyNames[iCarType]);
-            front_text(front_vga[1], buffer, font2_ascii, font2_offsets, 218, iTextYPos, 0x8Fu, 0);
+            menu_render_text(mr, 1, buffer, font2_ascii, font2_offsets, 218, iTextYPos, 0x8Fu, 0, pal_addr);
             iCarTypeForSprite = Players_Cars[iPlayerIndex];
             if (iCarTypeForSprite < 8) {
               if ((textures_off & TEX_OFF_ADVANCED_CARS) != 0)
-                display_block(scrbuf, front_vga[2], smallcars[1][iCarTypeForSprite], 165, iCarSpriteYOffset + 46, 0);
+                menu_render_sprite(mr, 2, smallcars[1][iCarTypeForSprite], 165, iCarSpriteYOffset + 46, 0, pal_addr);
               else
-                display_block(scrbuf, front_vga[2], smallcars[0][iCarTypeForSprite], 165, iCarSpriteYOffset + 46, 0);
+                menu_render_sprite(mr, 2, smallcars[0][iCarTypeForSprite], 165, iCarSpriteYOffset + 46, 0, pal_addr);
             } else {
-              front_text(front_vga[1], "CHEAT", font2_ascii, font2_offsets, 165, iTextYPos, 0x8Fu, 0);
+              menu_render_text(mr, 1, "CHEAT", font2_ascii, font2_offsets, 165, iTextYPos, 0x8Fu, 0, pal_addr);
             }
           } else {
-            front_text(front_vga[1], &language_buffer[4160], font2_ascii, font2_offsets, 218, iTextYPos, 0x8Fu, 0);
+            menu_render_text(mr, 1, &language_buffer[4160], font2_ascii, font2_offsets, 218, iTextYPos, 0x8Fu, 0, pal_addr);
           }
           ++iPlayerIndex;
           iTextYPos += 22;
@@ -6505,10 +6522,10 @@ void NetworkWait()
         iContinueLoop = 0;
       if (iContinueLoop) {
         show_received_mesage();
-        copypic(scrbuf, screen);
+        menu_render_end_frame(mr);
         if (!front_fade) {
           front_fade = -1;                      // Initialize screen fade and network synchronization
-          fade_palette(32);
+          menu_render_begin_fade(mr, 1, 32);
           broadcast_mode = -668;
           while (broadcast_mode)
             UpdateSDL();
@@ -6517,6 +6534,7 @@ void NetworkWait()
             UpdateSDL();
           frames = 0;
         }
+      }
       }
       while (fatkbhit())                      // Handle keyboard input for network lobby
       {
@@ -6600,7 +6618,18 @@ LABEL_83:
     }
   }
   check_cars();                                 // Cleanup: fade screen, free graphics memory, restore screen size
-  fade_palette(0);
+  // GPU fade-out
+  {
+    MenuRenderer *mr = GetMenuRenderer();
+    menu_render_begin_fade(mr, 0, 32);
+    menu_render_fade_wait(mr, fade_redraw_bg, mr);
+    palette_brightness = 0;
+    for (int i = 0; i < 256; i++) {
+      pal_addr[i].byR = 0;
+      pal_addr[i].byB = 0;
+      pal_addr[i].byG = 0;
+    }
+  }
   front_fade = 0;
   fre((void **)front_vga);
   fre((void **)&front_vga[1]);

--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -1623,6 +1623,12 @@ void select_disk()
   fade_palette(0);                              // Initialize screen fade and menu state variables
   uiMenuMode = 0;
   front_fade = 0;
+  // Restore palette for GPU rendering
+  {
+    extern tColor palette[];
+    memcpy(pal_addr, palette, 256 * sizeof(tColor));
+    palette_brightness = 32;
+  }
   iExitFlag = 0;
   iMenuCursor = 2;
   iStatusMessage = 0;
@@ -1640,55 +1646,62 @@ void select_disk()
     }
     if (!uiMenuMode)
       iSelectedSlot = 0;
-    display_picture(scrbuf, front_vga[0]);
-    display_block(scrbuf, front_vga[6], 0, 36, 2, 0);
-    display_block(scrbuf, front_vga[1], 0, head_x, head_y, 0);
+    {                                           // RENDER FRAME (GPU)
+    MenuRenderer *mr = GetMenuRenderer();
+    menu_render_begin_frame(mr);
+    if (!front_fade) {
+      front_fade = -1;
+      menu_render_begin_fade(mr, 1, 32);
+    }
+    menu_render_background(mr, 0);
+    menu_render_sprite(mr, 6, 0, 36, 2, 0, pal_addr);
+    menu_render_sprite(mr, 1, 0, head_x, head_y, 0, pal_addr);
     if (iMenuCursor >= 2)                     // Draw selection cursor
     {
-      display_block(scrbuf, front_vga[6], 4, 62, 336, -1);
+      menu_render_sprite(mr, 6, 4, 62, 336, -1, pal_addr);
     } else {
-      display_block(scrbuf, front_vga[6], 2, 62, 336, -1);
-      front_text(front_vga[2], "~", font2_ascii, font2_offsets, sel_posns[iMenuCursor].x, sel_posns[iMenuCursor].y, 0x8Fu, 0);
+      menu_render_sprite(mr, 6, 2, 62, 336, -1, pal_addr);
+      menu_render_text(mr, 2, "~", font2_ascii, font2_offsets, sel_posns[iMenuCursor].x, sel_posns[iMenuCursor].y, 0x8Fu, 0, pal_addr);
     }
-    front_text(front_vga[2], &language_buffer[576], font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u); // Display main menu options: "Load Game" and "Save Game"
-    front_text(front_vga[2], &language_buffer[640], font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[15], &language_buffer[704], font1_ascii, font1_offsets, 400, 270, 0xABu, 1u);// CURRENT GAME INFO: Display current championship settings and progress
-    front_text(front_vga[15], &language_buffer[768], font1_ascii, font1_offsets, 400, 290, 0x8Fu, 2u);
+    menu_render_text(mr, 2, &language_buffer[576], font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u, pal_addr); // Display main menu options: "Load Game" and "Save Game"
+    menu_render_text(mr, 2, &language_buffer[640], font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 15, &language_buffer[704], font1_ascii, font1_offsets, 400, 270, 0xABu, 1u, pal_addr);// CURRENT GAME INFO: Display current championship settings and progress
+    menu_render_text(mr, 15, &language_buffer[768], font1_ascii, font1_offsets, 400, 290, 0x8Fu, 2u, pal_addr);
     uiCupIndex = (TrackLoad - 1) / 8;
     //uiCupIndex = (TrackLoad - 1 - (__CFSHL__((TrackLoad - 1) >> 31, 3) + 8 * ((TrackLoad - 1) >> 31))) >> 3;// Show current cup name based on track group
     if (uiCupIndex) {
       if (uiCupIndex <= 1) {
-        front_text(front_vga[15], &language_buffer[896], font1_ascii, font1_offsets, 405, 290, 0x8Fu, 0);
+        menu_render_text(mr, 15, &language_buffer[896], font1_ascii, font1_offsets, 405, 290, 0x8Fu, 0, pal_addr);
         goto LABEL_20;
       }
       if (uiCupIndex == 2) {
-        front_text(front_vga[15], &language_buffer[4928], font1_ascii, font1_offsets, 405, 290, 0x8Fu, 0);
+        menu_render_text(mr, 15, &language_buffer[4928], font1_ascii, font1_offsets, 405, 290, 0x8Fu, 0, pal_addr);
         goto LABEL_20;
       }
     }
-    front_text(front_vga[15], &language_buffer[832], font1_ascii, font1_offsets, 405, 290, 0x8Fu, 0);
+    menu_render_text(mr, 15, &language_buffer[832], font1_ascii, font1_offsets, 405, 290, 0x8Fu, 0, pal_addr);
   LABEL_20:
-    front_text(front_vga[15], &language_buffer[960], font1_ascii, font1_offsets, 400, 308, 0x8Fu, 2u);
-    front_text(front_vga[15], CompanyNames[Race], font1_ascii, font1_offsets, 405, 308, 0x8Fu, 0);
-    front_text(front_vga[15], &language_buffer[1024], font1_ascii, font1_offsets, 400, 326, 0x8Fu, 2u);
+    menu_render_text(mr, 15, &language_buffer[960], font1_ascii, font1_offsets, 400, 308, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 15, CompanyNames[Race], font1_ascii, font1_offsets, 405, 308, 0x8Fu, 0, pal_addr);
+    menu_render_text(mr, 15, &language_buffer[1024], font1_ascii, font1_offsets, 400, 326, 0x8Fu, 2u, pal_addr);
     if ((unsigned int)competitors < 8) {
       if (competitors == 2)
-        front_text(front_vga[15], &language_buffer[1088], font1_ascii, font1_offsets, 405, 326, 0x8Fu,0);
+        menu_render_text(mr, 15, &language_buffer[1088], font1_ascii, font1_offsets, 405, 326, 0x8Fu, 0, pal_addr);
     } else if ((unsigned int)competitors <= 8) {
-      front_text(front_vga[15], &language_buffer[1152], font1_ascii, font1_offsets, 405, 326, 0x8Fu, 0);
+      menu_render_text(mr, 15, &language_buffer[1152], font1_ascii, font1_offsets, 405, 326, 0x8Fu, 0, pal_addr);
     } else if (competitors == 16) {
-      front_text(front_vga[15], &language_buffer[1216], font1_ascii, font1_offsets, 405, 326, 0x8Fu, 0);
+      menu_render_text(mr, 15, &language_buffer[1216], font1_ascii, font1_offsets, 405, 326, 0x8Fu, 0, pal_addr);
     }
-    front_text(front_vga[15], &language_buffer[1280], font1_ascii, font1_offsets, 400, 344, 0x8Fu, 2u);
-    front_text(front_vga[15], &language_buffer[64 * level + 1472], font1_ascii, font1_offsets, 405, 344, 0x8Fu, 0);
-    front_text(front_vga[15], &language_buffer[1344], font1_ascii, font1_offsets, 400, 362, 0x8Fu, 2u);
-    front_text(front_vga[15], &language_buffer[64 * damage_level + 1856], font1_ascii, font1_offsets, 405, 362, 0x8Fu, 0);
-    front_text(front_vga[15], &language_buffer[1408], font1_ascii, font1_offsets, 400, 380, 0x8Fu, 2u);
+    menu_render_text(mr, 15, &language_buffer[1280], font1_ascii, font1_offsets, 400, 344, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 15, &language_buffer[64 * level + 1472], font1_ascii, font1_offsets, 405, 344, 0x8Fu, 0, pal_addr);
+    menu_render_text(mr, 15, &language_buffer[1344], font1_ascii, font1_offsets, 400, 362, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 15, &language_buffer[64 * damage_level + 1856], font1_ascii, font1_offsets, 405, 362, 0x8Fu, 0, pal_addr);
+    menu_render_text(mr, 15, &language_buffer[1408], font1_ascii, font1_offsets, 400, 380, 0x8Fu, 2u, pal_addr);
     if (player_type == 1 && net_type) {
       if ((unsigned int)net_type >= (unsigned int)player_type && (unsigned int)net_type <= 2)
-        front_text(front_vga[15], &language_buffer[2304], font1_ascii, font1_offsets, 405, 380, 0x8Fu,0);
+        menu_render_text(mr, 15, &language_buffer[2304], font1_ascii, font1_offsets, 405, 380, 0x8Fu, 0, pal_addr);
     } else {
-      front_text(front_vga[15], &language_buffer[64 * player_type + 2112], font1_ascii, font1_offsets, 405, 380, 0x8Fu, 0);
+      menu_render_text(mr, 15, &language_buffer[64 * player_type + 2112], font1_ascii, font1_offsets, 405, 380, 0x8Fu, 0, pal_addr);
     }
     iSlotLoop = 0;                              // SAVE SLOT DISPLAY: Show all 4 championship save slots with their details
     iSlotYPosition = 56;
@@ -1700,7 +1713,7 @@ void select_disk()
         bySlotColor = 0xAB;
       else
         bySlotColor = 0x8F;
-      front_text(front_vga[15], buffer, font1_ascii, font1_offsets, 300, iSlotYPosition, bySlotColor, 2u);
+      menu_render_text(mr, 15, buffer, font1_ascii, font1_offsets, 300, iSlotYPosition, bySlotColor, 2u, pal_addr);
       iSlotNumber = iSlotLoop + 1;
       if (save_status[iSaveArrayIndex].iSlotUsed)// Show save slot contents: cup, track, difficulty, damage, player type
       {
@@ -1717,53 +1730,53 @@ void select_disk()
               byCupColor2 = 0xAB;
             else
               byCupColor2 = 0x8F;
-            front_text(front_vga[15], &language_buffer[896], font1_ascii, font1_offsets, 305, iSlotYPosition, byCupColor2, 0);
+            menu_render_text(mr, 15, &language_buffer[896], font1_ascii, font1_offsets, 305, iSlotYPosition, byCupColor2, 0, pal_addr);
           } else if (uiSaveCupIndex == 2) {
             if (iSelectedSlot == iSlotNumber)
               byCupColor3 = 0xAB;
             else
               byCupColor3 = 0x8F;
-            front_text(front_vga[15], &language_buffer[4928], font1_ascii, font1_offsets, 305, iSlotYPosition, byCupColor3, 0);
+            menu_render_text(mr, 15, &language_buffer[4928], font1_ascii, font1_offsets, 305, iSlotYPosition, byCupColor3, 0, pal_addr);
           }
         } else {
           if (iSelectedSlot == iSlotNumber)
             byCupColor1 = 0xAB;
           else
             byCupColor1 = 0x8F;
-          front_text(front_vga[15], &language_buffer[832], font1_ascii, font1_offsets, 305, iSlotYPosition, byCupColor1, 0);
+          menu_render_text(mr, 15, &language_buffer[832], font1_ascii, font1_offsets, 305, iSlotYPosition, byCupColor1, 0, pal_addr);
         }
         sprintf(buffer, "%s %i", &language_buffer[256], iSaveTrackNumber);
         if (iSelectedSlot == iSlotLoop + 1)
           byTrackColor = 0xAB;
         else
           byTrackColor = 0x8F;
-        front_text(front_vga[15], "-", font1_ascii, font1_offsets, 470, iSlotYPosition, byTrackColor, 0);
+        menu_render_text(mr, 15, "-", font1_ascii, font1_offsets, 470, iSlotYPosition, byTrackColor, 0, pal_addr);
         if (iSelectedSlot == iSlotLoop + 1)
           byDifficultyColor = 0xAB;
         else
           byDifficultyColor = 0x8F;
-        front_text(front_vga[15], buffer, font1_ascii, font1_offsets, 480, iSlotYPosition, byDifficultyColor, 0);
+        menu_render_text(mr, 15, buffer, font1_ascii, font1_offsets, 480, iSlotYPosition, byDifficultyColor, 0, pal_addr);
         if (iSelectedSlot == iSlotLoop + 1)
           byLevelColor = 0xAB;
         else
           byLevelColor = 0x8F;
-        front_text(front_vga[15], &language_buffer[64 * save_status[iSaveArrayIndex].iDifficulty + 1472], font1_ascii, font1_offsets, 460, iY,  byLevelColor, 2u);
+        menu_render_text(mr, 15, &language_buffer[64 * save_status[iSaveArrayIndex].iDifficulty + 1472], font1_ascii, font1_offsets, 460, iY, byLevelColor, 2u, pal_addr);
         if (iSelectedSlot == iSlotLoop + 1)
           byDamageColor = 0xAB;
         else
           byDamageColor = 0x8F;
-        front_text(front_vga[15], "-", font1_ascii, font1_offsets, 470, iY, byDamageColor, 0);
+        menu_render_text(mr, 15, "-", font1_ascii, font1_offsets, 470, iY, byDamageColor, 0, pal_addr);
         if (iSelectedSlot == iSlotLoop + 1)
           byPlayerTypeColor = 0xAB;
         else
           byPlayerTypeColor = 0x8F;
-        front_text(front_vga[15], &language_buffer[64 * save_status[iSaveArrayIndex].iPlayerType + 2112], font1_ascii, font1_offsets, 480, iY, byPlayerTypeColor, 0);
+        menu_render_text(mr, 15, &language_buffer[64 * save_status[iSaveArrayIndex].iPlayerType + 2112], font1_ascii, font1_offsets, 480, iY, byPlayerTypeColor, 0, pal_addr);
       } else {                                         // Display "Empty" for unused save slots
         if (iSelectedSlot == iSlotNumber)
           byEmptySlotColor = 0xAB;
         else
           byEmptySlotColor = 0x8F;
-        front_text(front_vga[15], &language_buffer[2496], font1_ascii, font1_offsets, 305, iSlotYPosition, byEmptySlotColor, 0);
+        menu_render_text(mr, 15, &language_buffer[2496], font1_ascii, font1_offsets, 305, iSlotYPosition, byEmptySlotColor, 0, pal_addr);
       }
       iSlotYPosition += 40;
       ++iSaveArrayIndex;
@@ -1773,25 +1786,26 @@ void select_disk()
     switch (iStatusMessage) {
       case 0:
         if (network_on)                       // Case 0: Network save restriction message
-          front_text(front_vga[15], &language_buffer[4864], font1_ascii, font1_offsets, 400, 230, 0xE7u, 1u);
+          menu_render_text(mr, 15, &language_buffer[4864], font1_ascii, font1_offsets, 400, 230, 0xE7u, 1u, pal_addr);
         break;
       case 1:
         if (iChampResult)                     // Case 1: Load operation messages (success/confirmation)
-          front_text(front_vga[15], &language_buffer[2624], font1_ascii, font1_offsets, 400, 230, 0xE7u, 1u);
+          menu_render_text(mr, 15, &language_buffer[2624], font1_ascii, font1_offsets, 400, 230, 0xE7u, 1u, pal_addr);
         else
-          front_text(front_vga[15], &language_buffer[2560], font1_ascii, font1_offsets, 400, 230, 0xE7u, 1u);
+          menu_render_text(mr, 15, &language_buffer[2560], font1_ascii, font1_offsets, 400, 230, 0xE7u, 1u, pal_addr);
         break;
       case 2:
-        front_text(front_vga[15], &language_buffer[2688], font1_ascii, font1_offsets, 400, 230, 0xE7u, 1u); // Case 2: Save operation success message
+        menu_render_text(mr, 15, &language_buffer[2688], font1_ascii, font1_offsets, 400, 230, 0xE7u, 1u, pal_addr); // Case 2: Save operation success message
         break;
       case 4:
-        front_text(front_vga[15], &language_buffer[2752], font1_ascii, font1_offsets, 400, 230, 0xE7u, 1u); // Case 4: Empty slot selected (no save to load)
+        menu_render_text(mr, 15, &language_buffer[2752], font1_ascii, font1_offsets, 400, 230, 0xE7u, 1u, pal_addr); // Case 4: Empty slot selected (no save to load)
         break;
       default:
         break;                                  // STATUS MESSAGES: Display operation results and warnings
     }
     show_received_mesage();
-    copypic(scrbuf, screen);
+    menu_render_end_frame(mr);
+    }
     if (switch_same > 0)                      // CHEAT MODE HANDLING: Process switch_same command for player synchronization
     {
       iCheatSetLoop = 0;
@@ -1834,12 +1848,6 @@ void select_disk()
     }
     cheat_mode = uiUpdatedCheatFlags;
   LABEL_95:
-    if (!front_fade)                          // Handle screen fade-in effect
-    {
-      front_fade = -1;
-      fade_palette(32);
-      frames = 0;
-    }
     while (fatkbhit())                        // KEYBOARD INPUT PROCESSING: Handle navigation and save/load operations
     {
       byInputKey = fatgetch();
@@ -1910,7 +1918,18 @@ void select_disk()
     }
     UpdateSDL();
   } while (!iExitFlag);                         // MAIN MENU LOOP - Handle UI rendering and input processing
-  fade_palette(0);                              // CLEANUP: Fade screen and exit save/load menu
+  // GPU fade-out
+  {
+    MenuRenderer *mr = GetMenuRenderer();
+    menu_render_begin_fade(mr, 0, 32);
+    menu_render_fade_wait(mr, fade_redraw_bg, mr);
+    palette_brightness = 0;
+    for (int i = 0; i < 256; i++) {
+      pal_addr[i].byR = 0;
+      pal_addr[i].byB = 0;
+      pal_addr[i].byG = 0;
+    }
+  }
   front_fade = 0;
 }
 

--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -1277,7 +1277,8 @@ void select_screen()
             // GPU fade-out before leaving main menu to sub-menus
             // (main menu is GPU-rendered, scrbuf is stale, so software
             // fade_palette(0) in sub-menus would flash stale content)
-            {
+            // Skip for case 7 (Exit to DOS) — menu stays visible for Y/N prompt
+            if (iMenuSelection != 7) {
               MenuRenderer *mr2 = GetMenuRenderer();
               menu_render_begin_fade(mr2, 0, 32);
               menu_render_fade_wait(mr2, fade_redraw_bg, mr2);
@@ -1287,10 +1288,10 @@ void select_screen()
                 pal_addr[i].byB = 0;
                 pal_addr[i].byG = 0;
               }
+              fre((void **)&front_vga[3]);
+              fre((void **)&front_vga[13]);
+              fre((void **)&front_vga[14]);
             }
-            fre((void **)&front_vga[3]);
-            fre((void **)&front_vga[13]);
-            fre((void **)&front_vga[14]);
             switch (iMenuSelection) {
               case 0:
                 sfxsample(SOUND_SAMPLE_BUTTON, 0x8000);

--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -2756,6 +2756,13 @@ void select_configure()
   front_fade = 0;
   iConfigState = 0;
 
+  // Restore palette for GPU rendering
+  {
+    extern tColor palette[];
+    memcpy(pal_addr, palette, 256 * sizeof(tColor));
+    palette_brightness = 32;
+  }
+
   // Main config loop
   while (2) {
     UpdateSDL();
@@ -2770,35 +2777,41 @@ void select_configure()
         network_champ_on = 0;
     }
 
-    // Draw background and ui elements
-    display_picture(scrbuf, front_vga[0]);
-    display_block(scrbuf, front_vga[1], 0, head_x, head_y, 0);
-    display_block(scrbuf, front_vga[6], 0, 36, 2, 0);
-    display_block(scrbuf, front_vga[5], player_type, -4, 247, 0);
-    display_block(scrbuf, front_vga[5], game_type + 5, 135, 247, 0);
-    display_block(scrbuf, front_vga[4], 1, 76, 257, -1);
+    // Draw background and ui elements (GPU)
+    MenuRenderer *mr = GetMenuRenderer();
+    menu_render_begin_frame(mr);
+    if (!front_fade) {
+      front_fade = -1;
+      menu_render_begin_fade(mr, 1, 32);
+    }
+    menu_render_background(mr, 0);
+    menu_render_sprite(mr, 1, 0, head_x, head_y, 0, pal_addr);
+    menu_render_sprite(mr, 6, 0, 36, 2, 0, pal_addr);
+    menu_render_sprite(mr, 5, player_type, -4, 247, 0, pal_addr);
+    menu_render_sprite(mr, 5, game_type + 5, 135, 247, 0, pal_addr);
+    menu_render_sprite(mr, 4, 1, 76, 257, -1, pal_addr);
 
     // draw menu selector
     if (iMenuSelection >= 7) {
       // no menu item selected (exit)
-      display_block(scrbuf, front_vga[6], 4, 62, 336, -1);
+      menu_render_sprite(mr, 6, 4, 62, 336, -1, pal_addr);
     } else {
       // draw menu selector
-      display_block(scrbuf, front_vga[6], 2, 62, 336, -1);
-      front_text(front_vga[2], "~", font2_ascii, font2_offsets, sel_posns[iMenuSelection].x, sel_posns[iMenuSelection].y, 0x8Fu, 0);
+      menu_render_sprite(mr, 6, 2, 62, 336, -1, pal_addr);
+      menu_render_text(mr, 2, "~", font2_ascii, font2_offsets, sel_posns[iMenuSelection].x, sel_posns[iMenuSelection].y, 0x8Fu, 0, pal_addr);
     }
 
     // menu options labels
-    front_text(front_vga[2], &config_buffer[3968], font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], &config_buffer[256], font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], &config_buffer[1664], font2_ascii, font2_offsets, sel_posns[2].x + 132, sel_posns[2].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], &config_buffer[4032], font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], &config_buffer[4096], font2_ascii, font2_offsets, sel_posns[4].x + 132, sel_posns[4].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], &config_buffer[4160], font2_ascii, font2_offsets, sel_posns[5].x + 132, sel_posns[5].y + 7, 0x8Fu, 2u);
+    menu_render_text(mr, 2, &config_buffer[3968], font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, &config_buffer[256], font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, &config_buffer[1664], font2_ascii, font2_offsets, sel_posns[2].x + 132, sel_posns[2].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, &config_buffer[4032], font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, &config_buffer[4096], font2_ascii, font2_offsets, sel_posns[4].x + 132, sel_posns[4].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, &config_buffer[4160], font2_ascii, font2_offsets, sel_posns[5].x + 132, sel_posns[5].y + 7, 0x8Fu, 2u, pal_addr);
 
     // network option if enabled
     if (network_on)
-      front_text(front_vga[2], &config_buffer[5568], font2_ascii, font2_offsets, sel_posns[6].x + 132, sel_posns[6].y + 7, 0x8Fu, 2u);
+      menu_render_text(mr, 2, &config_buffer[5568], font2_ascii, font2_offsets, sel_posns[6].x + 132, sel_posns[6].y + 7, 0x8Fu, 2u, pal_addr);
 
     // Config state machine
     switch (iMenuSelection) {
@@ -2844,19 +2857,19 @@ void select_configure()
             // Car is available for Ai palyers
             if (iCarIndex == iSelectedCar && iEditingName == 1) {
               // Selected car with name being edited
-              front_text(front_vga[15], szCarName, font1_ascii, font1_offsets, 425, iTextPosY, iNormalColor, 2u);
+              menu_render_text(mr, 15, szCarName, font1_ascii, font1_offsets, 425, iTextPosY, iNormalColor, 2u, pal_addr);
               if (iCarIndex == iSelectedCar)
                 byTextColor3 = iHighlightColor;
               else
                 byTextColor3 = 0x8F;
-              front_text(front_vga[15], szNewNameBuf, font1_ascii, font1_offsets, 430, iTextPosY, byTextColor3, 0);
+              menu_render_text(mr, 15, szNewNameBuf, font1_ascii, font1_offsets, 430, iTextPosY, byTextColor3, 0, pal_addr);
             } else {
               // Selected car with default name displayed
               if (iCarIndex == iSelectedCar)
                 byTextColor4 = iNormalColor;
               else
                 byTextColor4 = 0x8F;
-              front_text(front_vga[15], szCarName, font1_ascii, font1_offsets, 425, iTextPosY, byTextColor4, 2u);
+              menu_render_text(mr, 15, szCarName, font1_ascii, font1_offsets, 425, iTextPosY, byTextColor4, 2u, pal_addr);
               if (iCarIndex == iSelectedCar)
                 byChar = iHighlightColor;
               else
@@ -2867,7 +2880,7 @@ void select_configure()
               iFontWidth = iCarDisplay;
               //LOBYTE(iFontWidth) = iCarDisplay ^ 1;
               iFontWidth = iCarDisplay ^ 1;
-              front_text(front_vga[15], default_names[iFontWidth], font1_ascii, font1_offsets, 430, iTextPosY, byTempValue, 0);
+              menu_render_text(mr, 15, default_names[iFontWidth], font1_ascii, font1_offsets, 430, iTextPosY, byTempValue, 0, pal_addr);
             }
           } else {
             // Car is allocated to a human player
@@ -2875,14 +2888,14 @@ void select_configure()
               byTextColor1 = iActiveColor;
             else
               byTextColor1 = 0x8B;
-            front_text(front_vga[15], szCarName, font1_ascii, font1_offsets, 425, iTextPosY, byTextColor1, 2u);
+            menu_render_text(mr, 15, szCarName, font1_ascii, font1_offsets, 425, iTextPosY, byTextColor1, 2u, pal_addr);
             if (iCarIndex == iSelectedCar)
               byTextColor2 = iDimmedColor;
             else
               byTextColor2 = 0x7F;
 
             // Display human player name
-            front_text(front_vga[15], player_names[car_to_player[14 - (iCarLoop & 0xFE) + (iCarLoop & 1)]], font1_ascii, font1_offsets, 430, iTextPosY, byTextColor2, 0);
+            menu_render_text(mr, 15, player_names[car_to_player[14 - (iCarLoop & 0xFE) + (iCarLoop & 1)]], font1_ascii, font1_offsets, 430, iTextPosY, byTextColor2, 0, pal_addr);
           }
 
           // Move to next car
@@ -2901,12 +2914,12 @@ void select_configure()
               byTextColor5 = iNormalColor;
             else
               byTextColor5 = 0x8F;
-            front_text(front_vga[15], &config_buffer[4288], font1_ascii, font1_offsets, 425, 338, byTextColor5, player_type);
+            menu_render_text(mr, 15, &config_buffer[4288], font1_ascii, font1_offsets, 425, 338, byTextColor5, player_type, pal_addr);
             if (iSelectedCar == 2)
               byTextColor6 = iHighlightColor;
             else
               byTextColor6 = 0x8F;
-            front_text(front_vga[15], szNewNameBuf, font1_ascii, font1_offsets, 430, 338, byTextColor6, 0);
+            menu_render_text(mr, 15, szNewNameBuf, font1_ascii, font1_offsets, 430, 338, byTextColor6, 0, pal_addr);
           } else {
             // Player 2 name display mode
             if (iSelectedCar == 2)
@@ -2914,24 +2927,24 @@ void select_configure()
             else
               byTextColor7 = 0x8F;
             iTemp1 = iSelectedCar;
-            front_text(front_vga[15], &config_buffer[4288], font1_ascii, font1_offsets, 425, 338, byTextColor7, 2u);
+            menu_render_text(mr, 15, &config_buffer[4288], font1_ascii, font1_offsets, 425, 338, byTextColor7, 2u, pal_addr);
             if (iTemp1 == 2)
               byTextColor8 = iHighlightColor;
             else
               byTextColor8 = 0x8F;
-            front_text(front_vga[15], player_names[player2_car], font1_ascii, font1_offsets, 430, 338, byTextColor8, 0);
+            menu_render_text(mr, 15, player_names[player2_car], font1_ascii, font1_offsets, 430, 338, byTextColor8, 0, pal_addr);
           }
         }
 
         // Display player 1 configuration
         if (iSelectedCar == 1 && iEditingName == 1) {
           // Player 1 name being edited
-          front_text(front_vga[15], &config_buffer[4224], font1_ascii, font1_offsets, 425, 356, iNormalColor, 2u);
+          menu_render_text(mr, 15, &config_buffer[4224], font1_ascii, font1_offsets, 425, 356, iNormalColor, 2u, pal_addr);
           if (iSelectedCar == 1)
             byTextColor9 = iHighlightColor;
           else
             byTextColor9 = 0x8F;
-          front_text(front_vga[15], szNewNameBuf, font1_ascii, font1_offsets, 430, 356, byTextColor9, 0);
+          menu_render_text(mr, 15, szNewNameBuf, font1_ascii, font1_offsets, 430, 356, byTextColor9, 0, pal_addr);
         } else {
           // Player 1 name display mode
           if (iSelectedCar == 1)
@@ -2939,12 +2952,12 @@ void select_configure()
           else
             byColor = 0x8F;
           iSelectedCar_1 = iSelectedCar;
-          front_text(front_vga[15], &config_buffer[4224], font1_ascii, font1_offsets, 425, 356, byColor, 2u);
+          menu_render_text(mr, 15, &config_buffer[4224], font1_ascii, font1_offsets, 425, 356, byColor, 2u, pal_addr);
           if (iSelectedCar_1 == 1)
             byColor_1 = iHighlightColor;
           else
             byColor_1 = 0x8F;
-          front_text(front_vga[15], player_names[player1_car], font1_ascii, font1_offsets, 430, 356, byColor_1, 0);
+          menu_render_text(mr, 15, player_names[player1_car], font1_ascii, font1_offsets, 430, 356, byColor_1, 0, pal_addr);
         }
 
         // Display "BACK" option
@@ -2952,12 +2965,12 @@ void select_configure()
           byColor_2 = 0x8F;
         else
           byColor_2 = iNormalColor;
-        front_text(front_vga[15], &config_buffer[832], font1_ascii, font1_offsets, 420, 374, byColor_2, 2u);
+        menu_render_text(mr, 15, &config_buffer[832], font1_ascii, font1_offsets, 420, 374, byColor_2, 2u, pal_addr);
 
         // Display blinking cursor when editing names
         if (iEditingName == 1) {
           if ((frames & 0xFu) < 8)            // blink cursor based on frame counter
-            front_text(front_vga[15], "_", font1_ascii, font1_offsets, iTextPosX, iY, 0xABu, 0);
+            menu_render_text(mr, 15, "_", font1_ascii, font1_offsets, iTextPosX, iY, 0xABu, 0, pal_addr);
           szNewNameBuf[iNameLength] = 0;
         }
         goto RENDER_FRAME;                      // skip to end of switch
@@ -2971,49 +2984,49 @@ void select_configure()
           byVolumeColor1 = 0xAB;
         else
           byVolumeColor1 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[2304], font1_ascii, font1_offsets, 425, 80, byVolumeColor1, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[2304], font1_ascii, font1_offsets, 425, 80, byVolumeColor1, 2u, 200, 640, pal_addr);
 
         // SFX volume
         if (iVolumeSelection == 2)
           byVolumeColor2 = 0xAB;
         else
           byVolumeColor2 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[2368], font1_ascii, font1_offsets, 425, 104, byVolumeColor2, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[2368], font1_ascii, font1_offsets, 425, 104, byVolumeColor2, 2u, 200, 640, pal_addr);
 
         // Speech volume
         if (iVolumeSelection == 3)
           byVolumeColor3 = 0xAB;
         else
           byVolumeColor3 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[2432], font1_ascii, font1_offsets, 425, 128, byVolumeColor3, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[2432], font1_ascii, font1_offsets, 425, 128, byVolumeColor3, 2u, 200, 640, pal_addr);
 
         // Music volume
         if (iVolumeSelection == 4)
           byVolumeColor4 = 0xAB;
         else
           byVolumeColor4 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[2496], font1_ascii, font1_offsets, 425, 152, byVolumeColor4, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[2496], font1_ascii, font1_offsets, 425, 152, byVolumeColor4, 2u, 200, 640, pal_addr);
 
         // Engine options
         if (iVolumeSelection == 5)
           byColor_3 = 0xAB;
         else
           byColor_3 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[2560], font1_ascii, font1_offsets, 425, 176, byColor_3, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[2560], font1_ascii, font1_offsets, 425, 176, byColor_3, 2u, 200, 640, pal_addr);
         if (allengines) {
           if (iVolumeSelection == 5)
             byColor_4 = 0xAB;
           else
             byColor_4 = 0x8F;
           // ALL ENGINES
-          scale_text(front_vga[15], &config_buffer[2752], font1_ascii, font1_offsets, 430, 176, byColor_4, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2752], font1_ascii, font1_offsets, 430, 176, byColor_4, 0, 200, 640, pal_addr);
         } else {
           if (iVolumeSelection == 5)
             byColor_5 = 0xAB;
           else
             byColor_5 = 0x8F;
           // STARTERS & TURBOS
-          scale_text(front_vga[15], &config_buffer[2816], font1_ascii, font1_offsets, 430, 176, byColor_5, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2816], font1_ascii, font1_offsets, 430, 176, byColor_5, 0, 200, 640, pal_addr);
         }
 
         // Sound effects options
@@ -3021,28 +3034,28 @@ void select_configure()
           byColor_6 = 0xAB;
         else
           byColor_6 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[2880], font1_ascii, font1_offsets, 425, 200, byColor_6, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[2880], font1_ascii, font1_offsets, 425, 200, byColor_6, 2u, 200, 640, pal_addr);
         if (soundon) {
           if (iVolumeSelection == 6)
             byColor_7 = 0xAB;
           else
             byColor_7 = 0x8F;
           // ON
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 430, 200, byColor_7, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 430, 200, byColor_7, 0, 200, 640, pal_addr);
         } else if (SoundCard) {
           if (iVolumeSelection == 6)
             byColor_8 = 0xAB;
           else
             byColor_8 = 0x8F;
           // OFF
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 430, 200, byColor_8, soundon, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 430, 200, byColor_8, soundon, 200, 640, pal_addr);
         } else {
           if (iVolumeSelection == 6)
             byColor_9 = 0xAB;
           else
             byColor_9 = 0x8F;
           // DISABLED
-          scale_text(front_vga[15], &config_buffer[6848], font1_ascii, font1_offsets, 430, 200, byColor_9, soundon, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[6848], font1_ascii, font1_offsets, 430, 200, byColor_9, soundon, 200, 640, pal_addr);
         }
 
         // Music options
@@ -3050,28 +3063,28 @@ void select_configure()
           byColor_10 = 0xAB;
         else
           byColor_10 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[2944], font1_ascii, font1_offsets, 425, 224, byColor_10, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[2944], font1_ascii, font1_offsets, 425, 224, byColor_10, 2u, 200, 640, pal_addr);
         if (musicon) {
           if (iVolumeSelection == 7)
             byColor_11 = 0xAB;
           else
             byColor_11 = 0x8F;
           // ON
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 430, 224, byColor_11, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 430, 224, byColor_11, 0, 200, 640, pal_addr);
         } else if (MusicCard || MusicCD) {
           if (iVolumeSelection == 7)
             byColor_12 = 0xAB;
           else
             byColor_12 = 0x8F;
           // OFF
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 430, 224, byColor_12, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 430, 224, byColor_12, 0, 200, 640, pal_addr);
         } else {
           if (iVolumeSelection == 7)
             byColor_13 = 0xAB;
           else
             byColor_13 = 0x8F;
           // DISABLED
-          scale_text(front_vga[15], &config_buffer[6848], font1_ascii, font1_offsets, 430, 224, byColor_13, musicon, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[6848], font1_ascii, font1_offsets, 430, 224, byColor_13, musicon, 200, 640, pal_addr);
         }
 
         // Back option
@@ -3079,7 +3092,7 @@ void select_configure()
           byColor_14 = 0x8F;
         else
           byColor_14 = 0xAB;
-        scale_text(front_vga[15], &config_buffer[832], font1_ascii, font1_offsets, 420, 248, byColor_14, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[832], font1_ascii, font1_offsets, 420, 248, byColor_14, 2u, 200, 640, pal_addr);
 
         // Display volume bars
         if (iVolumeSelection == 1)
@@ -3146,15 +3159,15 @@ void select_configure()
         // Display calibration instructions when active
         if (iConfigState == 3) {
           // MOVE JOYSTICKS TO FULL EXTENTS
-          scale_text(front_vga[15], &config_buffer[2112], font1_ascii, font1_offsets, 400, 60, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2112], font1_ascii, font1_offsets, 400, 60, 143, 1u, 200, 640, pal_addr);
           // THEN PRESS ANY KEY
-          scale_text(front_vga[15], &config_buffer[2176], font1_ascii, font1_offsets, 400, 78, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2176], font1_ascii, font1_offsets, 400, 78, 143, 1u, 200, 640, pal_addr);
         }
 
         iConfigState_1 = iConfigState;
 
         // X1 axis display
-        scale_text(front_vga[15], &config_buffer[1728], font1_ascii, font1_offsets, 400, 110, 143, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[1728], font1_ascii, font1_offsets, 400, 110, 143, 1u, 200, 640, pal_addr);
         if (iConfigState_1 == 3) {
           // Show calibration bar
           if (x1ok && JAXmax - JAXmin >= 100)
@@ -3168,11 +3181,11 @@ void select_configure()
             szJoyStatus1 = &config_buffer[2048];
           else
             szJoyStatus1 = &config_buffer[1984];
-          scale_text(front_vga[15], szJoyStatus1, font1_ascii, font1_offsets, 400, 128, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, szJoyStatus1, font1_ascii, font1_offsets, 400, 128, 143, 1u, 200, 640, pal_addr);
         }
 
         // Y1 axis display
-        scale_text(front_vga[15], &config_buffer[1792], font1_ascii, font1_offsets, 400, 160, 143, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[1792], font1_ascii, font1_offsets, 400, 160, 143, 1u, 200, 640, pal_addr);
         if (iConfigState == 3) {
           // Show Calibration bar
           if (y1ok && JAYmax - JAYmin >= 100)
@@ -3186,11 +3199,11 @@ void select_configure()
             szJoyStatus2 = &config_buffer[2048];
           else
             szJoyStatus2 = &config_buffer[1984];
-          scale_text(front_vga[15], szJoyStatus2, font1_ascii, font1_offsets, 400, 178, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, szJoyStatus2, font1_ascii, font1_offsets, 400, 178, 143, 1u, 200, 640, pal_addr);
         }
 
         // X2 axis display
-        scale_text(front_vga[15], &config_buffer[1856], font1_ascii, font1_offsets, 400, 210, 143, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[1856], font1_ascii, font1_offsets, 400, 210, 143, 1u, 200, 640, pal_addr);
         if (iConfigState == 3) {
           // Calibration bar
           if (x2ok && JBXmax - JBXmin >= 100)
@@ -3204,13 +3217,13 @@ void select_configure()
             szX2Text = &config_buffer[2048];
           else
             szX2Text = &config_buffer[1984];
-          scale_text(front_vga[15], szX2Text, font1_ascii, font1_offsets, 400, 228, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, szX2Text, font1_ascii, font1_offsets, 400, 228, 143, 1u, 200, 640, pal_addr);
         }
 
         iConfigState_2 = iConfigState;
 
         // Y2 axis display
-        scale_text(front_vga[15], &config_buffer[1920], font1_ascii, font1_offsets, 400, 260, 143, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[1920], font1_ascii, font1_offsets, 400, 260, 143, 1u, 200, 640, pal_addr);
         if (iConfigState_2 == 3) {
           // Calibration bar
           if (y2ok && JBYmax - JBYmin >= 100)
@@ -3224,7 +3237,7 @@ void select_configure()
             szY2Text = &config_buffer[2048];
           else
             szY2Text = &config_buffer[1984];
-          scale_text(front_vga[15], szY2Text, font1_ascii, font1_offsets, 400, 278, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, szY2Text, font1_ascii, font1_offsets, 400, 278, 143, 1u, 200, 640, pal_addr);
         }
         goto RENDER_FRAME;
       case 3:
@@ -3259,7 +3272,7 @@ void select_configure()
             byColor_19 = 0xAB;
           else
             byColor_19 = 0x8F;
-          scale_text(front_vga[15], buffer, font1_ascii, font1_offsets, 420, 60, byColor_19, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, buffer, font1_ascii, font1_offsets, 420, 60, byColor_19, 1u, 200, 640, pal_addr);
 
           // Player 2 customize controls option
           if (iControlSelection == 3)
@@ -3267,7 +3280,7 @@ void select_configure()
           else
             byColor_20 = 0x8F;
           // CUSTOMIZE PLAYER 2
-          scale_text(front_vga[15], &config_buffer[704], font1_ascii, font1_offsets, 420, 78, byColor_20, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[704], font1_ascii, font1_offsets, 420, 78, byColor_20, 1u, 200, 640, pal_addr);
         }
 
         // Display player 1 controls
@@ -3279,21 +3292,21 @@ void select_configure()
           byColor_21 = 0xAB;
         else
           byColor_21 = 0x8F;
-        scale_text(front_vga[15], buffer, font1_ascii, font1_offsets, 420, 96, byColor_21, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, buffer, font1_ascii, font1_offsets, 420, 96, byColor_21, 1u, 200, 640, pal_addr);
         // Player 1 customize controls option
         if (iControlSelection == 1)
           byColor_22 = 0xAB;
         else
           byColor_22 = 0x8F;
         // CUSTOMIZE PLAYER 1
-        scale_text(front_vga[15], &config_buffer[768], font1_ascii, font1_offsets, 420, 114, byColor_22, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[768], font1_ascii, font1_offsets, 420, 114, byColor_22, 1u, 200, 640, pal_addr);
 
         // Back option
         if (iControlSelection)
           byColor_23 = 0x8F;
         else
           byColor_23 = 0xAB;
-        scale_text(front_vga[15], &config_buffer[832], font1_ascii, font1_offsets, 420, 132, byColor_23, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[832], font1_ascii, font1_offsets, 420, 132, byColor_23, 1u, 200, 640, pal_addr);
 
         // Display player 1 control customization screen
         if (iControlSelection == 1 || iControlSelection == 2) {
@@ -3306,12 +3319,12 @@ void select_configure()
               byControlColor = 0xAB;
             else
               byControlColor = 0x8F;
-            front_text(front_vga[15], szControlName, font1_ascii, font1_offsets, 475, iY_1, byControlColor, 2u);
+            menu_render_text(mr, 15, szControlName, font1_ascii, font1_offsets, 475, iY_1, byControlColor, 2u, pal_addr);
             if (iControlLoop == control_edit)
               byColor_24 = 0xAB;
             else
               byColor_24 = 0x8F;
-            scale_text(front_vga[15], keyname[userkey[iControlLoop]], font1_ascii, font1_offsets, 480, iY_1, byColor_24, 0, 200, 640);
+            menu_render_scaled_text(mr, 15, keyname[userkey[iControlLoop]], font1_ascii, font1_offsets, 480, iY_1, byColor_24, 0, 200, 640, pal_addr);
             szControlName += 64;                // next control name
             ++iControlLoop;
             iY_1 += 18;
@@ -3321,12 +3334,12 @@ void select_configure()
               byColor_25 = 0xAB;
             else
               byColor_25 = 0x8F;
-            front_text(front_vga[15], "CHEAT:", font1_ascii, font1_offsets, 475, 308, byColor_25, 2u);
+            menu_render_text(mr, 15, "CHEAT:", font1_ascii, font1_offsets, 475, 308, byColor_25, 2u, pal_addr);
             if (control_edit == 12)
               byColor_26 = 0xAB;
             else
               byColor_26 = 0x8F;
-            scale_text(front_vga[15], keyname[userkey[12]], font1_ascii, font1_offsets, 480, 308, byColor_26, 0, 200, 640);
+            menu_render_scaled_text(mr, 15, keyname[userkey[12]], font1_ascii, font1_offsets, 480, 308, byColor_26, 0, 200, 640, pal_addr);
           }
         }
         // Display Player 2 control customization screen
@@ -3340,12 +3353,12 @@ void select_configure()
               byColor_27 = 0xAB;
             else
               byColor_27 = 0x8F;
-            front_text(front_vga[15], szText, font1_ascii, font1_offsets, 475, iY_2, byColor_27, 2u);
+            menu_render_text(mr, 15, szText, font1_ascii, font1_offsets, 475, iY_2, byColor_27, 2u, pal_addr);
             if (iControlIndex2 == control_edit)
               byColor_28 = 0xAB;
             else
               byColor_28 = 0x8F;
-            front_text(front_vga[15], keyname[userkey[iControlIndex2]], font1_ascii, font1_offsets, 480, iY_2, byColor_28, 0);
+            menu_render_text(mr, 15, keyname[userkey[iControlIndex2]], font1_ascii, font1_offsets, 480, iY_2, byColor_28, 0, pal_addr);
             szText += 64;                       // Next control name
             ++iControlIndex2;
             iY_2 += 18;
@@ -3357,12 +3370,12 @@ void select_configure()
               byColor_29 = 0xAB;
             else
               byColor_29 = 0x8F;
-            front_text(front_vga[15], "CHEAT:", font1_ascii, font1_offsets, 475, 308, byColor_29, 2u);
+            menu_render_text(mr, 15, "CHEAT:", font1_ascii, font1_offsets, 475, 308, byColor_29, 2u, pal_addr);
             if (control_edit == 13)
               byColor_30 = 0xAB;
             else
               byColor_30 = 0x8F;
-            front_text(front_vga[15], keyname[userkey[13]], font1_ascii, font1_offsets, 480, 308, byColor_30, 0);
+            menu_render_text(mr, 15, keyname[userkey[13]], font1_ascii, font1_offsets, 480, 308, byColor_30, 0, pal_addr);
           }
         }
 
@@ -3500,8 +3513,8 @@ void select_configure()
               // Display any received network messages
         show_received_mesage();
 
-        // render
-        copypic(scrbuf, screen);
+        // render (GPU)
+        menu_render_end_frame(mr);
 
         // Handle CHEAT_MODE_CLONES
         if (switch_same > 0) {
@@ -3547,13 +3560,6 @@ void select_configure()
 
           cheat_mode &= ~CHEAT_MODE_CLONES;
           //cheat_mode &= ~0x4000u;
-        }
-
-        // Init screen fade
-        if (!front_fade) {
-          front_fade = -1;
-          fade_palette(32);
-          frames = 0;
         }
 
         // Process keyboard input when not editing controls
@@ -4395,7 +4401,18 @@ void select_configure()
         }
         if (!iExitFlag)
           continue;
-        fade_palette(0);
+        // GPU fade-out
+        {
+          MenuRenderer *mr = GetMenuRenderer();
+          menu_render_begin_fade(mr, 0, 32);
+          menu_render_fade_wait(mr, fade_redraw_bg, mr);
+          palette_brightness = 0;
+          for (int i = 0; i < 256; i++) {
+            pal_addr[i].byR = 0;
+            pal_addr[i].byB = 0;
+            pal_addr[i].byG = 0;
+          }
+        }
         front_fade = 0;
         return;
       case 4:
@@ -4405,7 +4422,7 @@ void select_configure()
           byColor_31 = 0xAB;
         else
           byColor_31 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[6912], font1_ascii, font1_offsets, 435, 60, byColor_31, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[6912], font1_ascii, font1_offsets, 435, 60, byColor_31, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_PERSPECTIVE_CORRECTION) != 0) {
           if (iVideoState == 16)
             byColor_32 = 0xAB;
@@ -4421,261 +4438,261 @@ void select_configure()
           byTempChar1 = byColor_33;
           szText_1 = &config_buffer[2624];
         }
-        scale_text(front_vga[15], szText_1, font1_ascii, font1_offsets, 440, 60, byTempChar1, 0, 200, 640);
+        menu_render_scaled_text(mr, 15, szText_1, font1_ascii, font1_offsets, 440, 60, byTempChar1, 0, 200, 640, pal_addr);
         sprintf(buffer, "%s:", &config_buffer[3968]);
         if (iVideoState == 15)
           byColor_34 = 0xAB;
         else
           byColor_34 = 0x8F;
-        scale_text(front_vga[15], buffer, font1_ascii, font1_offsets, 435, 80, byColor_34, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, buffer, font1_ascii, font1_offsets, 435, 80, byColor_34, 2u, 200, 640, pal_addr);
         if (names_on) {
           if (names_on == 2) {
             if (iVideoState == 15)
               byColor_105 = 0xAB;
             else
               byColor_105 = 0x8F;
-            scale_text(front_vga[15], &config_buffer[2816], font1_ascii, font1_offsets, 440, 80, byColor_105, 0, 200, 640);
+            menu_render_scaled_text(mr, 15, &config_buffer[2816], font1_ascii, font1_offsets, 440, 80, byColor_105, 0, 200, 640, pal_addr);
           } else {
             if (iVideoState == 15)
               byColor_35 = 0xAB;
             else
               byColor_35 = 0x8F;
-            scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 80, byColor_35, 0, 200, 640);
+            menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 80, byColor_35, 0, 200, 640, pal_addr);
           }
         } else {
           if (iVideoState == 15)
             byColor_36 = 0xAB;
           else
             byColor_36 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 80, byColor_36, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 80, byColor_36, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 14)
           byColor_37 = 0xAB;
         else
           byColor_37 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3008], font1_ascii, font1_offsets, 435, 100, byColor_37, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3008], font1_ascii, font1_offsets, 435, 100, byColor_37, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_BUILDINGS) != 0) {
           if (iVideoState == 14)
             byColor_38 = 0xAB;
           else
             byColor_38 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 100, byColor_38, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 100, byColor_38, 0, 200, 640, pal_addr);
         } else {
           if (iVideoState == 14)
             byColor_39 = 0xAB;
           else
             byColor_39 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 100, byColor_39, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 100, byColor_39, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 13)
           byColor_40 = 0xAB;
         else
           byColor_40 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3072], font1_ascii, font1_offsets, 435, 120, byColor_40, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3072], font1_ascii, font1_offsets, 435, 120, byColor_40, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_GLASS_WALLS) != 0) {
           if (iVideoState == 13)
             byColor_41 = 0xAB;
           else
             byColor_41 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 120, byColor_41, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 120, byColor_41, 0, 200, 640, pal_addr);
         } else {
           if (iVideoState == 13)
             byColor_42 = 0xAB;
           else
             byColor_42 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 120, byColor_42, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 120, byColor_42, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 12)
           byColor_43 = 0xAB;
         else
           byColor_43 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3200], font1_ascii, font1_offsets, 435, 140, byColor_43, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3200], font1_ascii, font1_offsets, 435, 140, byColor_43, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_HORIZON) != 0) {
           if (iVideoState == 12)
             byColor_44 = 0xAB;
           else
             byColor_44 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 140, byColor_44, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 140, byColor_44, 0, 200, 640, pal_addr);
         } else {
           if (iVideoState == 12)
             byColor_45 = 0xAB;
           else
             byColor_45 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 140, byColor_45, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 140, byColor_45, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 11)
           byColor_46 = 0xAB;
         else
           byColor_46 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3136], font1_ascii, font1_offsets, 435, 160, byColor_46, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3136], font1_ascii, font1_offsets, 435, 160, byColor_46, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_CAR_TEXTURES) != 0) {
           if (iVideoState == 11)
             byColor_47 = 0xAB;
           else
             byColor_47 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 160, byColor_47, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 160, byColor_47, 0, 200, 640, pal_addr);
         } else {
           if (iVideoState == 11)
             byColor_48 = 0xAB;
           else
             byColor_48 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 160, byColor_48, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 160, byColor_48, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 10)
           byColor_49 = 0xAB;
         else
           byColor_49 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3264], font1_ascii, font1_offsets, 435, 180, byColor_49, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3264], font1_ascii, font1_offsets, 435, 180, byColor_49, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_WALL_TEXTURES) != 0) {
           if (iVideoState == 10)
             byColor_50 = 0xAB;
           else
             byColor_50 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 180, byColor_50, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 180, byColor_50, 0, 200, 640, pal_addr);
         } else {
           if (iVideoState == 10)
             byColor_51 = 0xAB;
           else
             byColor_51 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 180, byColor_51, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 180, byColor_51, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 9)
           byColor_52 = 0xAB;
         else
           byColor_52 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3328], font1_ascii, font1_offsets, 435, 200, byColor_52, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3328], font1_ascii, font1_offsets, 435, 200, byColor_52, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_GROUND_TEXTURES) != 0) {
           if (iVideoState == 9)
             byColor_53 = 0xAB;
           else
             byColor_53 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 200, byColor_53, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 200, byColor_53, 0, 200, 640, pal_addr);
         } else {
           if (iVideoState == 9)
             byColor_54 = 0xAB;
           else
             byColor_54 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 200, byColor_54, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 200, byColor_54, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 8)
           byColor_55 = 0xAB;
         else
           byColor_55 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3392], font1_ascii, font1_offsets, 435, 220, byColor_55, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3392], font1_ascii, font1_offsets, 435, 220, byColor_55, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_BUILDING_TEXTURES) == 0) {
           if (iVideoState == 8)
             byColor_56 = 0xAB;
           else
             byColor_56 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 220, byColor_56, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 220, byColor_56, 0, 200, 640, pal_addr);
         } else {
           if (iVideoState == 8)
             byColor_57 = 0xAB;
           else
             byColor_57 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 220, byColor_57, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 220, byColor_57, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 7)
           byColor_58 = 0xAB;
         else
           byColor_58 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3456], font1_ascii, font1_offsets, 435, 240, byColor_58, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3456], font1_ascii, font1_offsets, 435, 240, byColor_58, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_ROAD_TEXTURES) != 0) {
           if (iVideoState == 7)
             byColor_59 = 0xAB;
           else
             byColor_59 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 240, byColor_59, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 240, byColor_59, 0, 200, 640, pal_addr);
         } else {
           if (iVideoState == 7)
             byColor_60 = 0xAB;
           else
             byColor_60 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 240, byColor_60, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 240, byColor_60, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 6)
           byColor_61 = 0xAB;
         else
           byColor_61 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3520], font1_ascii, font1_offsets, 435, 260, byColor_61, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3520], font1_ascii, font1_offsets, 435, 260, byColor_61, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_SHADOWS) != 0) {
           if (iVideoState == 6)
             byColor_62 = 0xAB;
           else
             byColor_62 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 260, byColor_62, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 260, byColor_62, 0, 200, 640, pal_addr);
         } else {
           if (iVideoState == 6)
             byColor_63 = 0xAB;
           else
             byColor_63 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 260, byColor_63, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 260, byColor_63, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 5)
           byColor_64 = 0xAB;
         else
           byColor_64 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3584], font1_ascii, font1_offsets, 435, 280, byColor_64, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3584], font1_ascii, font1_offsets, 435, 280, byColor_64, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_CLOUDS) != 0) {
           if (iVideoState == 5)
             byColor_65 = 0xAB;
           else
             byColor_65 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 280, byColor_65, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 280, byColor_65, 0, 200, 640, pal_addr);
         } else {
           if (iVideoState == 5)
             byColor_66 = 0xAB;
           else
             byColor_66 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 280, byColor_66, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 280, byColor_66, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 4)
           byColor_67 = 0xAB;
         else
           byColor_67 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3648], font1_ascii, font1_offsets, 435, 300, byColor_67, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3648], font1_ascii, font1_offsets, 435, 300, byColor_67, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_PANEL_OFF) != 0) {
           if (iVideoState == 4)
             byColor_68 = 0xAB;
           else
             byColor_68 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 300, byColor_68, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 300, byColor_68, 0, 200, 640, pal_addr);
         } else if ((textures_off & TEX_OFF_PANEL_RESTRICTED) != 0) {
           if (iVideoState == 4)
             byColor_69 = 0xAB;
           else
             byColor_69 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[3776], font1_ascii, font1_offsets, 440, 300, byColor_69, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[3776], font1_ascii, font1_offsets, 440, 300, byColor_69, 0, 200, 640, pal_addr);
         } else {
           if (iVideoState == 4)
             byColor_70 = 0xAB;
           else
             byColor_70 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 300, byColor_70, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 300, byColor_70, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 3)
           byColor_71 = 0xAB;
         else
           byColor_71 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3712], font1_ascii, font1_offsets, 435, 320, byColor_71, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3712], font1_ascii, font1_offsets, 435, 320, byColor_71, 2u, 200, 640, pal_addr);
         if (view_limit) {
           if (iVideoState == 3)
             byColor_72 = 0xAB;
           else
             byColor_72 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[3776], font1_ascii, font1_offsets, 440, 320, byColor_72, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[3776], font1_ascii, font1_offsets, 440, 320, byColor_72, 0, 200, 640, pal_addr);
         } else {
           if (iVideoState == 3)
             byColor_73 = 0xAB;
           else
             byColor_73 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[3840], font1_ascii, font1_offsets, 440, 320, byColor_73, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[3840], font1_ascii, font1_offsets, 440, 320, byColor_73, 0, 200, 640, pal_addr);
         }
         if (iVideoState == 2)
           byColor_74 = 0xAB;
         else
           byColor_74 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[3904], font1_ascii, font1_offsets, 435, 340, byColor_74, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[3904], font1_ascii, font1_offsets, 435, 340, byColor_74, 2u, 200, 640, pal_addr);
         if (game_svga)
           iReturnValue = (100 * game_size) >> 7;
           //iReturnValue = (100 * game_size) % 128;
@@ -4689,25 +4706,25 @@ void select_configure()
           byColor_76 = 0xAB;
         else
           byColor_76 = 0x8F;
-        scale_text(front_vga[15], buffer, font1_ascii, font1_offsets, 440, 340, byColor_76, 0, 200, 640);
+        menu_render_scaled_text(mr, 15, buffer, font1_ascii, font1_offsets, 440, 340, byColor_76, 0, 200, 640, pal_addr);
         if (game_svga) {
           if (iVideoState == 1)
             byColor_75 = 0xAB;
           else
             byColor_75 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[512], font1_ascii, font1_offsets, 440, 360, byColor_75, 1u, 20, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[512], font1_ascii, font1_offsets, 440, 360, byColor_75, 1u, 20, 640, pal_addr);
         } else {
           if (iVideoState == 1)
             byColor_77 = 0xAB;
           else
             byColor_77 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[448], font1_ascii, font1_offsets, 440, 360, byColor_77, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[448], font1_ascii, font1_offsets, 440, 360, byColor_77, 1u, 200, 640, pal_addr);
         }
         if (iVideoState)
           byColor_78 = 0x8F;
         else
           byColor_78 = 0xAB;
-        scale_text(front_vga[15], &config_buffer[832], font1_ascii, font1_offsets, 430, 380, byColor_78, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[832], font1_ascii, font1_offsets, 430, 380, byColor_78, 2u, 200, 640, pal_addr);
         goto RENDER_FRAME;
       case 5:
         if (iConfigState != 6)
@@ -4718,101 +4735,101 @@ void select_configure()
             byColor_79 = 0xAB;
           else
             byColor_79 = 0x8F;
-          scale_text(front_vga[15], buffer, font1_ascii, font1_offsets, 435, 78, byColor_79, 2u, 200, 640);
+          menu_render_scaled_text(mr, 15, buffer, font1_ascii, font1_offsets, 435, 78, byColor_79, 2u, 200, 640, pal_addr);
           if (iGraphicsState == 6)
             byColor_80 = 0xAB;
           else
             byColor_80 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[64 * game_view[1] + 4928], font1_ascii, font1_offsets, 440, 78, byColor_80, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[64 * game_view[1] + 4928], font1_ascii, font1_offsets, 440, 78, byColor_80, 0, 200, 640, pal_addr);
         }
         sprintf(buffer, "%s %s", &config_buffer[4416], &config_buffer[4864]);
         if (iGraphicsState == 5)
           byColor_81 = 0xAB;
         else
           byColor_81 = 0x8F;
-        scale_text(front_vga[15], buffer, font1_ascii, font1_offsets, 435, 96, byColor_81, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, buffer, font1_ascii, font1_offsets, 435, 96, byColor_81, 2u, 200, 640, pal_addr);
         if (iGraphicsState == 5)
           byColor_82 = 0xAB;
         else
           byColor_82 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[64 * game_view[0] + 4928], font1_ascii, font1_offsets, 440, 96, byColor_82, 0, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[64 * game_view[0] + 4928], font1_ascii, font1_offsets, 440, 96, byColor_82, 0, 200, 640, pal_addr);
         if (iGraphicsState == 4)
           byColor_83 = 0xAB;
         else
           byColor_83 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[5440], font1_ascii, font1_offsets, 435, 114, byColor_83, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[5440], font1_ascii, font1_offsets, 435, 114, byColor_83, 2u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_KMH) != 0) {
           if (iGraphicsState == 4)
             byColor_84 = 0xAB;
           else
             byColor_84 = 0x8F;
-          scale_text(front_vga[15], "KMH", font1_ascii, font1_offsets, 440, 114, byColor_84, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, "KMH", font1_ascii, font1_offsets, 440, 114, byColor_84, 0, 200, 640, pal_addr);
         } else {
           if (iGraphicsState == 4)
             byColor_85 = 0xAB;
           else
             byColor_85 = 0x8F;
-          scale_text(front_vga[15], "MPH", font1_ascii, font1_offsets, 440, 114, byColor_85, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, "MPH", font1_ascii, font1_offsets, 440, 114, byColor_85, 0, 200, 640, pal_addr);
         }
         if (iGraphicsState == 3)
           byColor_86 = 0xAB;
         else
           byColor_86 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[5504], font1_ascii, font1_offsets, 435, 132, byColor_86, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[5504], font1_ascii, font1_offsets, 435, 132, byColor_86, 2u, 200, 640, pal_addr);
         if (replay_record) {
           if (iGraphicsState == 3)
             byColor_87 = 0xAB;
           else
             byColor_87 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 132, byColor_87, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 132, byColor_87, 0, 200, 640, pal_addr);
         } else {
           if (iGraphicsState == 3)
             byColor_88 = 0xAB;
           else
             byColor_88 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 132, byColor_88, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 132, byColor_88, 0, 200, 640, pal_addr);
         }
         if (iGraphicsState == 2)
           byColor_89 = 0xAB;
         else
           byColor_89 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[4672], font1_ascii, font1_offsets, 435, 150, byColor_89, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[4672], font1_ascii, font1_offsets, 435, 150, byColor_89, 2u, 200, 640, pal_addr);
         if (p_tex_size == 1) {
           if (iGraphicsState == 2)
             byColor_90 = 0xAB;
           else
             byColor_90 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[4736], font1_ascii, font1_offsets, 440, 150, byColor_90, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[4736], font1_ascii, font1_offsets, 440, 150, byColor_90, 0, 200, 640, pal_addr);
         } else {
           if (iGraphicsState == 2)
             byColor_91 = 0xAB;
           else
             byColor_91 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[4800], font1_ascii, font1_offsets, 440, 150, byColor_91, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[4800], font1_ascii, font1_offsets, 440, 150, byColor_91, 0, 200, 640, pal_addr);
         }
         if (iGraphicsState == 1)
           byColor_92 = 0xAB;
         else
           byColor_92 = 0x8F;
-        scale_text(front_vga[15], &config_buffer[5888], font1_ascii, font1_offsets, 435, 168, byColor_92, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[5888], font1_ascii, font1_offsets, 435, 168, byColor_92, 2u, 200, 640, pal_addr);
         if (false_starts) {
           if (iGraphicsState == 1)
             byColor_93 = 0xAB;
           else
             byColor_93 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2624], font1_ascii, font1_offsets, 440, 168, byColor_93, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2624], font1_ascii, font1_offsets, 440, 168, byColor_93, 0, 200, 640, pal_addr);
         } else {
           if (iGraphicsState == 1)
             byColor_94 = 0xAB;
           else
             byColor_94 = 0x8F;
-          scale_text(front_vga[15], &config_buffer[2688], font1_ascii, font1_offsets, 440, 168, byColor_94, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &config_buffer[2688], font1_ascii, font1_offsets, 440, 168, byColor_94, 0, 200, 640, pal_addr);
         }
         if (iGraphicsState)
           byColor_95 = 0x8F;
         else
           byColor_95 = 0xAB;
-        scale_text(front_vga[15], &config_buffer[832], font1_ascii, font1_offsets, 430, 186, byColor_95, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &config_buffer[832], font1_ascii, font1_offsets, 430, 186, byColor_95, 2u, 200, 640, pal_addr);
         goto RENDER_FRAME;
       case 6:
         if (iEditingName == 1) {
@@ -4842,56 +4859,56 @@ void select_configure()
           byColor_106 = byColor_97;
         else
           byColor_106 = 0x8F;
-        front_text(front_vga[15], &language_buffer[7296], font1_ascii, font1_offsets, 390, 50, byColor_106, 1u);
+        menu_render_text(mr, 15, &language_buffer[7296], font1_ascii, font1_offsets, 390, 50, byColor_106, 1u, pal_addr);
         if (iNetworkState == 4)
           byColor_98 = byColor_97;
         else
           byColor_98 = 0x8F;
-        front_text(front_vga[15], &config_buffer[5632], font1_ascii, font1_offsets, 385, 68, byColor_98, 2u);
+        menu_render_text(mr, 15, &config_buffer[5632], font1_ascii, font1_offsets, 385, 68, byColor_98, 2u, pal_addr);
         if (iNetworkState == 4)
           byColor_99 = byColor_96;
         else
           byColor_99 = 0x8F;
-        scale_text(front_vga[15], network_messages[0], font1_ascii, font1_offsets, 390, 68, byColor_99, 0, 200, 630);
+        menu_render_scaled_text(mr, 15, network_messages[0], font1_ascii, font1_offsets, 390, 68, byColor_99, 0, 200, 630, pal_addr);
         if (iNetworkState == 3)
           byColor_100 = byColor_97;
         else
           byColor_100 = 0x8F;
-        front_text(front_vga[15], &config_buffer[5696], font1_ascii, font1_offsets, 385, 86, byColor_100, 2u);
+        menu_render_text(mr, 15, &config_buffer[5696], font1_ascii, font1_offsets, 385, 86, byColor_100, 2u, pal_addr);
         if (iNetworkState == 3)
           byColor_101 = byColor_96;
         else
           byColor_101 = 0x8F;
-        scale_text(front_vga[15], network_messages[1], font1_ascii, font1_offsets, 390, 86, byColor_101, 0, 200, 630);
+        menu_render_scaled_text(mr, 15, network_messages[1], font1_ascii, font1_offsets, 390, 86, byColor_101, 0, 200, 630, pal_addr);
         if (iNetworkState == 2)
           byColor_102 = byColor_97;
         else
           byColor_102 = 0x8F;
-        front_text(front_vga[15], &config_buffer[5760], font1_ascii, font1_offsets, 385, 104, byColor_102, 2u);
+        menu_render_text(mr, 15, &config_buffer[5760], font1_ascii, font1_offsets, 385, 104, byColor_102, 2u, pal_addr);
         if (iNetworkState == 2)
           byColor_103 = byColor_96;
         else
           byColor_103 = 0x8F;
-        scale_text(front_vga[15], network_messages[2], font1_ascii, font1_offsets, 390, 104, byColor_103, 0, 200, 630);
+        menu_render_scaled_text(mr, 15, network_messages[2], font1_ascii, font1_offsets, 390, 104, byColor_103, 0, 200, 630, pal_addr);
         if (iNetworkState == 1)
           byColor_104 = byColor_97;
         else
           byColor_104 = 0x8F;
-        front_text(front_vga[15], &config_buffer[5824], font1_ascii, font1_offsets, 385, 122, byColor_104, 2u);
+        menu_render_text(mr, 15, &config_buffer[5824], font1_ascii, font1_offsets, 385, 122, byColor_104, 2u, pal_addr);
         if (iNetworkState != 1)
           byColor_96 = 0x8F;
         byTempChar2 = byColor_96;
         iNetworkState_1 = iNetworkState;
-        scale_text(front_vga[15], network_messages[3], font1_ascii, font1_offsets, 390, 122, byTempChar2, 0, 200, 630);
+        menu_render_scaled_text(mr, 15, network_messages[3], font1_ascii, font1_offsets, 390, 122, byTempChar2, 0, 200, 630, pal_addr);
         if (iNetworkState_1)
           byColor_97 = 0x8F;
-        front_text(front_vga[15], &config_buffer[832], font1_ascii, font1_offsets, 390, 140, byColor_97, 1u);
+        menu_render_text(mr, 15, &config_buffer[832], font1_ascii, font1_offsets, 390, 140, byColor_97, 1u, pal_addr);
         if (iEditingName == 1 && (frames & 0xFu) < 8) {
           iX = stringwidth(network_messages[4 - iNetworkState]) + 390;
           if (iX <= 620)
-            front_text(front_vga[15], "_", font1_ascii, font1_offsets, iX, iY, 0xABu, 0);
+            menu_render_text(mr, 15, "_", font1_ascii, font1_offsets, iX, iY, 0xABu, 0, pal_addr);
           else
-            front_text(front_vga[15], "_", font1_ascii, font1_offsets, 621, iY, 0xABu, 0);
+            menu_render_text(mr, 15, "_", font1_ascii, font1_offsets, 621, iY, 0xABu, 0, pal_addr);
         }
         goto RENDER_FRAME;
       default:

--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -1972,6 +1972,17 @@ void select_car()
   front_fade = 0;
   front_vga[3] = (tBlockHeader*)load_picture("carnames.bm");   // Load car company name graphics (carnames.bm) and car selection UI (selcar2.bm)
   front_vga[7] = (tBlockHeader*)load_picture("selcar2.bm");    // Load car selection UI bitmap
+  // Restore palette and create GPU textures for sub-menu rendering
+  {
+    extern tColor palette[];
+    memcpy(pal_addr, palette, 256 * sizeof(tColor));
+    palette_brightness = 32;
+    MenuRenderer *mr = GetMenuRenderer();
+    if (mr) {
+      menu_render_load_blocks(mr, 3, front_vga[3], palette);
+      menu_render_load_blocks(mr, 7, front_vga[7], palette);
+    }
+  }
   car_request = 0;
   byMenuExitFlag = 0;                           // Initialize selection state: byMenuExitFlag=0 (stay in menu), iOriginalCarSelection=-1 (no backup)
   iOriginalCarSelection = -1;                   // byExitCode = 0 - stay in selection, -1 = exit to menu
@@ -2044,21 +2055,28 @@ void select_car()
         frontendsample(0x8000);
         SampleHandleCar[84].handles[0] = -1;
       }
-      display_picture(scrbuf, front_vga[0]);    // RENDER FRAME
+      {                                           // RENDER FRAME (GPU)
+      MenuRenderer *mr = GetMenuRenderer();
+      menu_render_begin_frame(mr);
+      if (!front_fade) {
+        front_fade = -1;
+        menu_render_begin_fade(mr, 1, 32);
+      }
+      menu_render_background(mr, 0);
       if (player_type == 2)                   // Two-player mode
       {
         if (iActivePlayer)
-          display_block(scrbuf, front_vga[1], 6, head_x, head_y, 0);
+          menu_render_sprite(mr, 1, 6, head_x, head_y, 0, pal_addr);
         else
-          display_block(scrbuf, front_vga[1], 5, head_x, head_y, 0);
-        display_block(scrbuf, front_vga[1], 7, 200, 56, 0);
+          menu_render_sprite(mr, 1, 5, head_x, head_y, 0, pal_addr);
+        menu_render_sprite(mr, 1, 7, 200, 56, 0, pal_addr);
       } else {
-        display_block(scrbuf, front_vga[1], 1, head_x, head_y, 0);
+        menu_render_sprite(mr, 1, 1, head_x, head_y, 0, pal_addr);
       }
-      display_block(scrbuf, front_vga[6], 0, 36, 2, 0);
+      menu_render_sprite(mr, 6, 0, 36, 2, 0, pal_addr);
       if (iPlayer1Car < CAR_DESIGN_AUTO) {
-        front_text(front_vga[15], &language_buffer[4160], font1_ascii, font1_offsets, 400, 200, 0xE7u, 1u);
-      } else {                                         // Render 3D car model with zoom/rotation
+        menu_render_text(mr, 15, &language_buffer[4160], font1_ascii, font1_offsets, 400, 200, 0xE7u, 1u, pal_addr);
+      } else {                                         // 3D car preview (Phase 6 — renders to scrbuf, not visible yet)
         if (iPlayer1Car == CAR_DESIGN_F1WACK) {
           DrawCar(scrbuf + 34640, CAR_DESIGN_F1WACK, 6000.0, 1280, 0);
         } else if (iDelayBeforeRotation) {
@@ -2068,37 +2086,37 @@ void select_car()
           DrawCar(scrbuf + 34640, iPlayer1Car, fCarDrawDistance, 1280, 0);
         }
         if (iPlayer1Car < CAR_DESIGN_SUICYCO)
-          display_block(scrbuf, front_vga[3], iPlayer1Car, 190, 356, 0);
+          menu_render_sprite(mr, 3, iPlayer1Car, 190, 356, 0, pal_addr);
       }
-      display_block(scrbuf, front_vga[7], 0, 560, 20, 0);// Draw car statistics as 7 pie chart segments (speed, acceleration, braking, etc.)
+      menu_render_sprite(mr, 7, 0, 560, 20, 0, pal_addr);
       uiNetworkLoop = 0;
-      iPieChartY = 19;                          // Draw 7 pie chart segments (iY starts at 19, increments by 51)
+      iPieChartY = 19;                          // Draw 7 pie chart segments
       do {
-        display_block(scrbuf, front_vga[7], blockIdxAy[uiNetworkLoop / 4], 568, iPieChartY, 0);
+        menu_render_sprite(mr, 7, blockIdxAy[uiNetworkLoop / 4], 568, iPieChartY, 0, pal_addr);
         uiNetworkLoop += 4;
         iPieChartY += 51;
       } while (uiNetworkLoop != 28);
-      display_block(scrbuf, front_vga[5], player_type, -4, 247, 0);
-      display_block(scrbuf, front_vga[5], game_type + 5, 135, 247, 0);
-      display_block(scrbuf, front_vga[4], 0, 76, 257, -1);
+      menu_render_sprite(mr, 5, player_type, -4, 247, 0, pal_addr);
+      menu_render_sprite(mr, 5, game_type + 5, 135, 247, 0, pal_addr);
+      menu_render_sprite(mr, 4, 0, 76, 257, -1, pal_addr);
       if (iCurrentCarSelectorPos >= 8)        // Draw car selection cursor
       {
-        display_block(scrbuf, front_vga[6], 4, 62, 336, -1);
+        menu_render_sprite(mr, 6, 4, 62, 336, -1, pal_addr);
       } else {
-        display_block(scrbuf, front_vga[6], 2, 62, 336, -1);
-        front_text(front_vga[2], "~", font2_ascii, font2_offsets, sel_posns[iCurrentCarSelectorPos].x, sel_posns[iCurrentCarSelectorPos].y, 0x8Fu, 0);
+        menu_render_sprite(mr, 6, 2, 62, 336, -1, pal_addr);
+        menu_render_text(mr, 2, "~", font2_ascii, font2_offsets, sel_posns[iCurrentCarSelectorPos].x, sel_posns[iCurrentCarSelectorPos].y, 0x8Fu, 0, pal_addr);
       }
-      front_text(front_vga[2], "AUTO ARIEL", font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u);                                    // Draw all car company names
-      front_text(front_vga[2], "DESILVA", font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u);
-      front_text(front_vga[2], "PULSE", font2_ascii, font2_offsets, sel_posns[2].x + 132, sel_posns[2].y + 7, 0x8Fu, 2u);
-      front_text(front_vga[2], "GLOBAL", font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u);
-      front_text(front_vga[2], "MILLION PLUS", font2_ascii, font2_offsets, sel_posns[4].x + 132, sel_posns[4].y + 7, 0x8Fu, 2u);
-      front_text(front_vga[2], "MISSION", font2_ascii, font2_offsets, sel_posns[5].x + 132, sel_posns[5].y + 7, 0x8Fu, 2u);
-      front_text(front_vga[2], "ZIZIN", font2_ascii, font2_offsets, sel_posns[6].x + 132, sel_posns[6].y + 7, 0x8Fu, 2u);
-      front_text(front_vga[2], "REISE WAGON", font2_ascii, font2_offsets, sel_posns[7].x + 132, sel_posns[7].y + 7, 0x8Fu, 2u);
-      if (iCurrentCarSelectorPos < 8 && network_on && (cheat_mode & 0x4000) == 0)// Network mode: show which players have allocated which cars
+      menu_render_text(mr, 2, "AUTO ARIEL", font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u, pal_addr);
+      menu_render_text(mr, 2, "DESILVA", font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u, pal_addr);
+      menu_render_text(mr, 2, "PULSE", font2_ascii, font2_offsets, sel_posns[2].x + 132, sel_posns[2].y + 7, 0x8Fu, 2u, pal_addr);
+      menu_render_text(mr, 2, "GLOBAL", font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u, pal_addr);
+      menu_render_text(mr, 2, "MILLION PLUS", font2_ascii, font2_offsets, sel_posns[4].x + 132, sel_posns[4].y + 7, 0x8Fu, 2u, pal_addr);
+      menu_render_text(mr, 2, "MISSION", font2_ascii, font2_offsets, sel_posns[5].x + 132, sel_posns[5].y + 7, 0x8Fu, 2u, pal_addr);
+      menu_render_text(mr, 2, "ZIZIN", font2_ascii, font2_offsets, sel_posns[6].x + 132, sel_posns[6].y + 7, 0x8Fu, 2u, pal_addr);
+      menu_render_text(mr, 2, "REISE WAGON", font2_ascii, font2_offsets, sel_posns[7].x + 132, sel_posns[7].y + 7, 0x8Fu, 2u, pal_addr);
+      if (iCurrentCarSelectorPos < 8 && network_on && (cheat_mode & 0x4000) == 0)// Network mode
       {
-        front_text(front_vga[15], &language_buffer[4672], font1_ascii, font1_offsets, 380, 380, 0x8Fu, 2u);
+        menu_render_text(mr, 15, &language_buffer[4672], font1_ascii, font1_offsets, 380, 380, 0x8Fu, 2u, pal_addr);
         if (allocated_cars[iCurrentCarSelectorPos]) {
           iPlayerNameX = 385;
           iNetworkPlayerCount = 0;
@@ -2111,7 +2129,7 @@ void select_car()
                   uiPlayerIndex = 0;
                 else
                   uiPlayerIndex = 2;
-                front_text(front_vga[15], szPlayerName, font1_ascii, font1_offsets, iPlayerNameX, 380, 0x8Fu, uiPlayerIndex);
+                menu_render_text(mr, 15, szPlayerName, font1_ascii, font1_offsets, iPlayerNameX, 380, 0x8Fu, uiPlayerIndex, pal_addr);
                 iPlayerNameX = 620;
               }
               uiNetworkPlayerIndex += 4;
@@ -2120,7 +2138,7 @@ void select_car()
             } while (iNetworkPlayerCount < players);
           }
         } else {
-          front_text(front_vga[15], &language_buffer[4736], font1_ascii, font1_offsets, 385, 380, 0x83u, 0);
+          menu_render_text(mr, 15, &language_buffer[4736], font1_ascii, font1_offsets, 385, 380, 0x83u, 0, pal_addr);
         }
       }
       if (iOriginalCarSelection >= 0)         // Display current player's selected car company name at bottom
@@ -2129,10 +2147,11 @@ void select_car()
           sprintf(buffer, "%s %s", &language_buffer[2880], CompanyNames[Players_Cars[player2_car]]);
         else
           sprintf(buffer, "%s %s", &language_buffer[2816], szCurrentCompanyName);
-        scale_text(front_vga[15], buffer, font1_ascii, font1_offsets, 375, 316, 231, 1u, 170, 550);
+        menu_render_scaled_text(mr, 15, buffer, font1_ascii, font1_offsets, 375, 316, 231, 1u, 170, 550, pal_addr);
       }
       show_received_mesage();
-      copypic(scrbuf, screen);
+      menu_render_end_frame(mr);
+      }
       iAnimationCounter = iDelayBeforeRotation; // ANIMATION UPDATE: Rotate pie chart segments during delay period
       if (iDelayBeforeRotation) {
         if (iPlayer1Car >= CAR_DESIGN_AUTO) {
@@ -2417,7 +2436,18 @@ void select_car()
       UpdateSDL();
     } while (!byMenuExitFlag);                  // MAIN SELECTION LOOP - Handle UI rendering, input, and car switching
   }
-  fade_palette(0);                              // CLEANUP: Fade screen, free graphics memory, restore original car selection
+  // GPU fade-out
+  {
+    MenuRenderer *mr = GetMenuRenderer();
+    menu_render_begin_fade(mr, 0, 32);
+    menu_render_fade_wait(mr, fade_redraw_bg, mr);
+    palette_brightness = 0;
+    for (int i = 0; i < 256; i++) {
+      pal_addr[i].byR = 0;
+      pal_addr[i].byB = 0;
+      pal_addr[i].byG = 0;
+    }
+  }
   fre((void **)&front_vga[7]);
   if (frontendspeechptr)
     fre((void **)&frontendspeechptr);

--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -5965,6 +5965,18 @@ void select_track()
   front_vga[13] = (tBlockHeader *)load_picture("bonustrk.bm");
   iYaw = 0;
   front_vga[14] = (tBlockHeader *)load_picture("cupicons.bm");
+  // Restore palette and create GPU textures for sub-menu rendering
+  {
+    extern tColor palette[];
+    memcpy(pal_addr, palette, 256 * sizeof(tColor));
+    palette_brightness = 32;
+    MenuRenderer *mr = GetMenuRenderer();
+    if (mr) {
+      menu_render_load_blocks(mr, 3, front_vga[3], palette);
+      menu_render_load_blocks(mr, 13, front_vga[13], palette);
+      menu_render_load_blocks(mr, 14, front_vga[14], palette);
+    }
+  }
   frames = 0;
   fZ = cur_TrackZ;
   fZ_1 = cur_TrackZ;
@@ -5992,29 +6004,36 @@ void select_track()
       else
         network_champ_on = 0;
     }
-    display_picture(scrbuf, front_vga[0]);      // Draw main background and UI elements
-    display_block(scrbuf, front_vga[1], 2, head_x, head_y, 0);
+    {                                           // RENDER FRAME (GPU)
+    MenuRenderer *mr = GetMenuRenderer();
+    menu_render_begin_frame(mr);
+    if (!front_fade) {
+      front_fade = -1;
+      menu_render_begin_fade(mr, 1, 32);
+    }
+    menu_render_background(mr, 0);
+    menu_render_sprite(mr, 1, 2, head_x, head_y, 0, pal_addr);
     if (cup_won)                              // Show cup trophy if championship won
-      display_block(scrbuf, front_vga[1], 8, 480, 388, 0);
-    display_block(scrbuf, front_vga[6], 0, 36, 2, 0);
-    display_block(scrbuf, front_vga[5], player_type, -4, 247, 0);// Display player type and game type indicators
-    display_block(scrbuf, front_vga[5], game_type + 5, 135, 247, 0);
-    display_block(scrbuf, front_vga[4], 1, 76, 257, -1);
+      menu_render_sprite(mr, 1, 8, 480, 388, 0, pal_addr);
+    menu_render_sprite(mr, 6, 0, 36, 2, 0, pal_addr);
+    menu_render_sprite(mr, 5, player_type, -4, 247, 0, pal_addr);// Display player type and game type indicators
+    menu_render_sprite(mr, 5, game_type + 5, 135, 247, 0, pal_addr);
+    menu_render_sprite(mr, 4, 1, 76, 257, -1, pal_addr);
     if (iSelectedTrack >= 8)                  // Draw track selector: championship view or individual track selector
     {
-      display_block(scrbuf, front_vga[6], 4, 62, 336, -1);
+      menu_render_sprite(mr, 6, 4, 62, 336, -1, pal_addr);
     } else {
-      display_block(scrbuf, front_vga[6], 2, 62, 336, -1);
-      front_text(front_vga[2], "~", font2_ascii, font2_offsets, sel_posns[iSelectedTrack].x, sel_posns[iSelectedTrack].y, 0x8Fu, 0);
+      menu_render_sprite(mr, 6, 2, 62, 336, -1, pal_addr);
+      menu_render_text(mr, 2, "~", font2_ascii, font2_offsets, sel_posns[iSelectedTrack].x, sel_posns[iSelectedTrack].y, 0x8Fu, 0, pal_addr);
     }
-    front_text(front_vga[2], "AUTO ARIEL", font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u);// Display hardcoded track names (should use track name data)
-    front_text(front_vga[2], "DESILVA", font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], "PULSE", font2_ascii, font2_offsets, sel_posns[2].x + 132, sel_posns[2].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], "GLOBAL", font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], "MILLION PLUS", font2_ascii, font2_offsets, sel_posns[4].x + 132, sel_posns[4].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], "MISSION", font2_ascii, font2_offsets, sel_posns[5].x + 132, sel_posns[5].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], "ZIZIN", font2_ascii, font2_offsets, sel_posns[6].x + 132, sel_posns[6].y + 7, 0x8Fu, 2u);
-    front_text(front_vga[2], "REISE WAGON", font2_ascii, font2_offsets, sel_posns[7].x + 132, sel_posns[7].y + 7, 0x8Fu, 2u);
+    menu_render_text(mr, 2, "AUTO ARIEL", font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u, pal_addr);// Display hardcoded track names (should use track name data)
+    menu_render_text(mr, 2, "DESILVA", font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, "PULSE", font2_ascii, font2_offsets, sel_posns[2].x + 132, sel_posns[2].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, "GLOBAL", font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, "MILLION PLUS", font2_ascii, font2_offsets, sel_posns[4].x + 132, sel_posns[4].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, "MISSION", font2_ascii, font2_offsets, sel_posns[5].x + 132, sel_posns[5].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, "ZIZIN", font2_ascii, font2_offsets, sel_posns[6].x + 132, sel_posns[6].y + 7, 0x8Fu, 2u, pal_addr);
+    menu_render_text(mr, 2, "REISE WAGON", font2_ascii, font2_offsets, sel_posns[7].x + 132, sel_posns[7].y + 7, 0x8Fu, 2u, pal_addr);
     iBlockIdx = (TrackLoad - 1) / 8;  // Calculate cup icon index (8 tracks per cup)
     //iBlockIdx = (TrackLoad - 1 - (__CFSHL__((TrackLoad - 1) >> 31, 3) + 8 * ((TrackLoad - 1) >> 31))) >> 3;// Calculate cup icon index for display
     if (TrackLoad >= 0) {                                           // Render 3D track preview
@@ -6032,8 +6051,8 @@ void select_track()
           NoOfLaps = iLapsForLevel / 2;
       }
       sprintf(buffer, "%s: %i", &language_buffer[4544], NoOfLaps);
-      front_text(front_vga[15], buffer, font1_ascii, font1_offsets, 420, 16, 0x8Fu, 1u);
-      front_text(front_vga[15], &language_buffer[4608], font1_ascii, font1_offsets, 420, 34, 0x8Fu, 1u);
+      menu_render_text(mr, 15, buffer, font1_ascii, font1_offsets, 420, 16, 0x8Fu, 1u, pal_addr);
+      menu_render_text(mr, 15, &language_buffer[4608], font1_ascii, font1_offsets, 420, 34, 0x8Fu, 1u, pal_addr);
       if (RecordCars[TrackLoad] < 0)          // Display track record holder and lap time
       {
         sprintf(buffer, "%s", RecordNames[TrackLoad]);
@@ -6067,22 +6086,23 @@ void select_track()
         //  iRecordSeconds,
         //  (unsigned int)(llTimeCalc % 100));
       }
-      front_text(front_vga[15], buffer, font1_ascii, font1_offsets, 420, 52, 0x8Fu, 1u);
+      menu_render_text(mr, 15, buffer, font1_ascii, font1_offsets, 420, 52, 0x8Fu, 1u, pal_addr);
     }
-    display_block(scrbuf, front_vga[14], iBlockIdx, 500, 300, 0);// Display cup icon and track name/type
+    menu_render_sprite(mr, 14, iBlockIdx, 500, 300, 0, pal_addr);// Display cup icon and track name/type
     if (TrackLoad <= 0) {
       if (TrackLoad)
-        front_text(front_vga[2], "EDITOR", font2_ascii, font2_offsets, 190, 350, 0x8Fu, 0);
+        menu_render_text(mr, 2, "EDITOR", font2_ascii, font2_offsets, 190, 350, 0x8Fu, 0, pal_addr);
       else
-        front_text(front_vga[2], "TRACK ZERO", font2_ascii, font2_offsets, 190, 350, 0x8Fu, 0);
+        menu_render_text(mr, 2, "TRACK ZERO", font2_ascii, font2_offsets, 190, 350, 0x8Fu, 0, pal_addr);
     } else if (TrackLoad >= 17)                 // Display track name: bonus tracks (17+), regular tracks (1-16), or special tracks
     {
-      display_block(scrbuf, front_vga[13], TrackLoad - 17, 190, 356, 0);
+      menu_render_sprite(mr, 13, TrackLoad - 17, 190, 356, 0, pal_addr);
     } else {
-      display_block(scrbuf, front_vga[3], TrackLoad - 1, 190, 356, 0);
+      menu_render_sprite(mr, 3, TrackLoad - 1, 190, 356, 0, pal_addr);
     }
     show_received_mesage();
-    copypic(scrbuf, screen);
+    menu_render_end_frame(mr);
+    }
     if (switch_same > 0)                      // Handle same-car mode activation/deactivation
     {
 
@@ -6154,8 +6174,6 @@ void select_track()
     if (!front_fade)                          // Initialize screen fade and sound effects on first display
     {
       loadtracksample(TrackLoad);
-      front_fade = -1;
-      fade_palette(32);
       frontendsample(0x8000);
       frames = 0;
     }
@@ -6243,7 +6261,18 @@ void select_track()
 
     UpdateSDL();
   } while (!iExitFlag);
-  fade_palette(0);                              // Cleanup: fade out, free graphics memory, restore car selection graphics
+  // GPU fade-out
+  {
+    MenuRenderer *mr = GetMenuRenderer();
+    menu_render_begin_fade(mr, 0, 32);
+    menu_render_fade_wait(mr, fade_redraw_bg, mr);
+    palette_brightness = 0;
+    for (int i = 0; i < 256; i++) {
+      pal_addr[i].byR = 0;
+      pal_addr[i].byB = 0;
+      pal_addr[i].byG = 0;
+    }
+  }
   front_fade = 0;
   fre((void **)&front_vga[3]);
   fre((void **)&front_vga[13]);

--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -5423,6 +5423,17 @@ void select_type()
   iMenuSelection = 0;
   fade_palette(0);
   front_fade = 0;
+  // Restore palette for GPU rendering
+  {
+    extern tColor palette[];
+    memcpy(pal_addr, palette, 256 * sizeof(tColor));
+    palette_brightness = 32;
+    MenuRenderer *mr = GetMenuRenderer();
+    if (mr) {
+      menu_render_load_blocks(mr, 14, front_vga[14], palette);
+    }
+  }
+  frames = 0;
   iCurrentOption = 5;
   do {                                             // Handle game type switches and updates
     if (switch_types) {
@@ -5435,58 +5446,65 @@ void select_type()
       else
         network_champ_on = 0;
     }
-    display_picture(scrbuf, front_vga[0]);      // RENDER FRAME: Draw background, UI elements, and cup winner icon
-    display_block(scrbuf, front_vga[1], 4, head_x, head_y, 0);
-    display_block(scrbuf, front_vga[6], 0, 36, 2, 0);
-    display_block(scrbuf, front_vga[5], player_type, -4, 247, 0);
-    display_block(scrbuf, front_vga[5], game_type + 5, 135, 247, 0);
-    display_block(scrbuf, front_vga[4], 4, 76, 257, -1);
+    {                                           // RENDER FRAME (GPU)
+    MenuRenderer *mr = GetMenuRenderer();
+    menu_render_begin_frame(mr);
+    if (!front_fade) {
+      front_fade = -1;
+      menu_render_begin_fade(mr, 1, 32);
+    }
+    menu_render_background(mr, 0);
+    menu_render_sprite(mr, 1, 4, head_x, head_y, 0, pal_addr);
+    menu_render_sprite(mr, 6, 0, 36, 2, 0, pal_addr);
+    menu_render_sprite(mr, 5, player_type, -4, 247, 0, pal_addr);
+    menu_render_sprite(mr, 5, game_type + 5, 135, 247, 0, pal_addr);
+    menu_render_sprite(mr, 4, 4, 76, 257, -1, pal_addr);
     if (cup_won && !iSkipColor)
-      display_block(scrbuf, front_vga[1], 8, 200, 56, 0);
+      menu_render_sprite(mr, 1, 8, 200, 56, 0, pal_addr);
     if (iCurrentOption >= 5)                  // Draw selection cursor or \"Random\" indicator (option 5 = Random)
     {
-      display_block(scrbuf, front_vga[6], 4, 62, 336, -1);
+      menu_render_sprite(mr, 6, 4, 62, 336, -1, pal_addr);
     } else {
-      display_block(scrbuf, front_vga[6], 2, 62, 336, -1);
-      front_text(front_vga[2], "~", font2_ascii, font2_offsets, sel_posns[iCurrentOption].x, sel_posns[iCurrentOption].y, 0x8Fu, 0);
+      menu_render_sprite(mr, 6, 2, 62, 336, -1, pal_addr);
+      menu_render_text(mr, 2, "~", font2_ascii, font2_offsets, sel_posns[iCurrentOption].x, sel_posns[iCurrentOption].y, 0x8Fu, 0, pal_addr);
     }
     if (iSkipColor)                           // OPTION LABELS: Display main option categories (Game Type/Difficulty/etc.)
     {
-      front_text(front_vga[2], &language_buffer[3136], font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u);
+      menu_render_text(mr, 2, &language_buffer[3136], font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u, pal_addr);
     } else {
-      front_text(front_vga[2], &language_buffer[384], font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u);
-      front_text(front_vga[2], &language_buffer[3200], font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u);
-      front_text(front_vga[2], &language_buffer[3264], font2_ascii, font2_offsets, sel_posns[2].x + 132, sel_posns[2].y + 7, 0x8Fu, 2u);
-      front_text(front_vga[2], &language_buffer[3328], font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u);
+      menu_render_text(mr, 2, &language_buffer[384], font2_ascii, font2_offsets, sel_posns[0].x + 132, sel_posns[0].y + 7, 0x8Fu, 2u, pal_addr);
+      menu_render_text(mr, 2, &language_buffer[3200], font2_ascii, font2_offsets, sel_posns[1].x + 132, sel_posns[1].y + 7, 0x8Fu, 2u, pal_addr);
+      menu_render_text(mr, 2, &language_buffer[3264], font2_ascii, font2_offsets, sel_posns[2].x + 132, sel_posns[2].y + 7, 0x8Fu, 2u, pal_addr);
+      menu_render_text(mr, 2, &language_buffer[3328], font2_ascii, font2_offsets, sel_posns[3].x + 132, sel_posns[3].y + 7, 0x8Fu, 2u, pal_addr);
       if (iCheatModesAvailable)
-        front_text(front_vga[2], &language_buffer[4288], font2_ascii, font2_offsets, sel_posns[4].x + 132, sel_posns[4].y + 7, 0x8Fu, 2u);
+        menu_render_text(mr, 2, &language_buffer[4288], font2_ascii, font2_offsets, sel_posns[4].x + 132, sel_posns[4].y + 7, 0x8Fu, 2u, pal_addr);
     }
-    display_block(scrbuf, front_vga[14], iBlockIdx, 500, 300, 0);// Display cup icon corresponding to current track selection
+    menu_render_sprite(mr, 14, iBlockIdx, 500, 300, 0, pal_addr);// Display cup icon corresponding to current track selection
     if (iSkipColor)                           // CHAMPIONSHIP MODE UI: Show current settings and restrictions
     {
-      scale_text(front_vga[15], &language_buffer[3392], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640);
-      scale_text(front_vga[15], &language_buffer[1280], font1_ascii, font1_offsets, 400, 100, 143, 2u, 200, 640);
+      menu_render_scaled_text(mr, 15, &language_buffer[3392], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640, pal_addr);
+      menu_render_scaled_text(mr, 15, &language_buffer[1280], font1_ascii, font1_offsets, 400, 100, 143, 2u, 200, 640, pal_addr);
       if ((cheat_mode & 2) != 0)
-        scale_text(front_vga[15], &language_buffer[2048], font1_ascii, font1_offsets, 405, 100, 143, 0, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[2048], font1_ascii, font1_offsets, 405, 100, 143, 0, 200, 640, pal_addr);
       else
-        scale_text(front_vga[15], &language_buffer[64 * level + 1472], font1_ascii, font1_offsets, 405, 100, 143, 0, 200, 640);
-      scale_text(front_vga[15], &language_buffer[1344], font1_ascii, font1_offsets, 400, 118, 143, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[64 * level + 1472], font1_ascii, font1_offsets, 405, 100, 143, 0, 200, 640, pal_addr);
+      menu_render_scaled_text(mr, 15, &language_buffer[1344], font1_ascii, font1_offsets, 400, 118, 143, 2u, 200, 640, pal_addr);
       if ((cheat_mode & 2) != 0)
-        scale_text(front_vga[15], &language_buffer[2048], font1_ascii, font1_offsets, 405, 118, 143, 0, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[2048], font1_ascii, font1_offsets, 405, 118, 143, 0, 200, 640, pal_addr);
       else
-        scale_text(front_vga[15], &language_buffer[64 * damage_level + 1856], font1_ascii, font1_offsets, 405, 118, 143, 0, 200, 640);
-      scale_text(front_vga[15], &language_buffer[1024], font1_ascii, font1_offsets, 400, 136, 143, 2u, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[64 * damage_level + 1856], font1_ascii, font1_offsets, 405, 118, 143, 0, 200, 640, pal_addr);
+      menu_render_scaled_text(mr, 15, &language_buffer[1024], font1_ascii, font1_offsets, 400, 136, 143, 2u, 200, 640, pal_addr);
       if ((unsigned int)competitors < 8) {
         if (competitors == 2)
-          scale_text(front_vga[15], &language_buffer[1088], font1_ascii, font1_offsets, 405, 136, 143, 0, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[1088], font1_ascii, font1_offsets, 405, 136, 143, 0, 200, 640, pal_addr);
       } else if ((unsigned int)competitors <= 8) {
-        scale_text(front_vga[15], &language_buffer[1152], font1_ascii, font1_offsets, 405, 136, 143, 0, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[1152], font1_ascii, font1_offsets, 405, 136, 143, 0, 200, 640, pal_addr);
       } else if (competitors == 16) {
-        scale_text(front_vga[15], &language_buffer[1216], font1_ascii, font1_offsets, 405, 136, 143, 0, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[1216], font1_ascii, font1_offsets, 405, 136, 143, 0, 200, 640, pal_addr);
       }
       if (network_on)                         // NETWORK MODE: Display connected players list
       {
-        scale_text(front_vga[15], &language_buffer[4672], font1_ascii, font1_offsets, 400, 154, 143, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[4672], font1_ascii, font1_offsets, 400, 154, 143, 1u, 200, 640, pal_addr);
         iNetworkPlayerCount = 0;
         if (players > 0) {
           szText = player_names[0];
@@ -5494,9 +5512,9 @@ void select_type()
           iNetworkDisplayY = 172;
           do {
             if (iNetworkPlayerCount >= 8)
-              scale_text(front_vga[15], szText, font1_ascii, font1_offsets, 405, iY, 143, 0, 200, 640);
+              menu_render_scaled_text(mr, 15, szText, font1_ascii, font1_offsets, 405, iY, 143, 0, 200, 640, pal_addr);
             else
-              scale_text(front_vga[15], szText, font1_ascii, font1_offsets, 400, iNetworkDisplayY, 143, 2u, 200, 640);
+              menu_render_scaled_text(mr, 15, szText, font1_ascii, font1_offsets, 400, iNetworkDisplayY, 143, 2u, 200, 640, pal_addr);
             szText += 9;
             iY += 18;
             iNetworkDisplayY += 18;
@@ -5511,9 +5529,9 @@ void select_type()
       case 0:
         if (!iSkipColor)                      // Option 0 - Game Type: Show race modes with highlighting for current selection
         {
-          scale_text(front_vga[15], &language_buffer[384], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[384], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640, pal_addr);
           if (iMenuSelection == 1) {
-            scale_text(front_vga[15], &language_buffer[3584], font1_ascii, font1_offsets, 400, 93, 143, 1u, 200, 640);
+            menu_render_scaled_text(mr, 15, &language_buffer[3584], font1_ascii, font1_offsets, 400, 93, 143, 1u, 200, 640, pal_addr);
             byTextColor = -85;
           } else {
             byTextColor = -87;
@@ -5522,12 +5540,12 @@ void select_type()
             byGameModeColor1 = -113;
           else
             byGameModeColor1 = byTextColor;
-          scale_text(front_vga[15], &language_buffer[3648], font1_ascii, font1_offsets, 400, 135, byGameModeColor1, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[3648], font1_ascii, font1_offsets, 400, 135, byGameModeColor1, 1u, 200, 640, pal_addr);
           if (game_type == 1)
             byGameModeColor2 = byTextColor;
           else
             byGameModeColor2 = -113;
-          scale_text(front_vga[15], &language_buffer[3520], font1_ascii, font1_offsets, 400, 153, byGameModeColor2, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[3520], font1_ascii, font1_offsets, 400, 153, byGameModeColor2, 1u, 200, 640, pal_addr);
           if (game_type == 2)
             byGameModeColor3 = byTextColor;
           else
@@ -5538,7 +5556,7 @@ void select_type()
           goto LABEL_130;
         }
         if (iMenuSelection == 6) {
-          scale_text(front_vga[15], &language_buffer[3456], font1_ascii, font1_offsets, 400, 320, 231, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[3456], font1_ascii, font1_offsets, 400, 320, 231, 1u, 200, 640, pal_addr);
           byFinalTextColor = -25;
           iTextYPosition = 338;
           pszTextBuffer = &language_buffer[3520];
@@ -5546,9 +5564,9 @@ void select_type()
         }
         break;
       case 1:
-        scale_text(front_vga[15], &language_buffer[3776], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640);// Option 1 - Difficulty: Show skill levels with cheat mode override
+        menu_render_scaled_text(mr, 15, &language_buffer[3776], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640, pal_addr);// Option 1 - Difficulty: Show skill levels with cheat mode override
         if (iMenuSelection == 2) {
-          scale_text(front_vga[15], &language_buffer[3840], font1_ascii, font1_offsets, 400, 93, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[3840], font1_ascii, font1_offsets, 400, 93, 143, 1u, 200, 640, pal_addr);
           byDifficultyMenuColor = -85;
         } else {
           byDifficultyMenuColor = -87;
@@ -5558,27 +5576,27 @@ void select_type()
             byDifficultyColor1 = byDifficultyMenuColor;
           else
             byDifficultyColor1 = -113;
-          scale_text(front_vga[15], &language_buffer[1792], font1_ascii, font1_offsets, 400, 135, byDifficultyColor1, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[1792], font1_ascii, font1_offsets, 400, 135, byDifficultyColor1, 1u, 200, 640, pal_addr);
           if (level == 4)
             byDifficultyColor2 = byDifficultyMenuColor;
           else
             byDifficultyColor2 = -113;
-          scale_text(front_vga[15], &language_buffer[1728], font1_ascii, font1_offsets, 400, 153, byDifficultyColor2, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[1728], font1_ascii, font1_offsets, 400, 153, byDifficultyColor2, 1u, 200, 640, pal_addr);
           if (level == 3)
             byDifficultyColor3 = byDifficultyMenuColor;
           else
             byDifficultyColor3 = -113;
-          scale_text(front_vga[15], &language_buffer[1664], font1_ascii, font1_offsets, 400, 171, byDifficultyColor3, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[1664], font1_ascii, font1_offsets, 400, 171, byDifficultyColor3, 1u, 200, 640, pal_addr);
           if (level == 2)
             byDifficultyColor4 = byDifficultyMenuColor;
           else
             byDifficultyColor4 = -113;
-          scale_text(front_vga[15], &language_buffer[1600], font1_ascii, font1_offsets, 400, 189, byDifficultyColor4, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[1600], font1_ascii, font1_offsets, 400, 189, byDifficultyColor4, 1u, 200, 640, pal_addr);
           if (level == 1)
             byDifficultyColor5 = byDifficultyMenuColor;
           else
             byDifficultyColor5 = -113;
-          scale_text(front_vga[15], &language_buffer[1536], font1_ascii, font1_offsets, 400, 207, byDifficultyColor5, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[1536], font1_ascii, font1_offsets, 400, 207, byDifficultyColor5, 1u, 200, 640, pal_addr);
           if (level)
             byDifficultyColor6 = -113;
           else
@@ -5588,12 +5606,12 @@ void select_type()
           pszTextBuffer = &language_buffer[1472];
           goto LABEL_130;
         }
-        scale_text(front_vga[15], &language_buffer[2048], font1_ascii, font1_offsets, 400, 135, byDifficultyMenuColor, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[2048], font1_ascii, font1_offsets, 400, 135, byDifficultyMenuColor, 1u, 200, 640, pal_addr);
         break;
       case 2:
-        scale_text(front_vga[15], &language_buffer[3904], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640);// Option 2 - Competitors: Show number of opponent cars (2/8/16 or \"Just Me\")
+        menu_render_scaled_text(mr, 15, &language_buffer[3904], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640, pal_addr);// Option 2 - Competitors: Show number of opponent cars (2/8/16 or \"Just Me\")
         if (iMenuSelection == 3) {
-          scale_text(front_vga[15], &language_buffer[3008], font1_ascii, font1_offsets, 400, 93, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[3008], font1_ascii, font1_offsets, 400, 93, 143, 1u, 200, 640, pal_addr);
           byDamageMenuColor = -85;
         } else {
           byDamageMenuColor = -87;
@@ -5603,12 +5621,12 @@ void select_type()
             byCompetitorColor1 = byDamageMenuColor;
           else
             byCompetitorColor1 = -113;
-          scale_text(front_vga[15], &language_buffer[1088], font1_ascii, font1_offsets, 400, 135, byCompetitorColor1, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[1088], font1_ascii, font1_offsets, 400, 135, byCompetitorColor1, 1u, 200, 640, pal_addr);
           if (competitors == 8)
             byCompetitorColor2 = byDamageMenuColor;
           else
             byCompetitorColor2 = -113;
-          scale_text(front_vga[15], &language_buffer[1152], font1_ascii, font1_offsets, 400, 153, byCompetitorColor2, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[1152], font1_ascii, font1_offsets, 400, 153, byCompetitorColor2, 1u, 200, 640, pal_addr);
           if (competitors == 16)
             byCompetitorColor3 = byDamageMenuColor;
           else
@@ -5618,12 +5636,12 @@ void select_type()
           pszTextBuffer = &language_buffer[1216];
           goto LABEL_130;
         }
-        scale_text(front_vga[15], &language_buffer[3968], font1_ascii, font1_offsets, 400, 135, byDamageMenuColor, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[3968], font1_ascii, font1_offsets, 400, 135, byDamageMenuColor, 1u, 200, 640, pal_addr);
         break;
       case 3:
-        scale_text(front_vga[15], &language_buffer[4032], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640); // Option 3 - Damage: Show car damage levels (None/Cosmetic/Realistic)
+        menu_render_scaled_text(mr, 15, &language_buffer[4032], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640, pal_addr); // Option 3 - Damage: Show car damage levels (None/Cosmetic/Realistic)
         if (iMenuSelection == 4) {
-          scale_text(front_vga[15], &language_buffer[3840], font1_ascii, font1_offsets, 400, 93, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[3840], font1_ascii, font1_offsets, 400, 93, 143, 1u, 200, 640, pal_addr);
           byTextureMenuColor = -85;
         } else {
           byTextureMenuColor = -87;
@@ -5633,12 +5651,12 @@ void select_type()
             byDamageColor1 = -113;
           else
             byDamageColor1 = byTextureMenuColor;
-          scale_text(front_vga[15], &language_buffer[1856], font1_ascii, font1_offsets, 400, 135, byDamageColor1, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[1856], font1_ascii, font1_offsets, 400, 135, byDamageColor1, 1u, 200, 640, pal_addr);
           if (damage_level == 1)
             byDamageColor2 = byTextureMenuColor;
           else
             byDamageColor2 = -113;
-          scale_text(front_vga[15], &language_buffer[1920], font1_ascii, font1_offsets, 400, 153, byDamageColor2, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[1920], font1_ascii, font1_offsets, 400, 153, byDamageColor2, 1u, 200, 640, pal_addr);
           if (damage_level == 2)
             byDamageColor3 = byTextureMenuColor;
           else
@@ -5648,12 +5666,12 @@ void select_type()
           pszTextBuffer = &language_buffer[1984];
           goto LABEL_130;
         }
-        scale_text(front_vga[15], &language_buffer[2048], font1_ascii, font1_offsets, 400, 135, byTextureMenuColor, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[2048], font1_ascii, font1_offsets, 400, 135, byTextureMenuColor, 1u, 200, 640, pal_addr);
         break;
       case 4:
-        scale_text(front_vga[15], &language_buffer[4288], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640);// Option 4 - Textures: Show texture quality options (On/Off)
+        menu_render_scaled_text(mr, 15, &language_buffer[4288], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640, pal_addr);// Option 4 - Textures: Show texture quality options (On/Off)
         if (iMenuSelection == 5) {
-          scale_text(front_vga[15], &language_buffer[4480], font1_ascii, font1_offsets, 400, 93, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[4480], font1_ascii, font1_offsets, 400, 93, 143, 1u, 200, 640, pal_addr);
           byCompetitorMenuColor = -85;
         } else {
           byCompetitorMenuColor = -87;
@@ -5662,7 +5680,7 @@ void select_type()
           byTextureColor1 = -113;
         else
           byTextureColor1 = byCompetitorMenuColor;
-        scale_text(front_vga[15], &language_buffer[4352], font1_ascii, font1_offsets, 400, 135, byTextureColor1, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[4352], font1_ascii, font1_offsets, 400, 135, byTextureColor1, 1u, 200, 640, pal_addr);
         if ((textures_off & TEX_OFF_ADVANCED_CARS) != 0)
           byTextureColor2 = byCompetitorMenuColor;
         else
@@ -5671,13 +5689,14 @@ void select_type()
         iTextYPosition = 153;
         pszTextBuffer = &language_buffer[4416];
       LABEL_130:
-        scale_text(front_vga[15], pszTextBuffer, font1_ascii, font1_offsets, 400, iTextYPosition, byFinalTextColor, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, pszTextBuffer, font1_ascii, font1_offsets, 400, iTextYPosition, byFinalTextColor, 1u, 200, 640, pal_addr);
         break;
       default:
         break;                                  // OPTION-SPECIFIC UI: Display details for currently selected option
     }
     show_received_mesage();
-    copypic(scrbuf, screen);
+    menu_render_end_frame(mr);
+    }
     if (switch_same > 0)                      // CHEAT MODE HANDLING: Process switch_same command for player synchronization
     {
       iCheatSetLoop = 0;
@@ -5717,12 +5736,7 @@ void select_type()
     }
     cheat_mode = uiUpdatedCheatFlags;
   LABEL_142:
-    if (!front_fade)                          // Handle screen fade-in effect
-    {
-      front_fade = -1;
-      fade_palette(32);
-      frames = 0;
-    }
+    ;
     while (fatkbhit())                        // KEYBOARD INPUT PROCESSING: Handle navigation and option changes
     {
       byInputKey = fatgetch();
@@ -5950,7 +5964,18 @@ void select_type()
     while (broadcast_mode)
       UpdateSDL();
   }
-  fade_palette(0);
+  // GPU fade-out
+  {
+    MenuRenderer *mr = GetMenuRenderer();
+    menu_render_begin_fade(mr, 0, 32);
+    menu_render_fade_wait(mr, fade_redraw_bg, mr);
+    palette_brightness = 0;
+    for (int i = 0; i < 256; i++) {
+      pal_addr[i].byR = 0;
+      pal_addr[i].byB = 0;
+      pal_addr[i].byG = 0;
+    }
+  }
   fre((void **)&front_vga[14]);
   front_fade = 0;
 }

--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -5012,6 +5012,12 @@ void select_players()
   fade_palette(0);
   uiSelectedPlayerType = player_type;
   front_fade = 0;
+  // Restore palette for GPU rendering
+  {
+    extern tColor palette[];
+    memcpy(pal_addr, palette, 256 * sizeof(tColor));
+    palette_brightness = 32;
+  }
   if (player_type == 1 && net_type)           // Map network types to player selection modes: Serial=3, Modem=4
   {
     if ((unsigned int)net_type <= 1) {
@@ -5037,17 +5043,24 @@ void select_players()
       else
         network_champ_on = 0;
     }
-    display_picture(scrbuf, front_vga[0]);
-    display_block(scrbuf, front_vga[1], 3, head_x, head_y, 0);
-    display_block(scrbuf, front_vga[6], 0, 36, 2, 0);
-    display_block(scrbuf, front_vga[5], uiSelectedPlayerType, -4, 247, 0);
-    display_block(scrbuf, front_vga[5], game_type + 5, 135, 247, 0);
-    display_block(scrbuf, front_vga[4], 4, 76, 257, -1);
-    display_block(scrbuf, front_vga[6], 4, 62, 336, -1);
+    {                                           // RENDER FRAME (GPU)
+    MenuRenderer *mr = GetMenuRenderer();
+    menu_render_begin_frame(mr);
+    if (!front_fade) {
+      front_fade = -1;
+      menu_render_begin_fade(mr, 1, 32);
+    }
+    menu_render_background(mr, 0);
+    menu_render_sprite(mr, 1, 3, head_x, head_y, 0, pal_addr);
+    menu_render_sprite(mr, 6, 0, 36, 2, 0, pal_addr);
+    menu_render_sprite(mr, 5, uiSelectedPlayerType, -4, 247, 0, pal_addr);
+    menu_render_sprite(mr, 5, game_type + 5, 135, 247, 0, pal_addr);
+    menu_render_sprite(mr, 4, 4, 76, 257, -1, pal_addr);
+    menu_render_sprite(mr, 6, 4, 62, 336, -1, pal_addr);
     if (iNetworkStatus && (uiSelectedPlayerType == 1 || uiSelectedPlayerType == 3 || uiSelectedPlayerType == 4))// Show connection status message for network modes
-      scale_text(front_vga[15], &language_buffer[4992], font1_ascii, font1_offsets, 400, 300, 231, 1u, 200, 640);
+      menu_render_scaled_text(mr, 15, &language_buffer[4992], font1_ascii, font1_offsets, 400, 300, 231, 1u, 200, 640, pal_addr);
     if ((uiSelectedPlayerType == 3 || uiSelectedPlayerType == 4) && !iComPortStatus)// Show COM port error message if networking failed to initialize
-      scale_text(front_vga[15], &language_buffer[8064], font1_ascii, font1_offsets, 400, 300, 231, 1u, 200, 640);
+      menu_render_scaled_text(mr, 15, &language_buffer[8064], font1_ascii, font1_offsets, 400, 300, 231, 1u, 200, 640, pal_addr);
     do {
       uiCheatArrayOffset = broadcast_mode;
       UpdateSDL();
@@ -5093,12 +5106,12 @@ void select_players()
       }
       if (net_type) {
         if ((unsigned int)net_type <= 1) {
-          scale_text(front_vga[15], &language_buffer[5056], font1_ascii, font1_offsets, 400, 60, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[5056], font1_ascii, font1_offsets, 400, 60, 143, 1u, 200, 640, pal_addr);
         } else if (net_type == 2) {
-          scale_text(front_vga[15], &language_buffer[5120], font1_ascii, font1_offsets, 400, 60, 143, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[5120], font1_ascii, font1_offsets, 400, 60, 143, 1u, 200, 640, pal_addr);
         }
       } else {
-        scale_text(front_vga[15], &language_buffer[4096], font1_ascii, font1_offsets, 400, 60, 143, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[4096], font1_ascii, font1_offsets, 400, 60, 143, 1u, 200, 640, pal_addr);
       }
       iPlayerListCount = 0;
       if (network_on > 0)                     // Display connected players and their selected cars
@@ -5107,12 +5120,12 @@ void select_players()
         iY = 80;
         szText = player_names[0];
         do {
-          scale_text(front_vga[15], szText, font1_ascii, font1_offsets, 336, iY, 143, 2u, 200, 640);
+          menu_render_scaled_text(mr, 15, szText, font1_ascii, font1_offsets, 336, iY, 143, 2u, 200, 640, pal_addr);
           iPlayerCarIndex = Players_Cars[iPlayerIndex];
           if (iPlayerCarIndex < 0)
-            scale_text(front_vga[15], &language_buffer[4160], font1_ascii, font1_offsets, 340, iY, 131, 0, 200, 640);
+            menu_render_scaled_text(mr, 15, &language_buffer[4160], font1_ascii, font1_offsets, 340, iY, 131, 0, 200, 640, pal_addr);
           else
-            scale_text(front_vga[15], CompanyNames[iPlayerCarIndex], font1_ascii, font1_offsets, 342, iY, 143, 0, 200, 640);
+            menu_render_scaled_text(mr, 15, CompanyNames[iPlayerCarIndex], font1_ascii, font1_offsets, 342, iY, 143, 0, 200, 640, pal_addr);
           ++iPlayerIndex;
           szText += 9;
           iY += 18;
@@ -5123,51 +5136,46 @@ void select_players()
       }
       if (net_type) {
         if ((unsigned int)net_type <= 1) {
-          scale_text(front_vga[15], &language_buffer[5184], font1_ascii, font1_offsets, 400, 380, 231, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[5184], font1_ascii, font1_offsets, 400, 380, 231, 1u, 200, 640, pal_addr);
         } else if (net_type == 2) {
-          scale_text(front_vga[15], &language_buffer[5248], font1_ascii, font1_offsets, 400, 380, 231, 1u, 200, 640);
+          menu_render_scaled_text(mr, 15, &language_buffer[5248], font1_ascii, font1_offsets, 400, 380, 231, 1u, 200, 640, pal_addr);
         }
       } else {
-        scale_text(front_vga[15], &language_buffer[4224], font1_ascii, font1_offsets, 400, 380, 231, 1u, 200, 640);
+        menu_render_scaled_text(mr, 15, &language_buffer[4224], font1_ascii, font1_offsets, 400, 380, 231, 1u, 200, 640, pal_addr);
       }
-      scale_text(front_vga[15], &language_buffer[7104], font1_ascii, font1_offsets, 400, 360, 231, 1u, 200, 640);
+      menu_render_scaled_text(mr, 15, &language_buffer[7104], font1_ascii, font1_offsets, 400, 360, 231, 1u, 200, 640, pal_addr);
     } else {
-      scale_text(front_vga[15], &language_buffer[2944], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640);// MENU MODE UI: Show player selection options with highlighting
-      scale_text(front_vga[15], &language_buffer[3008], font1_ascii, font1_offsets, 400, 93, 143, 1u, 200, 640);
+      menu_render_scaled_text(mr, 15, &language_buffer[2944], font1_ascii, font1_offsets, 400, 75, 143, 1u, 200, 640, pal_addr);// MENU MODE UI: Show player selection options with highlighting
+      menu_render_scaled_text(mr, 15, &language_buffer[3008], font1_ascii, font1_offsets, 400, 93, 143, 1u, 200, 640, pal_addr);
       if (uiSelectedPlayerType)               // Highlight current selection
         byMenuColor1 = 0x8F;
       else
         byMenuColor1 = 0xAB;
-      scale_text(front_vga[15], &language_buffer[2112], font1_ascii, font1_offsets, 400, 135, byMenuColor1, 1u, 200, 640);
+      menu_render_scaled_text(mr, 15, &language_buffer[2112], font1_ascii, font1_offsets, 400, 135, byMenuColor1, 1u, 200, 640, pal_addr);
       if (uiSelectedPlayerType == 2)
         byMenuColor2 = 0xAB;
       else
         byMenuColor2 = 0x8F;
-      scale_text(front_vga[15], &language_buffer[2240], font1_ascii, font1_offsets, 400, 153, byMenuColor2, 1u, 200, 640);
+      menu_render_scaled_text(mr, 15, &language_buffer[2240], font1_ascii, font1_offsets, 400, 153, byMenuColor2, 1u, 200, 640, pal_addr);
       if (uiSelectedPlayerType == 1)
         byMenuColor3 = 0xAB;
       else
         byMenuColor3 = 0x8F;
-      scale_text(front_vga[15], &language_buffer[2176], font1_ascii, font1_offsets, 400, 171, byMenuColor3, 1u, 200, 640);
+      menu_render_scaled_text(mr, 15, &language_buffer[2176], font1_ascii, font1_offsets, 400, 171, byMenuColor3, 1u, 200, 640, pal_addr);
       if (uiSelectedPlayerType == 3)
         byMenuColor4 = 0xAB;
       else
         byMenuColor4 = 0x8F;
-      scale_text(front_vga[15], &language_buffer[2304], font1_ascii, font1_offsets, 400, 189, byMenuColor4, 1u, 200, 640);
+      menu_render_scaled_text(mr, 15, &language_buffer[2304], font1_ascii, font1_offsets, 400, 189, byMenuColor4, 1u, 200, 640, pal_addr);
       if (uiSelectedPlayerType == 4)
         byMenuColor5 = 0xAB;
       else
         byMenuColor5 = 0x8F;
-      scale_text(front_vga[15], &language_buffer[2368], font1_ascii, font1_offsets, 400, 207, byMenuColor5, 1u, 200, 640);
+      menu_render_scaled_text(mr, 15, &language_buffer[2368], font1_ascii, font1_offsets, 400, 207, byMenuColor5, 1u, 200, 640, pal_addr);
     }
     show_received_mesage();
-    copypic(scrbuf, screen);
-    if (!front_fade)                          // Handle screen fade-in effect
-    {
-      front_fade = -1;
-      fade_palette(32);
-      frames = 0;
-    }
+    menu_render_end_frame(mr);
+    }                                         // end RENDER FRAME (GPU)
     while (fatkbhit())                        // KEYBOARD INPUT PROCESSING: Handle navigation and selection
     {
       byInputKey = fatgetch();
@@ -5339,7 +5347,18 @@ void select_players()
   LABEL_169:
     player_type = uiSelectedPlayerType;
   }
-  fade_palette(0);
+  // GPU fade-out
+  {
+    MenuRenderer *mr = GetMenuRenderer();
+    menu_render_begin_fade(mr, 0, 32);
+    menu_render_fade_wait(mr, fade_redraw_bg, mr);
+    palette_brightness = 0;
+    for (int i = 0; i < 256; i++) {
+      pal_addr[i].byR = 0;
+      pal_addr[i].byB = 0;
+      pal_addr[i].byG = 0;
+    }
+  }
   front_fade = 0;
 }
 

--- a/PROJECTS/ROLLER/menu_render.c
+++ b/PROJECTS/ROLLER/menu_render.c
@@ -557,7 +557,7 @@ void menu_render_sprite(MenuRenderer *r, int slot, int blockIdx, int x, int y,
 //---------------------------------------------------------------------------
 
 void menu_render_text(MenuRenderer *r, int fontSlot, const char *text,
-                      const uint8 *mappingTable, int *charVOffsets,
+                      const char *mappingTable, int *charVOffsets,
                       int x, int y, uint8 colorReplace, int alignment,
                       const tColor *pal)
 {
@@ -602,7 +602,7 @@ void menu_render_text(MenuRenderer *r, int fontSlot, const char *text,
 
 void menu_render_scaled_text(MenuRenderer *r, int fontSlot, const char *text,
                              const char *mappingTable, int *charVOffsets,
-                             int x, int y, char colorReplace,
+                             int x, int y, uint8 colorReplace,
                              unsigned int alignment, int clipLeft, int clipRight,
                              const tColor *pal)
 {

--- a/PROJECTS/ROLLER/menu_render.c
+++ b/PROJECTS/ROLLER/menu_render.c
@@ -67,11 +67,6 @@ struct MenuRenderer {
     float fadeStep;
     int fadeActive;
 
-    // 3D preview
-    SDL_GPUTexture *previewTexture;
-    SDL_GPUTransferBuffer *previewTransferBuffer;
-    int previewWidth;
-    int previewHeight;
 };
 
 //---------------------------------------------------------------------------
@@ -369,24 +364,6 @@ MenuRenderer *menu_render_create(SDL_GPUDevice *device, SDL_Window *window)
     uint8 blackPixel[4] = {0, 0, 0, 255};
     r->blackTexture = UploadRGBA(device, blackPixel, 1, 1);
 
-    // Preview texture for car/track 3D renders
-    r->previewWidth = 280;
-    r->previewHeight = 200;
-    SDL_GPUTextureCreateInfo ptInfo = {0};
-    ptInfo.type = SDL_GPU_TEXTURETYPE_2D;
-    ptInfo.format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
-    ptInfo.width = r->previewWidth;
-    ptInfo.height = r->previewHeight;
-    ptInfo.layer_count_or_depth = 1;
-    ptInfo.num_levels = 1;
-    ptInfo.usage = SDL_GPU_TEXTUREUSAGE_SAMPLER;
-    r->previewTexture = SDL_CreateGPUTexture(device, &ptInfo);
-
-    SDL_GPUTransferBufferCreateInfo ptbInfo = {0};
-    ptbInfo.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
-    ptbInfo.size = r->previewWidth * r->previewHeight * 4;
-    r->previewTransferBuffer = SDL_CreateGPUTransferBuffer(device, &ptbInfo);
-
     return r;
 }
 
@@ -396,8 +373,6 @@ void menu_render_destroy(MenuRenderer *r)
     for (int i = 0; i < MAX_SLOTS; i++)
         menu_render_free_blocks(r, i);
     if (r->blackTexture) SDL_ReleaseGPUTexture(r->device, r->blackTexture);
-    if (r->previewTexture) SDL_ReleaseGPUTexture(r->device, r->previewTexture);
-    if (r->previewTransferBuffer) SDL_ReleaseGPUTransferBuffer(r->device, r->previewTransferBuffer);
     SDL_ReleaseGPUBuffer(r->device, r->vertexBuffer);
     SDL_ReleaseGPUTransferBuffer(r->device, r->vertexTransferBuffer);
     SDL_ReleaseGPUSampler(r->device, r->sampler);
@@ -679,37 +654,6 @@ void menu_render_scaled_text(MenuRenderer *r, int fontSlot, const char *text,
 
         curX += cw + scale;
     }
-}
-
-//---------------------------------------------------------------------------
-// 3D preview compositing
-//---------------------------------------------------------------------------
-
-void menu_render_preview(MenuRenderer *r, const uint8 *buf, int w, int h,
-                         int destX, int destY, const tColor *pal)
-{
-    if (!buf || !r->previewTexture) return;
-
-    // Convert indexed to RGBA and upload
-    uint8 *rgba = malloc(w * h * 4);
-    IndexedToRGBA(buf, pal, rgba, w * h);
-
-    void *mapped = SDL_MapGPUTransferBuffer(r->device, r->previewTransferBuffer, false);
-    memcpy(mapped, rgba, w * h * 4);
-    SDL_UnmapGPUTransferBuffer(r->device, r->previewTransferBuffer);
-    free(rgba);
-
-    // Upload via separate command buffer (can't mix copy+render on same cmd buf)
-    SDL_GPUCommandBuffer *cmd = SDL_AcquireGPUCommandBuffer(r->device);
-    SDL_GPUCopyPass *cp = SDL_BeginGPUCopyPass(cmd);
-    SDL_GPUTextureTransferInfo src = { .transfer_buffer = r->previewTransferBuffer };
-    SDL_GPUTextureRegion dst = { .texture = r->previewTexture, .w = w, .h = h, .d = 1 };
-    SDL_UploadToGPUTexture(cp, &src, &dst, false);
-    SDL_EndGPUCopyPass(cp);
-    SDL_SubmitGPUCommandBuffer(cmd);
-
-    EmitQuad(r, (float)destX, (float)destY, (float)w, (float)h, 0, 0, 1, 1);
-    RecordDraw(r, r->previewTexture, 1.0f, -1, NULL);
 }
 
 //---------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/menu_render.c
+++ b/PROJECTS/ROLLER/menu_render.c
@@ -66,6 +66,12 @@ struct MenuRenderer {
     float fadeAlpha;
     float fadeStep;
     int fadeActive;
+
+    // 3D preview
+    SDL_GPUTexture *previewTexture;
+    SDL_GPUTransferBuffer *previewTransferBuffer;
+    int previewWidth;
+    int previewHeight;
 };
 
 //---------------------------------------------------------------------------
@@ -363,6 +369,24 @@ MenuRenderer *menu_render_create(SDL_GPUDevice *device, SDL_Window *window)
     uint8 blackPixel[4] = {0, 0, 0, 255};
     r->blackTexture = UploadRGBA(device, blackPixel, 1, 1);
 
+    // Preview texture for car/track 3D renders
+    r->previewWidth = 280;
+    r->previewHeight = 200;
+    SDL_GPUTextureCreateInfo ptInfo = {0};
+    ptInfo.type = SDL_GPU_TEXTURETYPE_2D;
+    ptInfo.format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+    ptInfo.width = r->previewWidth;
+    ptInfo.height = r->previewHeight;
+    ptInfo.layer_count_or_depth = 1;
+    ptInfo.num_levels = 1;
+    ptInfo.usage = SDL_GPU_TEXTUREUSAGE_SAMPLER;
+    r->previewTexture = SDL_CreateGPUTexture(device, &ptInfo);
+
+    SDL_GPUTransferBufferCreateInfo ptbInfo = {0};
+    ptbInfo.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
+    ptbInfo.size = r->previewWidth * r->previewHeight * 4;
+    r->previewTransferBuffer = SDL_CreateGPUTransferBuffer(device, &ptbInfo);
+
     return r;
 }
 
@@ -372,6 +396,8 @@ void menu_render_destroy(MenuRenderer *r)
     for (int i = 0; i < MAX_SLOTS; i++)
         menu_render_free_blocks(r, i);
     if (r->blackTexture) SDL_ReleaseGPUTexture(r->device, r->blackTexture);
+    if (r->previewTexture) SDL_ReleaseGPUTexture(r->device, r->previewTexture);
+    if (r->previewTransferBuffer) SDL_ReleaseGPUTransferBuffer(r->device, r->previewTransferBuffer);
     SDL_ReleaseGPUBuffer(r->device, r->vertexBuffer);
     SDL_ReleaseGPUTransferBuffer(r->device, r->vertexTransferBuffer);
     SDL_ReleaseGPUSampler(r->device, r->sampler);
@@ -653,6 +679,37 @@ void menu_render_scaled_text(MenuRenderer *r, int fontSlot, const char *text,
 
         curX += cw + scale;
     }
+}
+
+//---------------------------------------------------------------------------
+// 3D preview compositing
+//---------------------------------------------------------------------------
+
+void menu_render_preview(MenuRenderer *r, const uint8 *buf, int w, int h,
+                         int destX, int destY, const tColor *pal)
+{
+    if (!buf || !r->previewTexture) return;
+
+    // Convert indexed to RGBA and upload
+    uint8 *rgba = malloc(w * h * 4);
+    IndexedToRGBA(buf, pal, rgba, w * h);
+
+    void *mapped = SDL_MapGPUTransferBuffer(r->device, r->previewTransferBuffer, false);
+    memcpy(mapped, rgba, w * h * 4);
+    SDL_UnmapGPUTransferBuffer(r->device, r->previewTransferBuffer);
+    free(rgba);
+
+    // Upload via separate command buffer (can't mix copy+render on same cmd buf)
+    SDL_GPUCommandBuffer *cmd = SDL_AcquireGPUCommandBuffer(r->device);
+    SDL_GPUCopyPass *cp = SDL_BeginGPUCopyPass(cmd);
+    SDL_GPUTextureTransferInfo src = { .transfer_buffer = r->previewTransferBuffer };
+    SDL_GPUTextureRegion dst = { .texture = r->previewTexture, .w = w, .h = h, .d = 1 };
+    SDL_UploadToGPUTexture(cp, &src, &dst, false);
+    SDL_EndGPUCopyPass(cp);
+    SDL_SubmitGPUCommandBuffer(cmd);
+
+    EmitQuad(r, (float)destX, (float)destY, (float)w, (float)h, 0, 0, 1, 1);
+    RecordDraw(r, r->previewTexture, 1.0f, -1, NULL);
 }
 
 //---------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/menu_render.h
+++ b/PROJECTS/ROLLER/menu_render.h
@@ -42,13 +42,13 @@ void menu_render_fade_wait(MenuRenderer *renderer,
 
 // Text rendering
 void menu_render_text(MenuRenderer *renderer, int fontSlot, const char *text,
-                      const uint8 *mappingTable, int *charVOffsets,
+                      const char *mappingTable, int *charVOffsets,
                       int x, int y, uint8 colorReplace, int alignment,
                       const tColor *palette);
 void menu_render_scaled_text(MenuRenderer *renderer, int fontSlot,
                              const char *text, const char *mappingTable,
                              int *charVOffsets, int x, int y,
-                             char colorReplace, unsigned int alignment,
+                             uint8 colorReplace, unsigned int alignment,
                              int clipLeft, int clipRight,
                              const tColor *palette);
 

--- a/PROJECTS/ROLLER/menu_render.h
+++ b/PROJECTS/ROLLER/menu_render.h
@@ -52,9 +52,4 @@ void menu_render_scaled_text(MenuRenderer *renderer, int fontSlot,
                              int clipLeft, int clipRight,
                              const tColor *palette);
 
-// 3D preview compositing
-void menu_render_preview(MenuRenderer *renderer, const uint8 *previewBuf,
-                         int width, int height, int destX, int destY,
-                         const tColor *palette);
-
 #endif


### PR DESCRIPTION
## Summary
- Convert car selection, load/save, track selection, configure, player selection, game type, and NetworkWait screens to GPU renderer
- Implement 3D preview compositing for car and track previews (later refactored in Phase 6)
- All menu screens now render through the GPU pipeline

## Plan
`docs/plans/2026-03-17-menu-gpu-rendering.md` — Phase 5

## Stack
- Phase 1 (merged): GPU bootstrap
- Phase 2: Renderer skeleton + shaders
- Phase 3: Main menu integration + fades
- Phase 4: Text rendering
- **Phase 5** (this PR): Remaining menu screens
- Phase 6: 3D preview meshes
- Phase 7: GPU/software mode switching