### PR TITLE
fix linux compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,20 @@ endif()
 find_package(SDL3 REQUIRED)
 find_package(SDL3_image REQUIRED)
 find_package(WildMidi REQUIRED)
-find_package(libcdio REQUIRED)
+
+if(UNIX AND NOT APPLE)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(LIBCDIO REQUIRED libcdio libiso9660)
+    if(NOT TARGET libcdio::cdio)
+        add_library(libcdio::cdio INTERFACE IMPORTED)
+        set_target_properties(libcdio::cdio PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${LIBCDIO_INCLUDE_DIRS}"
+            INTERFACE_LINK_LIBRARIES "${LIBCDIO_LIBRARIES}"
+        )
+    endif()
+else()
+    find_package(libcdio REQUIRED)
+endif()
 
 if(WIN32)
     set(PLATFORM_SOURCES ROLLER.rc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,7 @@ if(UNIX AND NOT APPLE)
         add_library(libcdio::cdio INTERFACE IMPORTED)
         set_target_properties(libcdio::cdio PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${LIBCDIO_INCLUDE_DIRS}"
-            INTERFACE_LINK_LIBRARIES "${LIBCDIO_LIBRARIES}"
-        )
+            INTERFACE_LINK_LIBRARIES "${LIBCDIO_LIBRARIES}")
     endif()
 else()
     find_package(libcdio REQUIRED)


### PR DESCRIPTION
On linux, cmake wouldn't find libcdio without this change

```
CMake Error at CMakeLists.txt:17 (find_package):
  By not providing "Findlibcdio.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "libcdio", but
  CMake did not find one.

  Could not find a package configuration file provided by "libcdio" with any
  of the following names:

    libcdio.cps
    libcdioConfig.cmake
    libcdio-config.cmake

  Add the installation prefix of "libcdio" to CMAKE_PREFIX_PATH or set
  "libcdio_DIR" to a directory containing one of the above files.  If
  "libcdio" provides a separate development package or SDK, be sure it has
  been installed.
```