### PR TITLE
feat(#119): introduce GameRenderVertex and game_render_quad_world tracer bullet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 ## Agent skills
 
+### Build
+
+Use `zig build` to compile the project. The `cmake`-based build is not configured in this workspace.
+
 ### Issue tracker
 
 Issues live as GitHub Issues on `FatalDecomp/ROLLER`, accessed via the `gh` CLI. See `docs/agents/issue-tracker.md`.

--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -1086,6 +1086,20 @@ void draw_road(uint8 *pScrPtr, int iCarIdx, unsigned int uiViewMode, int iCopyIm
       };
       game_render_set_camera(g_pGameRenderer, &cam);
   }
+  {
+      extern float vk1, vk2, vk3, vk4, vk5, vk6, vk7, vk8, vk9;
+      extern int scr_size, xbase, ybase, gfx_size;
+      GameRenderProjection proj = {
+          .view = {{vk1, vk2, vk3},
+                   {vk4, vk5, vk6},
+                   {vk7, vk8, vk9}},
+          .screenScale = scr_size,
+          .centerX = xbase,
+          .centerY = ybase,
+          .texHalfRes = gfx_size,
+      };
+      game_render_set_projection(g_pGameRenderer, &proj);
+  }
   game_render_draw_horizon(g_pGameRenderer);    // Draw sky/horizon background
   CalcVisibleTrack(iCarIdx, uiViewMode);        // Calculate which track segments are visible from current viewpoint
   DrawCars(iCarIdx, uiViewMode);                // Render all visible cars (excluding current player if in chase cam)

--- a/PROJECTS/ROLLER/building.c
+++ b/PROJECTS/ROLLER/building.c
@@ -484,14 +484,14 @@ void DrawBuilding(int iBuildingIdx, uint8 *pScrPtr)
   float fMatrix21; // [esp+1B4h] [ebp-24h]
   uint8 byNumPols; // [esp+1BCh] [ebp-1Ch]
   uint8 byNumCoords; // [esp+1C0h] [ebp-18h]
+  tVec3 worldCoords[32];
+  float sortDepths[32];
 
   if (iBuildingIdx < 0)
     return; //added by ROLLER
 
   set_starts(0);                                // Initialize rendering system
   uiBuildingType = BuildingBase[iBuildingIdx][0];// Get building plan data (polygons, coordinates, etc.)
-  pScreenPt = BuildingCoords;
-  pBuildingView = BuildingView;
   byNumPols = BuildingPlans[uiBuildingType].byNumPols;
   pPols = BuildingPlans[uiBuildingType].pPols;
   byNumCoords = BuildingPlans[uiBuildingType].byNumCoords;
