### PR TITLE
feat(#118): introduce GameRenderCamera struct, move calculateview to game loop

### DIFF
--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -1080,8 +1080,8 @@ void draw_road(uint8 *pScrPtr, int iCarIdx, unsigned int uiViewMode, int iCopyIm
           .viewX = viewx,
           .viewY = viewy,
           .viewZ = viewz,
-          .cosYaw = cosf((float)worlddirn * 3.1415926535f / 8192.0f),
-          .sinYaw = sinf((float)worlddirn * 3.1415926535f / 8192.0f),
+          .cosYaw = SDL_cosf(ANGLE_TO_RADIANS(worlddirn)),
+          .sinYaw = SDL_sinf(ANGLE_TO_RADIANS(worlddirn)),
           .fovScale = (float)VIEWDIST,
       };
       game_render_set_camera(g_pGameRenderer, &cam);

--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -172,6 +172,8 @@ float ext_z;                //0013F9A0
 float viewx;                //0013F9A4
 float viewy;                //0013F9A8
 float viewz;                //0013F9AC
+float fcos;
+float fsin;
 int worlddirn;              //0013F9B0
 char keys[140];             //0013F9B4
 int oldmode;                //0013FA40
@@ -1070,7 +1072,20 @@ void draw_road(uint8 *pScrPtr, int iCarIdx, unsigned int uiViewMode, int iCopyIm
     subscale = (float)dTextureSubscaleMultiplier;
   }
   screen_pointer = pScrPtr;                     // Set global screen buffer pointer for rendering functions
-  game_render_set_camera(g_pGameRenderer, uiViewMode, iCarIdx, iChaseCamIdx);// Calculate camera view matrix and projection parameters
+  calculateview(uiViewMode, iCarIdx, iChaseCamIdx); // Calculate camera view matrix and projection parameters
+  {
+      extern float viewx, viewy, viewz;
+      extern int worlddirn, VIEWDIST;
+      GameRenderCamera cam = {
+          .viewX = viewx,
+          .viewY = viewy,
+          .viewZ = viewz,
+          .cosYaw = cosf((float)worlddirn * 3.1415926535f / 8192.0f),
+          .sinYaw = sinf((float)worlddirn * 3.1415926535f / 8192.0f),
+          .fovScale = (float)VIEWDIST,
+      };
+      game_render_set_camera(g_pGameRenderer, &cam);
+  }
   game_render_draw_horizon(g_pGameRenderer);    // Draw sky/horizon background
   CalcVisibleTrack(iCarIdx, uiViewMode);        // Calculate which track segments are visible from current viewpoint
   DrawCars(iCarIdx, uiViewMode);                // Render all visible cars (excluding current player if in chase cam)

--- a/PROJECTS/ROLLER/3d.h
+++ b/PROJECTS/ROLLER/3d.h
@@ -324,6 +324,8 @@ extern float ext_z;
 extern float viewx;
 extern float viewy;
 extern float viewz;
+extern float fcos;
+extern float fsin;
 extern int worlddirn;
 extern char keys[140];
 extern int oldmode;

--- a/PROJECTS/ROLLER/game_render.c
+++ b/PROJECTS/ROLLER/game_render.c
@@ -57,9 +57,9 @@ void game_render_set_viewport(GameRenderer *renderer,
 // Camera
 
 void game_render_set_camera(GameRenderer *renderer,
-                            int viewMode, int carIdx, int chaseCamIdx) {
+                            const GameRenderCamera *camera) {
     if (renderer->mode == GAME_RENDER_SOFTWARE)
-        game_render_sw_set_camera(renderer->sw, viewMode, carIdx, chaseCamIdx);
+        game_render_sw_set_camera(renderer->sw, camera);
 }
 
 // Asset loading

--- a/PROJECTS/ROLLER/game_render.h
+++ b/PROJECTS/ROLLER/game_render.h
@@ -14,6 +14,12 @@ typedef enum {
 typedef int TextureHandle;
 #define TEXTURE_HANDLE_INVALID 0
 
+typedef struct {
+    float viewX, viewY, viewZ;
+    float cosYaw, sinYaw;
+    float fovScale;
+} GameRenderCamera;
+
 typedef struct GameRenderer GameRenderer;
 
 // Lifecycle
@@ -32,7 +38,7 @@ void game_render_set_viewport(GameRenderer *renderer,
 
 // Camera
 void game_render_set_camera(GameRenderer *renderer,
-                            int viewMode, int carIdx, int chaseCamIdx);
+                            const GameRenderCamera *camera);
 
 // Unified texture loading
 // tex_idx selects the texture bank (0=track, 17=building, 18=cargen,

--- a/PROJECTS/ROLLER/game_render_software.c
+++ b/PROJECTS/ROLLER/game_render_software.c
@@ -2,7 +2,6 @@
 #include "3d.h"
 #include "func2.h"
 #include "func3.h"
-#include "view.h"
 #include "horizon.h"
 #include "car.h"
 #include "polytex.h"
@@ -95,9 +94,17 @@ void game_render_sw_set_viewport(GameRendererSoftware *sw,
 // ---------------------------------------------------------------------------
 
 void game_render_sw_set_camera(GameRendererSoftware *sw,
-                               int viewMode, int carIdx, int chaseCamIdx) {
+                               const GameRenderCamera *camera) {
     (void)sw;
-    calculateview(viewMode, carIdx, chaseCamIdx);
+    extern float viewx, viewy, viewz;
+    extern float fcos, fsin;
+    extern int VIEWDIST;
+    viewx = camera->viewX;
+    viewy = camera->viewY;
+    viewz = camera->viewZ;
+    fcos = camera->cosYaw;
+    fsin = camera->sinYaw;
+    VIEWDIST = (int)camera->fovScale;
 }
 
 // ---------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/game_render_software.h
+++ b/PROJECTS/ROLLER/game_render_software.h
@@ -24,7 +24,7 @@ void game_render_sw_set_viewport(GameRendererSoftware *sw,
 
 // Camera
 void game_render_sw_set_camera(GameRendererSoftware *sw,
-                               int viewMode, int carIdx, int chaseCamIdx);
+                               const GameRenderCamera *camera);
 
 // Asset loading
 TextureHandle game_render_sw_load_texture(GameRendererSoftware *sw,

--- a/PROJECTS/ROLLER/types.h
+++ b/PROJECTS/ROLLER/types.h
@@ -18,6 +18,7 @@
 #define ONE_OVER_TRIG_LOOKUP_AY_COUNT 0.00006103515625
 #define ONE_OVER_TATN_LOOKUP_AY_COUNT 0.0009765625
 #define TWO_PI 6.28318530718
+#define ANGLE_TO_RADIANS(a) ((float)(a) * (float)TWO_PI / 16384.0f)
 #define HZ_TO_NS(x) ((x) > 0 ? (1000000000UL / (x)) : 0)
 #define TRIG_SCALE 25600.0f
 #define MAX_CARS 16


### PR DESCRIPTION
Closes #118.

## What changed

- **`game_render.h`** — Added `GameRenderCamera` struct with `{viewX, viewY, viewZ, cosYaw, sinYaw, fovScale}`; changed `game_render_set_camera` to accept `const GameRenderCamera*`
- **`game_render.c`** — Updated facade dispatch
- **`game_render_software.h/.c`** — Changed signature; replaced `calculateview()` call with struct unpacking into `viewx/y/z`, `fcos`, `fsin`, `VIEWDIST` globals
- **`3d.h`** — Declared `extern float fcos, fsin`
- **`3d.c`** — Defined `fcos`/`fsin` globals; moved `calculateview()` call before `set_camera`; extracts values into `GameRenderCamera` struct

## Verification

- [x] `zig build` passes clean
- [x] Single call site: `3d.c` calls `calculateview()` then `game_render_set_camera(&cam)`
- [x] Old `(viewMode, carIdx, chaseCamIdx)` signature fully removed
- [x] All view modes preserved (same `calculateview()` params flow)