@@ -519,7 +519,6 @@ void DrawBuilding(int iBuildingIdx, uint8 *pScrPtr)
   dCosRoll = cos(fRollRad);
   fBuildingY = BuildingY[iBuildingIdx];
   for (i = 0; byNumCoords > i; ++i) {
-    iClipped = 0;
     p_fY = &pCoords->fY;
     p_fZ = &pCoords->fZ;
     // CHEAT_MODE_DOUBLE_TRACK
@@ -538,46 +537,26 @@ void DrawBuilding(int iBuildingIdx, uint8 *pScrPtr)
     fMatrix01 = (float)(dCosYaw * dSinPitch * dSinRoll - dSinYaw * dCosRoll);// Build 3x3 rotation matrix elements from yaw/pitch/roll
     fMatrix00 = (float)(dCosYaw * dCosPitch);
     fMatrix02 = (float)(-dCosYaw * dSinPitch * dCosRoll - dSinYaw * dSinRoll);
-    dTransformedX = fX * fMatrix00 + fCoordY * fMatrix01 + v109 * fMatrix02 + fBuildingX - viewx;// Apply 3D rotation and translation to building coordinates
+    dTransformedX = fX * fMatrix00 + fCoordY * fMatrix01 + v109 * fMatrix02 + fBuildingX;// Apply 3D rotation and translation to building coordinates
     dTransformedX = floor(dTransformedX);//_CHP();
     dTempX = dTransformedX;
     fMatrix10 = (float)(dSinYaw * dCosPitch);
     fMatrix12 = (float)(-dSinYaw * dSinPitch * dCosRoll + dCosYaw * dSinRoll);
     fMatrix11 = (float)(dSinYaw * dSinPitch * dSinRoll + dCosYaw * dCosRoll);
-    dTransformedY = fX * fMatrix10 + fCoordY * fMatrix11 + v109 * fMatrix12 + fBuildingY - viewy;
+    dTransformedY = fX * fMatrix10 + fCoordY * fMatrix11 + v109 * fMatrix12 + fBuildingY;
     dTransformedY = floor(dTransformedY);//_CHP();
     dTempY = dTransformedY;
     fVert2X = (float)(dCosPitch * dCosRoll);
     fMatrix20 = (float)dSinPitch;
     fMatrix21 = (float)(-dSinRoll * dCosPitch);
-    dTransformedZ = fX * fMatrix20 + fCoordY * fMatrix21 + v109 * fVert2X + fBuildingZ - viewz;
+    dTransformedZ = fX * fMatrix20 + fCoordY * fMatrix21 + v109 * fVert2X + fBuildingZ;
     dTransformedZ = floor(dTransformedZ);//_CHP();
-    dViewX = dTempX * vk1 + dTempY * vk4 + dTransformedZ * vk7;// Transform world coordinates to view space
-    //_CHP();
-    iViewX = (int)dViewX;
-    dViewY = dTempX * vk2 + dTempY * vk5 + dTransformedZ * vk8;
-    //_CHP();
-    iViewY = (int)dViewY;
-    dViewZ = dTempX * vk3 + dTempY * vk6 + dTransformedZ * vk9;
-    //_CHP();
-    iViewZ = (int)dViewZ;
-    if ((int)dViewZ < 80)                     // Clip Z coordinate to prevent division by zero
-    {
-      iClipped = 1;
-      iViewZ = 80;
-    }
-    xp = iViewX * VIEWDIST / iViewZ + xbase;    // Project 3D coordinates to 2D screen coordinates
-    yp = iViewY * VIEWDIST / iViewZ + ybase;
-    iScreenY = iViewY * VIEWDIST / iViewZ + ybase;
-    pScreenPt->iX = (scr_size * (iViewX * VIEWDIST / iViewZ + xbase)) >> 6;
-    pScreenPt->iY = (scr_size * (199 - iScreenY)) >> 6;
-    pBuildingView->fX = (float)iViewX;
-    pBuildingView->fY = (float)iViewY;
-    pBuildingView->fZ = (float)(int)dViewZ;
-    p_iUnk3 = &pScreenPt->iClipped;
-    *p_iUnk3 = iClipped;
-    ++pBuildingView;
-    pScreenPt = (tBuildingCoord *)(p_iUnk3 + 1);
+    // Store world-space position for game_render_quad_world
+    worldCoords[i].fX = (float)dTempX;
+    worldCoords[i].fY = (float)dTempY;
+    worldCoords[i].fZ = (float)dTransformedZ;
+    // Compute view-space Z for polygon sorting (dot with camera forward)
+    sortDepths[i] = (float)((dTempX - viewx) * vk3 + (dTempY - viewy) * vk6 + (dTransformedZ - viewz) * vk9);
   }
   iPolygonLoop = 0;
   iZOrderIdx = 0;
@@ -586,44 +565,44 @@ void DrawBuilding(int iBuildingIdx, uint8 *pScrPtr)
     BuildingZOrder[iZOrderIdx].iPolygonLink = pPols->nNextPolIdx;
     if ((pPols->uiTex & 0x8000) == 0)         // Calculate polygon Z depth for sorting (front-to-back vs back-to-front)
     {                                           // Find maximum Z (farthest) for back-to-front rendering order
-      if (BuildingView[pPols->verts[2]].fZ <= (double)BuildingView[pPols->verts[3]].fZ)
-        fZ = BuildingView[pPols->verts[3]].fZ;
+      if (sortDepths[pPols->verts[2]] <= (double)sortDepths[pPols->verts[3]])
+        fZ = sortDepths[pPols->verts[3]];
       else
-        fZ = BuildingView[pPols->verts[2]].fZ;
+        fZ = sortDepths[pPols->verts[2]];
       fTempZ2 = fZ;
-      if (BuildingView[pPols->verts[0]].fZ <= (double)BuildingView[pPols->verts[1]].fZ)
-        fMaxZ = BuildingView[pPols->verts[1]].fZ;
+      if (sortDepths[pPols->verts[0]] <= (double)sortDepths[pPols->verts[1]])
+        fMaxZ = sortDepths[pPols->verts[1]];
       else
-        fMaxZ = BuildingView[pPols->verts[0]].fZ;
+        fMaxZ = sortDepths[pPols->verts[0]];
       if (fMaxZ <= (double)fTempZ2) {
-        if (BuildingView[pPols->verts[2]].fZ <= (double)BuildingView[pPols->verts[3]].fZ)
-          fPolygonZ = BuildingView[pPols->verts[3]].fZ;
+        if (sortDepths[pPols->verts[2]] <= (double)sortDepths[pPols->verts[3]])
+          fPolygonZ = sortDepths[pPols->verts[3]];
         else
-          fPolygonZ = BuildingView[pPols->verts[2]].fZ;
-      } else if (BuildingView[pPols->verts[0]].fZ <= (double)BuildingView[pPols->verts[1]].fZ) {
-        fPolygonZ = BuildingView[pPols->verts[1]].fZ;
+          fPolygonZ = sortDepths[pPols->verts[2]];
+      } else if (sortDepths[pPols->verts[0]] <= (double)sortDepths[pPols->verts[1]]) {
+        fPolygonZ = sortDepths[pPols->verts[1]];
       } else {
-        fPolygonZ = BuildingView[pPols->verts[0]].fZ;
+        fPolygonZ = sortDepths[pPols->verts[0]];
       }
     } else {                                           // Find minimum Z (closest) for front-to-back rendering order
-      if (BuildingView[pPols->verts[2]].fZ >= (double)BuildingView[pPols->verts[3]].fZ)
-        fMinZ1 = BuildingView[pPols->verts[3]].fZ;
+      if (sortDepths[pPols->verts[2]] >= (double)sortDepths[pPols->verts[3]])
+        fMinZ1 = sortDepths[pPols->verts[3]];
       else
-        fMinZ1 = BuildingView[pPols->verts[2]].fZ;
+        fMinZ1 = sortDepths[pPols->verts[2]];
       fTempZ = fMinZ1;
-      if (BuildingView[pPols->verts[0]].fZ >= (double)BuildingView[pPols->verts[1]].fZ)
-        fMinZ2 = BuildingView[pPols->verts[1]].fZ;
+      if (sortDepths[pPols->verts[0]] >= (double)sortDepths[pPols->verts[1]])
+        fMinZ2 = sortDepths[pPols->verts[1]];
       else
-        fMinZ2 = BuildingView[pPols->verts[0]].fZ;
+        fMinZ2 = sortDepths[pPols->verts[0]];
       if (fMinZ2 >= (double)fTempZ) {
-        if (BuildingView[pPols->verts[2]].fZ >= (double)BuildingView[pPols->verts[3]].fZ)
-          fPolygonZ = BuildingView[pPols->verts[3]].fZ;
+        if (sortDepths[pPols->verts[2]] >= (double)sortDepths[pPols->verts[3]])
+          fPolygonZ = sortDepths[pPols->verts[3]];
         else
-          fPolygonZ = BuildingView[pPols->verts[2]].fZ;
-      } else if (BuildingView[pPols->verts[0]].fZ >= (double)BuildingView[pPols->verts[1]].fZ) {
-        fPolygonZ = BuildingView[pPols->verts[1]].fZ;
+          fPolygonZ = sortDepths[pPols->verts[2]];
+      } else if (sortDepths[pPols->verts[0]] >= (double)sortDepths[pPols->verts[1]]) {
+        fPolygonZ = sortDepths[pPols->verts[1]];
       } else {
-        fPolygonZ = BuildingView[pPols->verts[0]].fZ;
+        fPolygonZ = sortDepths[pPols->verts[0]];
       }
     }
     BuildingZOrder[iZOrderIdx].fZDepth = fPolygonZ;
@@ -659,114 +638,29 @@ void DrawBuilding(int iBuildingIdx, uint8 *pScrPtr)
         BuildingZOrder[iCurrentZOrderIdx].iPolygonLink = -1;
         pPolygon = &BuildingPlans[uiBuildingType].pPols[iPolygonIndex];
         uiTex = pPolygon->uiTex;
-        iVert2 = pPolygon->verts[2];
-        v75 = BuildingView[iVert2].fX;
-        fY = BuildingView[iVert2].fY;
-        fVert2Z = BuildingView[iVert2].fZ;
-        iVert1 = pPolygon->verts[1];
-        fVert2Y = fY;
-        fVert1X = BuildingView[iVert1].fX;
-        fYCoord1 = BuildingView[iVert1].fY;
-        fVert1Z = BuildingView[iVert1].fZ;
-        iVert0 = pPolygon->verts[0];
-        fCoordZ = BuildingView[iVert0].fX;
-        fDeltaX2 = v75 - fCoordZ;
-        fVert0Y = BuildingView[iVert0].fY;
-        fDeltaY1 = fVert2Y - fVert0Y;
-        fVert0Z = BuildingView[iVert0].fZ;
-        iVert3 = pPolygon->verts[3];
-        fDeltaZ1 = fVert2Z - fVert0Z;
-        fVert1Y = fVert1X - BuildingView[iVert3].fX;
-        fDeltaY2 = fYCoord1 - BuildingView[iVert3].fY;
-        fDeltaZ2 = fVert1Z - BuildingView[iVert3].fZ;
-        fNormalDot = (fDeltaY1 * fDeltaZ2 - fDeltaZ1 * fDeltaY2) * fCoordZ
-          + (fDeltaZ1 * fVert1Y - fDeltaX2 * fDeltaZ2) * fVert0Y
-          + (fDeltaX2 * fDeltaY2 - fDeltaY1 * fVert1Y) * fVert0Z;// Calculate polygon normal dot product for backface culling
-        if (fNormalDot < 0.0 || (uiTex & 0x2000) != 0)// Render polygon if visible (negative normal = back-facing, or special flag)
+        // Handle special textures (advertisements, building remapping)
+        if ((uiTex & 0x200) != 0)
+          uiTex = advert_list[iBuildingIdx];
+        if ((textures_off & 0x80) != 0 && (uiTex & 0x100) != 0)
+          uiTex = (uiTex & 0xFFFFFE00) + bld_remap[(uint8)uiTex];
+        // Build world-space vertex array and dispatch via game_render_quad_world
         {
-          pEndVerts = (uint8 *)&pPolygon->uiTex;
-          iProjectedSum = 0;
-          if (fNormalDot < 0.0)               // Copy vertices in reverse order for back-facing polygons
-          {
-            pVertices = BuildingPol.vertices;   // Copy vertices in forward order for front-facing polygons
-            pVerts = (uint8 *)pPolygon;
-            do {
-              pScreenCoord = &BuildingCoords[*pVerts];
-              p_y = &pVertices->y;
-              *(p_y - 1) = pScreenCoord->iX;
-              ++pVerts;
-              *p_y = pScreenCoord->iY;
-              pVertices = (tPoint *)(p_y + 1);
-              iProjectedSum += pScreenCoord->iClipped;
-            } while (pVerts != pEndVerts);
-          } else {
-            pVerticesRev = &BuildingPol.vertices[3];
-            pVerts_1 = (uint8 *)pPolygon;
-            do {
-              pScreenCoordRev = &BuildingCoords[*pVerts_1];
-              pVerticesRev->x = pScreenCoordRev->iX;
-              --pVerticesRev;
-              pVerticesRev[1].y = pScreenCoordRev->iY;
-              ++pVerts_1;
-              iProjectedSum += pScreenCoordRev->iClipped;
-            } while (pVerts_1 != pEndVerts);
+          GameRenderVertex verts[4];
+          int vi;
+          for (vi = 0; vi < 4; vi++) {
+            tVec3 *wc = &worldCoords[pPolygon->verts[vi]];
+            verts[vi].x = wc->fX;
+            verts[vi].y = wc->fY;
+            verts[vi].z = wc->fZ;
+            verts[vi].u = 0.0f;
+            verts[vi].v = 0.0f;
           }
-          if ((uiTex & 0x200) != 0)           // Handle special textures (advertisements, building remapping)
-            uiTex = advert_list[iBuildingIdx];
-          if ((textures_off & 0x80) != 0 && (uiTex & 0x100) != 0)
-            uiTex = (uiTex & 0xFFFFFE00) + bld_remap[(uint8)uiTex];
-          BuildingPol.iSurfaceType = uiTex;
-          BuildingPol.uiNumVerts = 4;
-          if (iProjectedSum < 4) {
-            iFinalVert0 = pPolygon->verts[0];
-            iFinalVert1 = pPolygon->verts[1];
-            iFinalVert2 = pPolygon->verts[2];
-            iFinalVert3 = pPolygon->verts[3];
-            if (BuildingView[iFinalVert0].fZ >= (double)BuildingView[iFinalVert1].fZ)
-              fClosestZ1 = BuildingView[iFinalVert1].fZ;
-            else
-              fClosestZ1 = BuildingView[iFinalVert0].fZ;
-            fTempClosestZ = fClosestZ1;
-            if (BuildingView[iFinalVert2].fZ >= (double)BuildingView[iFinalVert3].fZ)
-              fClosestZ2 = BuildingView[iFinalVert3].fZ;
-            else
-              fClosestZ2 = BuildingView[iFinalVert2].fZ;
-            if (fTempClosestZ >= (double)fClosestZ2) {
-              if (BuildingView[iFinalVert2].fZ >= (double)BuildingView[iFinalVert3].fZ)
-                fClosestZ = BuildingView[iFinalVert3].fZ;
-              else
-                fClosestZ = BuildingView[iFinalVert2].fZ;
-            } else if (BuildingView[iFinalVert0].fZ >= (double)BuildingView[iFinalVert1].fZ) {
-              fClosestZ = BuildingView[iFinalVert1].fZ;
-            } else {
-              fClosestZ = BuildingView[iFinalVert0].fZ;
-            }
-            if ((double)BuildingSub[uiBuildingType] * subscale <= fClosestZ)// Check if polygon needs subdivision based on distance
-            {                                   // Render textured or flat polygon
-              if ((BuildingPol.iSurfaceType & 0x100) != 0)
-                game_render_quad(g_pGameRenderer, &BuildingPol, game_render_get_texture_handle(g_pGameRenderer, 17), NULL);
-              else
-                game_render_quad(g_pGameRenderer, &BuildingPol, TEXTURE_HANDLE_INVALID, NULL);
-            } else {
-              subdivide(
-                pScrPtr,
-                &BuildingPol,
-                BuildingView[iFinalVert0].fX,
-                BuildingView[iFinalVert0].fY,
-                BuildingView[iFinalVert0].fZ,
-                BuildingView[iFinalVert1].fX,
-                BuildingView[iFinalVert1].fY,
-                BuildingView[iFinalVert1].fZ,
-                BuildingView[iFinalVert2].fX,
-                BuildingView[iFinalVert2].fY,
-                BuildingView[iFinalVert2].fZ,
-                BuildingView[iFinalVert3].fX,
-                BuildingView[iFinalVert3].fY,
-                BuildingView[iFinalVert3].fZ,
-                666,
-                gfx_size);                      // Subdivide polygon for better quality when close to camera
-            }
-          }
+          TextureHandle th;
+          if ((uiTex & 0x100) != 0)
+            th = game_render_get_texture_handle(g_pGameRenderer, 17);
+          else
+            th = TEXTURE_HANDLE_INVALID;
+          game_render_quad_world(g_pGameRenderer, verts, th, (int)uiTex);
         }
         iZOrderOffset = iCurrentZOrderIdx * 12 + 12;
         ++iCurrentZOrderIdx;

--- a/PROJECTS/ROLLER/game_render.c
+++ b/PROJECTS/ROLLER/game_render.c
@@ -62,6 +62,14 @@ void game_render_set_camera(GameRenderer *renderer,
         game_render_sw_set_camera(renderer->sw, camera);
 }
 
+// Projection
+
+void game_render_set_projection(GameRenderer *renderer,
+                                const GameRenderProjection *proj) {
+    if (renderer->mode == GAME_RENDER_SOFTWARE)
+        game_render_sw_set_projection(renderer->sw, proj);
+}
+
 // Asset loading
 
 TextureHandle game_render_load_texture(GameRenderer *renderer,

--- a/PROJECTS/ROLLER/game_render.c
+++ b/PROJECTS/ROLLER/game_render.c
@@ -101,6 +101,14 @@ void game_render_quad(GameRenderer *renderer, tPolyParams *poly,
         game_render_sw_quad(renderer->sw, poly, handle, palette_remap);
 }
 
+void game_render_quad_world(GameRenderer *renderer,
+                            const GameRenderVertex *verts,
+                            TextureHandle handle,
+                            int surfaceFlags) {
+    if (renderer->mode == GAME_RENDER_SOFTWARE)
+        game_render_sw_quad_world(renderer->sw, verts, handle, surfaceFlags);
+}
+
 void game_render_draw_car(GameRenderer *renderer, int carIdx,
                           int yaw, int pitch, int roll,
                           float worldX, float worldY, float worldZ,

--- a/PROJECTS/ROLLER/game_render.h
+++ b/PROJECTS/ROLLER/game_render.h
@@ -15,6 +15,11 @@ typedef int TextureHandle;
 #define TEXTURE_HANDLE_INVALID 0
 
 typedef struct {
+    float x, y, z;  // world-space position
+    float u, v;     // texture coordinates
+} GameRenderVertex;
+
+typedef struct {
     float viewX, viewY, viewZ;
     float cosYaw, sinYaw;
     float fovScale;
@@ -66,6 +71,14 @@ void game_render_quad(GameRenderer *renderer,
                       tPolyParams *poly,
                       TextureHandle handle,
                       const uint8 *palette_remap);
+
+// Draw — world-space quad (GPU-ready interface)
+// verts must point to exactly 4 GameRenderVertex entries.
+// surfaceFlags carries the same bitfield as tPolyParams.iSurfaceType.
+void game_render_quad_world(GameRenderer *renderer,
+                            const GameRenderVertex *verts,
+                            TextureHandle handle,
+                            int surfaceFlags);
 
 // Draw — car mesh
 void game_render_draw_car(GameRenderer *renderer, int carIdx,

--- a/PROJECTS/ROLLER/game_render.h
+++ b/PROJECTS/ROLLER/game_render.h
@@ -25,6 +25,16 @@ typedef struct {
     float fovScale;
 } GameRenderCamera;
 
+// Column-major 3×3 view matrix + screen-space projection state.
+// view[col][row] maps to GLSL mat3 for direct GPU upload.
+typedef struct {
+    float view[3][3];
+    int   screenScale;   // 6-bit fixed-point scale (was scr_size)
+    int   centerX;       // projection origin X (was xbase)
+    int   centerY;       // projection origin Y (was ybase)
+    int   texHalfRes;    // 0=64×64, 1=32×32 (was gfx_size)
+} GameRenderProjection;
+
 typedef struct GameRenderer GameRenderer;
 
 // Lifecycle
@@ -44,6 +54,10 @@ void game_render_set_viewport(GameRenderer *renderer,
 // Camera
 void game_render_set_camera(GameRenderer *renderer,
                             const GameRenderCamera *camera);
+
+// Projection
+void game_render_set_projection(GameRenderer *renderer,
+                                const GameRenderProjection *proj);
 
 // Unified texture loading
 // tex_idx selects the texture bank (0=track, 17=building, 18=cargen,

--- a/PROJECTS/ROLLER/game_render_software.c
+++ b/PROJECTS/ROLLER/game_render_software.c
@@ -30,6 +30,9 @@ typedef struct {
 
 struct GameRendererSoftware {
     GameRenderCamera camera;
+    GameRenderProjection proj;
+    int screenWidth;
+    int screenHeight;
     int fadeInPending;
     tBlockHeader *blocks[GAME_RENDER_MAX_BLOCK_SLOTS];
     TextureHandle blockHandles[GAME_RENDER_MAX_BLOCK_SLOTS];
@@ -85,12 +88,11 @@ void game_render_sw_end_frame(GameRendererSoftware *sw) {
 
 void game_render_sw_set_viewport(GameRendererSoftware *sw,
                                  int x, int y, int w, int h) {
-    (void)sw;
-    (void)w;
-    (void)h;
+    sw->screenWidth = w;
+    sw->screenHeight = h;
     // Set screen_pointer to the viewport origin within scrbuf.
     // Existing rendering code writes relative to screen_pointer.
-    screen_pointer = scrbuf + (y * winw) + x;
+    screen_pointer = scrbuf + (y * sw->screenWidth) + x;
 }
 
 // ---------------------------------------------------------------------------
@@ -109,6 +111,21 @@ void game_render_sw_set_camera(GameRendererSoftware *sw,
     fcos = camera->cosYaw;
     fsin = camera->sinYaw;
     VIEWDIST = (int)camera->fovScale;
+}
+
+void game_render_sw_set_projection(GameRendererSoftware *sw,
+                                   const GameRenderProjection *proj) {
+    extern float vk1, vk2, vk3, vk4, vk5, vk6, vk7, vk8, vk9;
+    extern int scr_size, xbase, ybase, gfx_size;
+    sw->proj = *proj;
+    // Write through to globals for legacy code (subdivide, POLYTEX, etc.)
+    vk1 = proj->view[0][0]; vk2 = proj->view[0][1]; vk3 = proj->view[0][2];
+    vk4 = proj->view[1][0]; vk5 = proj->view[1][1]; vk6 = proj->view[1][2];
+    vk7 = proj->view[2][0]; vk8 = proj->view[2][1]; vk9 = proj->view[2][2];
+    scr_size = proj->screenScale;
+    xbase = proj->centerX;
+    ybase = proj->centerY;
+    gfx_size = proj->texHalfRes;
 }
 
 // ---------------------------------------------------------------------------
@@ -207,22 +224,20 @@ void game_render_sw_quad_world(GameRendererSoftware *sw,
                                int surfaceFlags) {
     (void)handle; // subdivide handles texture lookup internally via subpolytype
 
-    extern float vk1, vk2, vk3, vk4, vk5, vk6, vk7, vk8, vk9;
-    extern int scr_size, xbase, ybase, gfx_size;
-
     const GameRenderCamera *cam = &sw->camera;
+    const GameRenderProjection *proj = &sw->proj;
     float vx[4], vy[4], vz[4];
     int clippedCount = 0;
 
-    // World → view space transform using vk matrix
+    // World → view space transform using view matrix
     for (int i = 0; i < 4; i++) {
         float dx = verts[i].x - cam->viewX;
         float dy = verts[i].y - cam->viewY;
         float dz = verts[i].z - cam->viewZ;
 
-        vx[i] = dx * vk1 + dy * vk4 + dz * vk7;
-        vy[i] = dx * vk2 + dy * vk5 + dz * vk8;
-        vz[i] = dx * vk3 + dy * vk6 + dz * vk9;
+        vx[i] = dx * proj->view[0][0] + dy * proj->view[1][0] + dz * proj->view[2][0];
+        vy[i] = dx * proj->view[0][1] + dy * proj->view[1][1] + dz * proj->view[2][1];
+        vz[i] = dx * proj->view[0][2] + dy * proj->view[1][2] + dz * proj->view[2][2];
     }
 
     // Populate tPolyParams with screen-space vertices
@@ -237,11 +252,11 @@ void game_render_sw_quad_world(GameRendererSoftware *sw,
             clippedCount++;
         }
 
-        int sx = (int)(vx[i] * (int)cam->fovScale / z + xbase);
-        int sy = (int)(vy[i] * (int)cam->fovScale / z + ybase);
+        int sx = (int)(vx[i] * (int)cam->fovScale / z + proj->centerX);
+        int sy = (int)(vy[i] * (int)cam->fovScale / z + proj->centerY);
 
-        poly.vertices[i].x = (scr_size * sx) >> 6;
-        poly.vertices[i].y = (scr_size * (199 - sy)) >> 6;
+        poly.vertices[i].x = (proj->screenScale * sx) >> 6;
+        poly.vertices[i].y = (proj->screenScale * (199 - sy)) >> 6;
     }
 
     // Skip fully-clipped polygons
@@ -254,22 +269,21 @@ void game_render_sw_quad_world(GameRendererSoftware *sw,
               vx[1], vy[1], vz[1],
               vx[2], vy[2], vz[2],
               vx[3], vy[3], vz[3],
-              666, gfx_size);
+              666, proj->texHalfRes);
 }
 
 void game_render_sw_draw_car(GameRendererSoftware *sw, int carIdx,
                              int yaw, int pitch, int roll,
                              float worldX, float worldY, float worldZ,
                              int animFrame, const uint8 *color_remap) {
-    (void)sw;
     (void)yaw; (void)pitch; (void)roll;
     (void)animFrame; (void)color_remap;
     // Compute distance from camera to car for LOD.
     // DisplayCar reads car state from global Car[] array.
-    extern float viewx, viewy, viewz;
-    float dx = worldX - viewx;
-    float dy = worldY - viewy;
-    float dz = worldZ - viewz;
+    const GameRenderCamera *cam = &sw->camera;
+    float dx = worldX - cam->viewX;
+    float dy = worldY - cam->viewY;
+    float dz = worldZ - cam->viewZ;
     float dist = sqrtf(dx * dx + dy * dy + dz * dz);
     DisplayCar(carIdx, screen_pointer, dist);
 }

--- a/PROJECTS/ROLLER/game_render_software.c
+++ b/PROJECTS/ROLLER/game_render_software.c
@@ -1,5 +1,8 @@
 #include "game_render_software.h"
 #include "3d.h"
+#include "drawtrk3.h"
+#include "transfrm.h"
+#include "graphics.h"
 #include "func2.h"
 #include "func3.h"
 #include "horizon.h"
@@ -26,6 +29,7 @@ typedef struct {
 } TextureSlot;
 
 struct GameRendererSoftware {
+    GameRenderCamera camera;
     int fadeInPending;
     tBlockHeader *blocks[GAME_RENDER_MAX_BLOCK_SLOTS];
     TextureHandle blockHandles[GAME_RENDER_MAX_BLOCK_SLOTS];
@@ -95,10 +99,10 @@ void game_render_sw_set_viewport(GameRendererSoftware *sw,
 
 void game_render_sw_set_camera(GameRendererSoftware *sw,
                                const GameRenderCamera *camera) {
-    (void)sw;
     extern float viewx, viewy, viewz;
     extern float fcos, fsin;
     extern int VIEWDIST;
+    sw->camera = *camera;
     viewx = camera->viewX;
     viewy = camera->viewY;
     viewz = camera->viewZ;
@@ -195,6 +199,62 @@ void game_render_sw_quad(GameRendererSoftware *sw, tPolyParams *poly,
     } else {
         POLYFLAT(screen_pointer, poly);
     }
+}
+
+void game_render_sw_quad_world(GameRendererSoftware *sw,
+                               const GameRenderVertex *verts,
+                               TextureHandle handle,
+                               int surfaceFlags) {
+    (void)handle; // subdivide handles texture lookup internally via subpolytype
+
+    extern float vk1, vk2, vk3, vk4, vk5, vk6, vk7, vk8, vk9;
+    extern int scr_size, xbase, ybase, gfx_size;
+
+    const GameRenderCamera *cam = &sw->camera;
+    float vx[4], vy[4], vz[4];
+    int clippedCount = 0;
+
+    // World → view space transform using vk matrix
+    for (int i = 0; i < 4; i++) {
+        float dx = verts[i].x - cam->viewX;
+        float dy = verts[i].y - cam->viewY;
+        float dz = verts[i].z - cam->viewZ;
+
+        vx[i] = dx * vk1 + dy * vk4 + dz * vk7;
+        vy[i] = dx * vk2 + dy * vk5 + dz * vk8;
+        vz[i] = dx * vk3 + dy * vk6 + dz * vk9;
+    }
+
+    // Populate tPolyParams with screen-space vertices
+    tPolyParams poly;
+    poly.iSurfaceType = surfaceFlags;
+    poly.uiNumVerts = 4;
+
+    for (int i = 0; i < 4; i++) {
+        float z = vz[i];
+        if (z < 80.0f) {
+            z = 80.0f;
+            clippedCount++;
+        }
+
+        int sx = (int)(vx[i] * (int)cam->fovScale / z + xbase);
+        int sy = (int)(vy[i] * (int)cam->fovScale / z + ybase);
+
+        poly.vertices[i].x = (scr_size * sx) >> 6;
+        poly.vertices[i].y = (scr_size * (199 - sy)) >> 6;
+    }
+
+    // Skip fully-clipped polygons
+    if (clippedCount >= 4)
+        return;
+
+    // iSubpolyType 666 routes to building texture path inside dodivide
+    subdivide(screen_pointer, &poly,
+              vx[0], vy[0], vz[0],
+              vx[1], vy[1], vz[1],
+              vx[2], vy[2], vz[2],
+              vx[3], vy[3], vz[3],
+              666, gfx_size);
 }
 
 void game_render_sw_draw_car(GameRendererSoftware *sw, int carIdx,

--- a/PROJECTS/ROLLER/game_render_software.h
+++ b/PROJECTS/ROLLER/game_render_software.h
@@ -26,6 +26,10 @@ void game_render_sw_set_viewport(GameRendererSoftware *sw,
 void game_render_sw_set_camera(GameRendererSoftware *sw,
                                const GameRenderCamera *camera);
 
+// Projection
+void game_render_sw_set_projection(GameRendererSoftware *sw,
+                                   const GameRenderProjection *proj);
+
 // Asset loading
 TextureHandle game_render_sw_load_texture(GameRendererSoftware *sw,
                                           uint8 *pixelData,

--- a/PROJECTS/ROLLER/game_render_software.h
+++ b/PROJECTS/ROLLER/game_render_software.h
@@ -44,6 +44,10 @@ void game_render_sw_free_blocks(GameRendererSoftware *sw, int slot);
 void game_render_sw_quad(GameRendererSoftware *sw, tPolyParams *poly,
                          TextureHandle handle,
                          const uint8 *palette_remap);
+void game_render_sw_quad_world(GameRendererSoftware *sw,
+                               const GameRenderVertex *verts,
+                               TextureHandle handle,
+                               int surfaceFlags);
 void game_render_sw_draw_car(GameRendererSoftware *sw, int carIdx,
                              int yaw, int pitch, int roll,
                              float worldX, float worldY, float worldZ,


### PR DESCRIPTION
Closes #119.

## What changed

- **`game_render.h`** — Added `GameRenderVertex` struct `{float x, y, z, u, v}`; added `game_render_quad_world(renderer, verts[4], TextureHandle, surfaceFlags)` public API
- **`game_render.c`** — Added dispatch forwarding to sw backend
- **`game_render_software.h/.c`** — Added `game_render_sw_quad_world`: world→view transform (vk1–vk9), screen projection (VIEWDIST/scr_size/xbase/ybase), `tPolyParams` construction, delegates to `subdivide(..., 666, gfx_size)`. Includes `drawtrk3.h`, `transfrm.h`, `graphics.h`.
- **`building.c`** — `DrawBuilding()` converted: computes world-space positions (3×3 rotation + translation), stores in `worldCoords[32]`, computes `sortDepths[32]` via `vk3/vk6/vk9` for Z-sort, removes view-matrix transform, screen projection, backface culling, subdivision decision, and `game_render_quad`/`subdivide` calls. Replaced with `game_render_quad_world` per polygon.

## Verification

- [x] `zig build` passes clean (zero warnings)
- [x] Only ~2 call sites changed (both in building.c `DrawBuilding`)
- [x] All other `game_render_quad` callers unchanged
- [x] Texture/advert remapping preserved in building.c
- [x] Z-sorting produces equivalent order (view-space Z dot product)