### PR TITLE
Route remaining world quads through game renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -387,3 +387,5 @@ packages.microsoft.gpg
 .claude
 .codex
 .worktrees/
+
+.worktrees/

--- a/PROJECTS/ROLLER/building.c
+++ b/PROJECTS/ROLLER/building.c
@@ -571,7 +571,7 @@ void DrawBuilding(int iBuildingIdx, uint8 *pScrPtr)
       viewIntZ[i] = (int)(dx * vk3 + dy * vk6 + dz * vk9);
       sortDepths[i] = (float)viewIntZ[i];
       // Project to screen-space using legacy integer math; far polygons
-      // dispatch via game_render_quad with these pre-projected coords.
+      // dispatch via game_render_quad_screen with these pre-projected coords.
       int iClipped = 0;
       int iVz = viewIntZ[i];
       if (iVz < 80) {
@@ -720,7 +720,7 @@ void DrawBuilding(int iBuildingIdx, uint8 *pScrPtr)
           if ((float)iZ3 < fClosestZ) fClosestZ = (float)iZ3;
 
           if ((double)BuildingSub[uiBuildingType] * subscale <= fClosestZ) {
-            // Far polygon — pre-projected screen verts via game_render_quad.
+            // Far polygon — pre-projected screen verts via game_render_quad_screen.
             BuildingPol.iSurfaceType = (int)uiTex;
             BuildingPol.uiNumVerts = 4;
             for (int vi = 0; vi < 4; vi++) {
@@ -728,10 +728,10 @@ void DrawBuilding(int iBuildingIdx, uint8 *pScrPtr)
               BuildingPol.vertices[vi].y = screenY[iOrder[vi]];
             }
             if ((uiTex & 0x100) != 0)
-              game_render_quad(g_pGameRenderer, &BuildingPol,
+              game_render_quad_screen(g_pGameRenderer, &BuildingPol,
                                game_render_get_texture_handle(g_pGameRenderer, TEXTURE_BANK_BUILDING), NULL);
             else
-              game_render_quad(g_pGameRenderer, &BuildingPol, TEXTURE_HANDLE_INVALID, NULL);
+              game_render_quad_screen(g_pGameRenderer, &BuildingPol, TEXTURE_HANDLE_INVALID, NULL);
           } else {
             // Close polygon — world-space dispatch lets sw_quad_world subdivide.
             GameRenderVertex verts[4];

--- a/PROJECTS/ROLLER/car.c
+++ b/PROJECTS/ROLLER/car.c
@@ -19,6 +19,7 @@ static inline int d2i(double d) {
 }
 #include "func2.h"
 #include "function.h"
+#include "polyf.h"
 #include "polytex.h"
 #include "roller.h"
 #include <math.h>
@@ -1944,7 +1945,28 @@ LABEL_117:
           if ((textures_off & TEX_OFF_ADVANCED_CARS) != 0 && (uiTextureSurface & SURFACE_FLAG_APPLY_TEXTURE) == 0 && (uint8)uiTextureSurface == uiColorFrom)
             uiTextureSurface = uiColorTo;
           CarPol.iSurfaceType = uiTextureSurface;
-          if (bCloseToCamera) {
+          GameRenderer *renderer = g_pGameRenderer;
+          if (renderer) {
+            GameRenderVertex verts[4];
+            for (int vi = 0; vi < 4; vi++) {
+              verts[vi].x = polygonVertices[vi]->world.fX;
+              verts[vi].y = polygonVertices[vi]->world.fY;
+              verts[vi].z = polygonVertices[vi]->world.fZ;
+              verts[vi].u = 0.0f;
+              verts[vi].v = 0.0f;
+            }
+            TextureHandle carPolyTexture = TEXTURE_HANDLE_INVALID;
+            if ((uiTextureSurface & SURFACE_FLAG_APPLY_TEXTURE) != 0 && iTextureDisabled) {
+              carPolyTexture = game_render_get_texture_handle(renderer, car_texmap[uiTextureMapOffset / 4]);
+            }
+            game_render_quad_world_subdivide_type(
+              renderer,
+              verts,
+              carPolyTexture,
+              uiTextureSurface,
+              iSubdivisionParam,
+              bCloseToCamera ? 0.0f : 1.0f);
+          } else if (bCloseToCamera) {
             subdivide(
               pScrBuf,
               &CarPol,
@@ -1961,14 +1983,12 @@ LABEL_117:
               polygonVertices[3]->view.fY,
               polygonVertices[3]->view.fZ,
               iSubdivisionParam,
-              gfx_size);                        // Subdivide polygon if too close to camera for better quality
+              gfx_size);
+          } else if ((uiTextureSurface & SURFACE_FLAG_APPLY_TEXTURE) != 0 && iTextureDisabled) {
+            int iCarTexSlot = car_texmap[uiTextureMapOffset / 4];
+            POLYTEX(cartex_vga[iCarTexSlot - 1], pScrBuf, &CarPol, iCarTexSlot, gfx_size);
           } else {
-            // SURFACE_FLAG_APPLY_TEXTURE
-            if ((uiTextureSurface & SURFACE_FLAG_APPLY_TEXTURE) != 0 && iTextureDisabled) {
-              game_render_quad_screen(g_pGameRenderer, &CarPol, game_render_get_texture_handle(g_pGameRenderer, car_texmap[uiTextureMapOffset / 4]), NULL);
-            } else {
-              goto LABEL_267;  // No texture - render flat polygon
-            }
+            POLYFLAT(pScrBuf, &CarPol);
           }
         } else {
           CarZOrder[uiRenderLoopOffset / 0xC].iPolygonLink = -1;

--- a/PROJECTS/ROLLER/car.c
+++ b/PROJECTS/ROLLER/car.c
@@ -1493,7 +1493,7 @@ LABEL_105:
     CarPol.uiNumVerts = 4;
     CarPol.iSurfaceType = 0x202002;
     CarPol.vertices[3].y = d2i(dShadowCorner3Y);
-    game_render_quad(g_pGameRenderer, &CarPol, TEXTURE_HANDLE_INVALID, NULL);
+    game_render_quad_screen(g_pGameRenderer, &CarPol, TEXTURE_HANDLE_INVALID, NULL);
   }
 LABEL_117:
   pCoords = CarDesigns[carDesignIndex].pCoords;
@@ -1965,7 +1965,7 @@ LABEL_117:
           } else {
             // SURFACE_FLAG_APPLY_TEXTURE
             if ((uiTextureSurface & SURFACE_FLAG_APPLY_TEXTURE) != 0 && iTextureDisabled) {
-              game_render_quad(g_pGameRenderer, &CarPol, game_render_get_texture_handle(g_pGameRenderer, car_texmap[uiTextureMapOffset / 4]), NULL);
+              game_render_quad_screen(g_pGameRenderer, &CarPol, game_render_get_texture_handle(g_pGameRenderer, car_texmap[uiTextureMapOffset / 4]), NULL);
             } else {
               goto LABEL_267;  // No texture - render flat polygon
             }
@@ -2028,11 +2028,11 @@ LABEL_117:
               // SURFACE_FLAG_APPLY_TEXTURE
               if ((CarPol.iSurfaceType & SURFACE_FLAG_APPLY_TEXTURE) == 0) {
               LABEL_267:
-                game_render_quad(g_pGameRenderer, &CarPol, TEXTURE_HANDLE_INVALID, NULL);
+                game_render_quad_screen(g_pGameRenderer, &CarPol, TEXTURE_HANDLE_INVALID, NULL);
                 goto LABEL_268;
               }
             }
-            game_render_quad(g_pGameRenderer, &CarPol, game_render_get_texture_handle(g_pGameRenderer, 18), NULL);
+            game_render_quad_screen(g_pGameRenderer, &CarPol, game_render_get_texture_handle(g_pGameRenderer, 18), NULL);
           }
         }
       LABEL_268:
@@ -2124,7 +2124,7 @@ LABEL_117:
       scr_size = iPrevScrSize;
       CarPol.iSurfaceType = team_col[iTeamColIdx];
       CarPol.uiNumVerts = 4;
-      game_render_quad(g_pGameRenderer, &CarPol, TEXTURE_HANDLE_INVALID, NULL);
+      game_render_quad_screen(g_pGameRenderer, &CarPol, TEXTURE_HANDLE_INVALID, NULL);
     }
   }
 }

--- a/PROJECTS/ROLLER/drawtrk3.c
+++ b/PROJECTS/ROLLER/drawtrk3.c
@@ -2911,9 +2911,9 @@ LABEL_393:
             RoadPoly.vertices[3].y = LightXYZ[iRenderingCoordIndex].screen.y;
             RoadPoly.vertices[3].x = iRenderingDataIndex;
             if ((RoadPoly.iSurfaceType & SURFACE_FLAG_APPLY_TEXTURE) != 0)
-              game_render_quad(g_pGameRenderer, &RoadPoly, game_render_get_texture_handle(g_pGameRenderer, 18), NULL);
+              game_render_quad_screen(g_pGameRenderer, &RoadPoly, game_render_get_texture_handle(g_pGameRenderer, 18), NULL);
             else
-              game_render_quad(g_pGameRenderer, &RoadPoly, TEXTURE_HANDLE_INVALID, NULL);
+              game_render_quad_screen(g_pGameRenderer, &RoadPoly, TEXTURE_HANDLE_INVALID, NULL);
             ++iNextSectionIndex;
           } while (iNextSectionIndex < 6);
           goto LABEL_1271;
@@ -3385,7 +3385,7 @@ void dodivide(float fX0_3D, float fY0_3D, float fZ0_3D,
               {
                 // Render textured pol with car texture
                 //TODO is this correct?
-                game_render_quad(
+                game_render_quad_screen(
                   g_pGameRenderer,
                   subpoly,
                   game_render_get_texture_handle(g_pGameRenderer, car_texmap[subpolytype - 3]),
@@ -3401,7 +3401,7 @@ void dodivide(float fX0_3D, float fY0_3D, float fZ0_3D,
               pFrameBuf = subptr;
               pPolyParams = subpoly;
             LABEL_114:
-              game_render_quad(g_pGameRenderer, pPolyParams, TEXTURE_HANDLE_INVALID, NULL); // render flat pol
+              game_render_quad_screen(g_pGameRenderer, pPolyParams, TEXTURE_HANDLE_INVALID, NULL); // render flat pol
             LABEL_115:
                           // Debug: draw pol outline if showsub is enabled
               if (showsub) {
@@ -3424,7 +3424,7 @@ void dodivide(float fX0_3D, float fY0_3D, float fZ0_3D,
               goto LABEL_111;
             if ((pPolyParams->iSurfaceType & SURFACE_FLAG_APPLY_TEXTURE) != 0)// SURFACE_FLAG_APPLY_TEXTURE
             {
-              game_render_quad(g_pGameRenderer, pPolyParamsLocal, game_render_get_texture_handle(g_pGameRenderer, 17), NULL);
+              game_render_quad_screen(g_pGameRenderer, pPolyParamsLocal, game_render_get_texture_handle(g_pGameRenderer, 17), NULL);
               goto LABEL_115;
             }
           LABEL_106:
@@ -3432,7 +3432,7 @@ void dodivide(float fX0_3D, float fY0_3D, float fZ0_3D,
             goto LABEL_107;
           }
           // Default texture rendering
-          game_render_quad(g_pGameRenderer, pPolyParamsLocal, game_render_get_texture_handle(g_pGameRenderer, 0), NULL);
+          game_render_quad_screen(g_pGameRenderer, pPolyParamsLocal, game_render_get_texture_handle(g_pGameRenderer, 0), NULL);
           goto LABEL_115;
         case 1:                                 // Horiz subdivision only
           // Calculate midpoint between verts 0 and 1, and 2 and 3

--- a/PROJECTS/ROLLER/func2.c
+++ b/PROJECTS/ROLLER/func2.c
@@ -504,7 +504,7 @@ void draw_smoke(uint8 *pScrBuf, int iPlayerCarIdx)
           if ((iColor & 0x100) == 0)          // SURFACE_FLAG_APPLY_TEXTURE
           {
           RENDER_POLYFLAT:
-            game_render_quad(g_pGameRenderer, &CarPol, TEXTURE_HANDLE_INVALID, NULL); // Render flat (untextured) polygon
+            game_render_quad_screen(g_pGameRenderer, &CarPol, TEXTURE_HANDLE_INVALID, NULL); // Render flat (untextured) polygon
             goto NEXT_PARTICLE;
           }
         } else {
@@ -535,7 +535,7 @@ void draw_smoke(uint8 *pScrBuf, int iPlayerCarIdx)
           if ((uiColor2 & 0x100) == 0)        // SURFACE_FLAG_APPLY_TEXTURE
             goto RENDER_POLYFLAT;               // Check texture flag - 0x100 bit indicates textured polygon
         }
-        game_render_quad(g_pGameRenderer, &CarPol, game_render_get_texture_handle(g_pGameRenderer, 18), NULL); // Render textured polygon using car texture
+        game_render_quad_screen(g_pGameRenderer, &CarPol, game_render_get_texture_handle(g_pGameRenderer, 18), NULL); // Render textured polygon using car texture
       }
     NEXT_PARTICLE:
       if (++pCarSpray == pNextCarSpray)       // Move to next spray particle

--- a/PROJECTS/ROLLER/func3.c
+++ b/PROJECTS/ROLLER/func3.c
@@ -2754,19 +2754,38 @@ void DrawCar(uint8 *pScrBuf, int iCarDesignIndex, float fDistance, int iAngle, c
       CarPol.iSurfaceType = uiTex;
 
       // Render pol
-      if (fMinViewZ >= 1.0) {
+      if (g_pGameRenderer) {
+        GameRenderVertex verts[4];
+        for (int vi = 0; vi < 4; vi++) {
+          verts[vi].x = screenVertAy[vi]->world.fX;
+          verts[vi].y = screenVertAy[vi]->world.fY;
+          verts[vi].z = screenVertAy[vi]->world.fZ;
+          verts[vi].u = 0.0f;
+          verts[vi].v = 0.0f;
+        }
+        TextureHandle carPolyTexture = TEXTURE_HANDLE_INVALID;
+        if ((uiTex & SURFACE_FLAG_APPLY_TEXTURE) != 0 && iTexturesEnabled) {
+          iCartexOffset = car_texmap[uiCarDesignIdxTimes4 / 4];
+          iGfxSize = gfx_size;
+          carPolyTexture = game_render_get_texture_handle(g_pGameRenderer, iCartexOffset);
+        }
+        game_render_quad_world_subdivide_type(
+          g_pGameRenderer,
+          verts,
+          carPolyTexture,
+          uiTex,
+          iSubPolType,
+          fMinViewZ >= 1.0 ? 1.0f : 0.0f);
+      } else if (fMinViewZ >= 1.0) {
         if ((uiTex & SURFACE_FLAG_APPLY_TEXTURE) != 0 && iTexturesEnabled) {
           iCartexOffset = car_texmap[uiCarDesignIdxTimes4 / 4];
           iGfxSize = gfx_size;
           POLYTEX(cartex_vga[iCartexOffset - 1], pScreenBuffer, &CarPol, iCartexOffset, gfx_size);
-        } else                                    // flat color pol
-        {
+        } else {
           POLYFLAT(pScreenBuffer, &CarPol);
         }
-      } else                                      // near plane clipping required
-      {
+      } else {
         iGfxSize = gfx_size;
-        // Subdivide pol for proper clipping
         subdivide(
           pScreenBuffer,
           &CarPol,

--- a/PROJECTS/ROLLER/game_render.c
+++ b/PROJECTS/ROLLER/game_render.c
@@ -102,11 +102,11 @@ void game_render_free_blocks(GameRenderer *renderer, int slot) {
 
 // Draw calls
 
-void game_render_quad(GameRenderer *renderer, tPolyParams *poly,
+void game_render_quad_screen(GameRenderer *renderer, tPolyParams *poly,
                       TextureHandle handle,
                       const uint8 *palette_remap) {
     if (renderer->mode == GAME_RENDER_SOFTWARE)
-        game_render_sw_quad(renderer->sw, poly, handle, palette_remap);
+        game_render_sw_quad_screen(renderer->sw, poly, handle, palette_remap);
 }
 
 void game_render_quad_world(GameRenderer *renderer,

--- a/PROJECTS/ROLLER/game_render.c
+++ b/PROJECTS/ROLLER/game_render.c
@@ -76,27 +76,37 @@ TextureHandle game_render_load_texture(GameRenderer *renderer,
                                        uint8 *pixelData,
                                        int width, int height,
                                        int tex_idx, int gfx_size) {
+    if (!renderer)
+        return TEXTURE_HANDLE_INVALID;
     return game_render_sw_load_texture(renderer->sw, pixelData,
                                        width, height, tex_idx, gfx_size);
 }
 
 void game_render_free_texture(GameRenderer *renderer,
                               TextureHandle handle) {
+    if (!renderer)
+        return;
     game_render_sw_free_texture(renderer->sw, handle);
 }
 
 TextureHandle game_render_get_texture_handle(GameRenderer *renderer,
                                              int tex_idx) {
+    if (!renderer)
+        return TEXTURE_HANDLE_INVALID;
     return game_render_sw_get_texture_handle(renderer->sw, tex_idx);
 }
 
 TextureHandle game_render_load_blocks(GameRenderer *renderer, int slot,
                                       tBlockHeader *blocks,
                                       const tColor *palette) {
+    if (!renderer)
+        return TEXTURE_HANDLE_INVALID;
     return game_render_sw_load_blocks(renderer->sw, slot, blocks, palette);
 }
 
 void game_render_free_blocks(GameRenderer *renderer, int slot) {
+    if (!renderer)
+        return;
     game_render_sw_free_blocks(renderer->sw, slot);
 }
 
@@ -105,6 +115,8 @@ void game_render_free_blocks(GameRenderer *renderer, int slot) {
 void game_render_quad_screen(GameRenderer *renderer, tPolyParams *poly,
                       TextureHandle handle,
                       const uint8 *palette_remap) {
+    if (!renderer)
+        return;
     if (renderer->mode == GAME_RENDER_SOFTWARE)
         game_render_sw_quad_screen(renderer->sw, poly, handle, palette_remap);
 }
@@ -125,6 +137,8 @@ void game_render_quad_world_subdivide_type(GameRenderer *renderer,
                                            int surfaceFlags,
                                            int subdivideType,
                                            float subThreshold) {
+    if (!renderer)
+        return;
     if (renderer->mode == GAME_RENDER_SOFTWARE)
         game_render_sw_quad_world_subdivide_type(renderer->sw, verts, handle,
                                                  surfaceFlags, subdivideType,

--- a/PROJECTS/ROLLER/game_render.c
+++ b/PROJECTS/ROLLER/game_render.c
@@ -114,9 +114,21 @@ void game_render_quad_world(GameRenderer *renderer,
                             TextureHandle handle,
                             int surfaceFlags,
                             float subThreshold) {
+    game_render_quad_world_subdivide_type(renderer, verts, handle, surfaceFlags,
+                                          GAME_RENDER_SUBDIVIDE_TYPE_AUTO,
+                                          subThreshold);
+}
+
+void game_render_quad_world_subdivide_type(GameRenderer *renderer,
+                                           const GameRenderVertex *verts,
+                                           TextureHandle handle,
+                                           int surfaceFlags,
+                                           int subdivideType,
+                                           float subThreshold) {
     if (renderer->mode == GAME_RENDER_SOFTWARE)
-        game_render_sw_quad_world(renderer->sw, verts, handle, surfaceFlags,
-                                  subThreshold);
+        game_render_sw_quad_world_subdivide_type(renderer->sw, verts, handle,
+                                                 surfaceFlags, subdivideType,
+                                                 subThreshold);
 }
 
 void game_render_draw_car(GameRenderer *renderer, int carIdx,

--- a/PROJECTS/ROLLER/game_render.h
+++ b/PROJECTS/ROLLER/game_render.h
@@ -25,6 +25,8 @@ typedef struct {
     float u, v;     // texture coordinates
 } GameRenderVertex;
 
+#define GAME_RENDER_SUBDIVIDE_TYPE_AUTO (-2147483647 - 1)
+
 typedef struct {
     float viewX, viewY, viewZ;
     float cosYaw, sinYaw;
@@ -105,6 +107,12 @@ void game_render_quad_world(GameRenderer *renderer,
                             TextureHandle handle,
                             int surfaceFlags,
                             float subThreshold);
+void game_render_quad_world_subdivide_type(GameRenderer *renderer,
+                                           const GameRenderVertex *verts,
+                                           TextureHandle handle,
+                                           int surfaceFlags,
+                                           int subdivideType,
+                                           float subThreshold);
 
 // Draw — car mesh
 void game_render_draw_car(GameRenderer *renderer, int carIdx,

--- a/PROJECTS/ROLLER/game_render.h
+++ b/PROJECTS/ROLLER/game_render.h
@@ -87,7 +87,7 @@ void game_render_free_blocks(GameRenderer *renderer, int slot);
 
 // Draw — polygon (track, buildings, particles, clouds)
 // Pass TEXTURE_HANDLE_INVALID for flat (untextured) polygons.
-void game_render_quad(GameRenderer *renderer,
+void game_render_quad_screen(GameRenderer *renderer,
                       tPolyParams *poly,
                       TextureHandle handle,
                       const uint8 *palette_remap);
@@ -98,7 +98,7 @@ void game_render_quad(GameRenderer *renderer,
 // subThreshold is the legacy `subdivides[i] * subscale` depth threshold;
 // when >0 and the polygon's nearest projected Z meets/exceeds it, the
 // renderer skips subdivide and rasterizes via POLYTEX/POLYFLAT directly
-// (matches the legacy subdivide-vs-game_render_quad branch). Pass 0.0f
+// (matches the legacy subdivide-vs-game_render_quad_screen branch). Pass 0.0f
 // to always subdivide.
 void game_render_quad_world(GameRenderer *renderer,
                             const GameRenderVertex *verts,

--- a/PROJECTS/ROLLER/game_render.h
+++ b/PROJECTS/ROLLER/game_render.h
@@ -26,6 +26,7 @@ typedef struct {
 } GameRenderVertex;
 
 #define GAME_RENDER_SUBDIVIDE_TYPE_AUTO (-2147483647 - 1)
+#define GAME_RENDER_SUBDIVIDE_TYPE_CLOUD (-2147483647)
 
 typedef struct {
     float viewX, viewY, viewZ;

--- a/PROJECTS/ROLLER/game_render_software.c
+++ b/PROJECTS/ROLLER/game_render_software.c
@@ -230,6 +230,17 @@ void game_render_sw_quad_world(GameRendererSoftware *sw,
                                TextureHandle handle,
                                int surfaceFlags,
                                float subThreshold) {
+    game_render_sw_quad_world_subdivide_type(sw, verts, handle, surfaceFlags,
+                                             GAME_RENDER_SUBDIVIDE_TYPE_AUTO,
+                                             subThreshold);
+}
+
+void game_render_sw_quad_world_subdivide_type(GameRendererSoftware *sw,
+                                              const GameRenderVertex *verts,
+                                              TextureHandle handle,
+                                              int surfaceFlags,
+                                              int subdivideType,
+                                              float subThreshold) {
     const GameRenderCamera *cam = &sw->camera;
     const GameRenderProjection *proj = &sw->proj;
 
@@ -241,7 +252,9 @@ void game_render_sw_quad_world(GameRendererSoftware *sw,
      * drawtrk3 double+round recipe. Wide-texture roads only land in the
      * wall path when wide_on is enabled (mirrors legacy case 5 dispatch). */
     int subpolyType;
-    if (handle > 0 && handle < GAME_RENDER_MAX_TEXTURE_SLOTS
+    if (subdivideType != GAME_RENDER_SUBDIVIDE_TYPE_AUTO) {
+        subpolyType = subdivideType;
+    } else if (handle > 0 && handle < GAME_RENDER_MAX_TEXTURE_SLOTS
         && sw->texSlots[handle].in_use
         && sw->texSlots[handle].tex_idx == TEXTURE_BANK_BUILDING) {
         subpolyType = SUBPOLY_BUILDING;
@@ -290,7 +303,14 @@ void game_render_sw_quad_world(GameRendererSoftware *sw,
         /* Track/wall recipe (legacy drawtrk3): world − view in double (no floor),
          * matrix product cast to float for X/Y, double Z preserved for clip
          * and perspective division (rounded int separately for subdivide Z),
-         * round-to-int after double projection, no skip-all-clipped. */
+         * round-to-int after double projection, no skip-all-clipped.
+         *
+         * Car polygons use explicit subpoly types 3+ for car texture routing.
+         * DisplayCar's legacy projection differs subtly from drawtrk3: it
+         * truncates projected X/Y with d2i() and passes raw view-Z into
+         * subdivide(). Preserve that recipe so routing car meshes through the
+         * world API does not move their screen-space silhouette. */
+        int useCarProjection = subpolyType >= 3;
         double viewDist = (double)cam->fovScale;
         for (int i = 0; i < 4; i++) {
             /* Float subtraction first (matches legacy: tVec3.fX - viewx),
@@ -302,16 +322,23 @@ void game_render_sw_quad_world(GameRendererSoftware *sw,
             float fVy = (float)(dx * proj->view[0][1] + dy * proj->view[1][1] + dz * proj->view[2][1]);
             double dCameraZ = dx * proj->view[0][2] + dy * proj->view[1][2] + dz * proj->view[2][2];
             float fVz = (float)dCameraZ;
-            int iProjectedZ = (int)round(dCameraZ);
-            if (fVz < 80.0f) fVz = 80.0f;
-            double dInvZ = 1.0 / (double)fVz;
-            int xp = (int)round(viewDist * (double)fVx * dInvZ + (double)proj->centerX);
-            int yp = (int)round(dInvZ * (viewDist * (double)fVy) + (double)proj->centerY);
+            float fProjectedZ = fVz;
+            if (fProjectedZ < 80.0f) fProjectedZ = 80.0f;
+            double dInvZ = 1.0 / (double)fProjectedZ;
+            int xp;
+            int yp;
+            if (useCarProjection) {
+                xp = (int)(viewDist * (double)fVx * dInvZ + (double)proj->centerX);
+                yp = (int)(dInvZ * (viewDist * (double)fVy) + (double)proj->centerY);
+            } else {
+                xp = (int)round(viewDist * (double)fVx * dInvZ + (double)proj->centerX);
+                yp = (int)round(dInvZ * (viewDist * (double)fVy) + (double)proj->centerY);
+            }
             poly.vertices[i].x = (xp * proj->screenScale) >> 6;
             poly.vertices[i].y = (proj->screenScale * (199 - yp)) >> 6;
             subVx[i] = fVx;
             subVy[i] = fVy;
-            subVz[i] = (float)iProjectedZ;
+            subVz[i] = useCarProjection ? fVz : (float)((int)round(dCameraZ));
         }
     }
 
@@ -334,7 +361,7 @@ void game_render_sw_quad_world(GameRendererSoftware *sw,
             useDirect = 1;
     }
 
-    if (handle == TEXTURE_HANDLE_INVALID) {
+    if (useDirect && handle == TEXTURE_HANDLE_INVALID) {
         POLYFLAT(screen_pointer, &poly);
     } else if (useDirect) {
         TextureSlot *slot = &sw->texSlots[handle];

--- a/PROJECTS/ROLLER/game_render_software.c
+++ b/PROJECTS/ROLLER/game_render_software.c
@@ -225,6 +225,17 @@ void game_render_sw_quad_screen(GameRendererSoftware *sw, tPolyParams *poly,
     }
 }
 
+void game_render_sw_subdivide_view_quad(uint8 *pDest, tPolyParams *poly,
+                                        const float viewCoords[4][3],
+                                        int subdivideType, int texHalfRes) {
+    subdivide(pDest, poly,
+              viewCoords[0][0], viewCoords[0][1], viewCoords[0][2],
+              viewCoords[1][0], viewCoords[1][1], viewCoords[1][2],
+              viewCoords[2][0], viewCoords[2][1], viewCoords[2][2],
+              viewCoords[3][0], viewCoords[3][1], viewCoords[3][2],
+              subdivideType, texHalfRes);
+}
+
 void game_render_sw_quad_world(GameRendererSoftware *sw,
                                const GameRenderVertex *verts,
                                TextureHandle handle,

--- a/PROJECTS/ROLLER/game_render_software.c
+++ b/PROJECTS/ROLLER/game_render_software.c
@@ -211,7 +211,7 @@ void game_render_sw_free_blocks(GameRendererSoftware *sw, int slot) {
 // Draw calls
 // ---------------------------------------------------------------------------
 
-void game_render_sw_quad(GameRendererSoftware *sw, tPolyParams *poly,
+void game_render_sw_quad_screen(GameRendererSoftware *sw, tPolyParams *poly,
                          TextureHandle handle,
                          const uint8 *palette_remap) {
     (void)palette_remap;
@@ -322,7 +322,7 @@ void game_render_sw_quad_world(GameRendererSoftware *sw,
     /* Subdivide-vs-direct dispatch: when caller provided a threshold and
      * the polygon's nearest projected Z exceeds it, render directly via
      * POLYTEX/POLYFLAT — mirrors the legacy
-     * `if (subdivides[i] * subscale > min_z) subdivide else game_render_quad`
+     * `if (subdivides[i] * subscale > min_z) subdivide else game_render_quad_screen`
      * branch in drawtrk3.c. */
     int useDirect = 0;
     if (subThreshold > 0.0f) {

--- a/PROJECTS/ROLLER/game_render_software.c
+++ b/PROJECTS/ROLLER/game_render_software.c
@@ -262,8 +262,11 @@ void game_render_sw_quad_world_subdivide_type(GameRendererSoftware *sw,
      * legacy floor/int-math recipe, tracks/walls/standard use the legacy
      * drawtrk3 double+round recipe. Wide-texture roads only land in the
      * wall path when wide_on is enabled (mirrors legacy case 5 dispatch). */
+    int useCloudProjection = subdivideType == GAME_RENDER_SUBDIVIDE_TYPE_CLOUD;
     int subpolyType;
-    if (subdivideType != GAME_RENDER_SUBDIVIDE_TYPE_AUTO) {
+    if (useCloudProjection) {
+        subpolyType = SUBPOLY_STANDARD;
+    } else if (subdivideType != GAME_RENDER_SUBDIVIDE_TYPE_AUTO) {
         subpolyType = subdivideType;
     } else if (handle > 0 && handle < GAME_RENDER_MAX_TEXTURE_SLOTS
         && sw->texSlots[handle].in_use
@@ -316,11 +319,12 @@ void game_render_sw_quad_world_subdivide_type(GameRendererSoftware *sw,
          * and perspective division (rounded int separately for subdivide Z),
          * round-to-int after double projection, no skip-all-clipped.
          *
-         * Car polygons use explicit subpoly types 3+ for car texture routing.
-         * DisplayCar's legacy projection differs subtly from drawtrk3: it
-         * truncates projected X/Y with d2i() and passes raw view-Z into
-         * subdivide(). Preserve that recipe so routing car meshes through the
-         * world API does not move their screen-space silhouette. */
+         * Car polygons use explicit subpoly types 3+ for car texture routing,
+         * and cloud quads use GAME_RENDER_SUBDIVIDE_TYPE_CLOUD. Their legacy
+         * projections differ subtly from drawtrk3: both truncate projected X/Y,
+         * and cars pass raw view-Z into subdivide(). Preserve that recipe so
+         * routing those meshes through the world API does not move their
+         * screen-space silhouette. */
         int useCarProjection = subpolyType >= 3;
         double viewDist = (double)cam->fovScale;
         for (int i = 0; i < 4; i++) {
@@ -338,7 +342,7 @@ void game_render_sw_quad_world_subdivide_type(GameRendererSoftware *sw,
             double dInvZ = 1.0 / (double)fProjectedZ;
             int xp;
             int yp;
-            if (useCarProjection) {
+            if (useCarProjection || useCloudProjection) {
                 xp = (int)(viewDist * (double)fVx * dInvZ + (double)proj->centerX);
                 yp = (int)(dInvZ * (viewDist * (double)fVy) + (double)proj->centerY);
             } else {
@@ -349,7 +353,7 @@ void game_render_sw_quad_world_subdivide_type(GameRendererSoftware *sw,
             poly.vertices[i].y = (proj->screenScale * (199 - yp)) >> 6;
             subVx[i] = fVx;
             subVy[i] = fVy;
-            subVz[i] = useCarProjection ? fVz : (float)((int)round(dCameraZ));
+            subVz[i] = (useCarProjection || useCloudProjection) ? fVz : (float)((int)round(dCameraZ));
         }
     }
 

--- a/PROJECTS/ROLLER/game_render_software.h
+++ b/PROJECTS/ROLLER/game_render_software.h
@@ -45,7 +45,7 @@ TextureHandle game_render_sw_load_blocks(GameRendererSoftware *sw, int slot,
 void game_render_sw_free_blocks(GameRendererSoftware *sw, int slot);
 
 // Draw calls
-void game_render_sw_quad(GameRendererSoftware *sw, tPolyParams *poly,
+void game_render_sw_quad_screen(GameRendererSoftware *sw, tPolyParams *poly,
                          TextureHandle handle,
                          const uint8 *palette_remap);
 void game_render_sw_quad_world(GameRendererSoftware *sw,

--- a/PROJECTS/ROLLER/game_render_software.h
+++ b/PROJECTS/ROLLER/game_render_software.h
@@ -59,6 +59,9 @@ void game_render_sw_quad_world_subdivide_type(GameRendererSoftware *sw,
                                               int surfaceFlags,
                                               int subdivideType,
                                               float subThreshold);
+void game_render_sw_subdivide_view_quad(uint8 *pDest, tPolyParams *poly,
+                                        const float viewCoords[4][3],
+                                        int subdivideType, int texHalfRes);
 void game_render_sw_draw_car(GameRendererSoftware *sw, int carIdx,
                              int yaw, int pitch, int roll,
                              float worldX, float worldY, float worldZ,

--- a/PROJECTS/ROLLER/game_render_software.h
+++ b/PROJECTS/ROLLER/game_render_software.h
@@ -53,6 +53,12 @@ void game_render_sw_quad_world(GameRendererSoftware *sw,
                                TextureHandle handle,
                                int surfaceFlags,
                                float subThreshold);
+void game_render_sw_quad_world_subdivide_type(GameRendererSoftware *sw,
+                                              const GameRenderVertex *verts,
+                                              TextureHandle handle,
+                                              int surfaceFlags,
+                                              int subdivideType,
+                                              float subThreshold);
 void game_render_sw_draw_car(GameRendererSoftware *sw, int carIdx,
                              int yaw, int pitch, int roll,
                              float worldX, float worldY, float worldZ,

--- a/PROJECTS/ROLLER/horizon.c
+++ b/PROJECTS/ROLLER/horizon.c
@@ -630,7 +630,7 @@ void displayclouds(uint8 *pScrBuf)
             if (!iBehindCamera) {
               poly.iSurfaceType = cloud[iCloudIdx].iSurfaceType;// Set polygon surface type and vertex count (quad = 4 vertices)
               poly.uiNumVerts = -4;
-              game_render_quad(g_pGameRenderer, &poly, game_render_get_texture_handle(g_pGameRenderer, 18), NULL);// Render textured polygon to screen buffer
+              game_render_quad_screen(g_pGameRenderer, &poly, game_render_get_texture_handle(g_pGameRenderer, 18), NULL);// Render textured polygon to screen buffer
             }
           }
         }

--- a/PROJECTS/ROLLER/horizon.c
+++ b/PROJECTS/ROLLER/horizon.c
@@ -628,9 +628,21 @@ void displayclouds(uint8 *pScrBuf)
               iBehindCamera = 1;
             }
             if (!iBehindCamera) {
-              poly.iSurfaceType = cloud[iCloudIdx].iSurfaceType;// Set polygon surface type and vertex count (quad = 4 vertices)
-              poly.uiNumVerts = -4;
-              game_render_quad_screen(g_pGameRenderer, &poly, game_render_get_texture_handle(g_pGameRenderer, 18), NULL);// Render textured polygon to screen buffer
+              GameRenderVertex verts[4];
+              for (int vi = 0; vi < 4; vi++) {
+                verts[vi].x = cloud[iCloudIdx].matrix[vi][0];
+                verts[vi].y = cloud[iCloudIdx].matrix[vi][1];
+                verts[vi].z = cloud[iCloudIdx].matrix[vi][2] * 0.5f;
+                verts[vi].u = 0.0f;
+                verts[vi].v = 0.0f;
+              }
+              game_render_quad_world_subdivide_type(
+                g_pGameRenderer,
+                verts,
+                game_render_get_texture_handle(g_pGameRenderer, 18),
+                cloud[iCloudIdx].iSurfaceType,
+                GAME_RENDER_SUBDIVIDE_TYPE_CLOUD,
+                1.0f);// Render textured polygon through world-space renderer
             }
           }
         }

--- a/PROJECTS/ROLLER/replay.c
+++ b/PROJECTS/ROLLER/replay.c
@@ -2572,7 +2572,7 @@ void warning(int iX1, int iY1, int iX2, int iY2, char *szWarning)
   poly.vertices[3].y = iY2;
   poly.iSurfaceType = SURFACE_FLAG_TRANSPARENT | 0x3;// 0x200003;
   poly.uiNumVerts = 4;
-  game_render_quad(g_pGameRenderer, &poly, TEXTURE_HANDLE_INVALID, NULL);
+  game_render_quad_screen(g_pGameRenderer, &poly, TEXTURE_HANDLE_INVALID, NULL);
   prt_centrecol(rev_vga[1], szWarning, (iX1Scaled + iX2) / 2, iY1_1 + 10, 231);
   if (fatkbhit()) {
     while (fatkbhit())
@@ -2616,7 +2616,7 @@ void lsd(int iX1, int iY1, int iX2, int iY2)
   poly.vertices[3].y = iY2;
   poly.iSurfaceType = 0x200003;                 // = SURFACE_FLAG_TRANSPARENT | 0x3;
   poly.uiNumVerts = 4;
-  game_render_quad(g_pGameRenderer, &poly, TEXTURE_HANDLE_INVALID, NULL);
+  game_render_quad_screen(g_pGameRenderer, &poly, TEXTURE_HANDLE_INVALID, NULL);
   prt_centrecol(rev_vga[1], &language_buffer[3072], 160, iOriginalY1 + 10, 231);// Display menu title text centered
   while (fatkbhit())                          // Main input loop - process keyboard input
   {
@@ -2846,7 +2846,7 @@ void fileselect(int iBoxX0, int iBoxY0, int iBoxX1, int iBoxY1, int iTextX, int 
   params.uiNumVerts = 4;
   params.vertices[1].x = iLeftEdge;
   params.vertices[2].x = iLeftEdge;
-  game_render_quad(g_pGameRenderer, &params, TEXTURE_HANDLE_INVALID, NULL);
+  game_render_quad_screen(g_pGameRenderer, &params, TEXTURE_HANDLE_INVALID, NULL);
   prt_centrecol(rev_vga[1], szText, iTextX, iTextY, 231);
   if (iFileIdx != lastfile)                   // If different directory selected, rescan files and reset selection
   {

--- a/PROJECTS/ROLLER/tower.c
+++ b/PROJECTS/ROLLER/tower.c
@@ -133,7 +133,7 @@ void DrawTower(int iTowerIdx, uint8 *pScrBuf)
       TowerPol.vertices[3].x = iPixelX + 3;
       TowerPol.iSurfaceType = SURFACE_FLAG_FLIP_BACKFACE | 0xE7; //0x20E7;          // Set tower polygon properties and draw to screen buffer
       TowerPol.uiNumVerts = 4;
-      game_render_quad(g_pGameRenderer, &TowerPol, TEXTURE_HANDLE_INVALID, NULL);
+      game_render_quad_screen(g_pGameRenderer, &TowerPol, TEXTURE_HANDLE_INVALID, NULL);
     }
   }
 }

--- a/PROJECTS/ROLLER/tower.c
+++ b/PROJECTS/ROLLER/tower.c
@@ -123,17 +123,23 @@ void DrawTower(int iTowerIdx, uint8 *pScrBuf)
     iPixelY = (iScreenSize * (199 - (int)dScreenY)) >> 6;// Complex visibility test for different distance ranges
     if (fOriginalZ >= 5000.0 && xp >= -50 && xp < 370 && yp >= -50 && yp < 250
       || fOriginalZ > -1000.0 && fOriginalZ < 5000.0 && (fTransformed3DX > -1000.0 && fTransformed3DX < 1000.0 || xp > -200 && xp < 520)) {
-      TowerPol.vertices[0].x = iPixelX + 3;     // Create 6x6 pixel rectangle for tower visualization
-      TowerPol.vertices[1].x = iPixelX - 3;
-      TowerPol.vertices[2].x = iPixelX - 3;
-      TowerPol.vertices[0].y = iPixelY - 3;
-      TowerPol.vertices[1].y = iPixelY - 3;
-      TowerPol.vertices[2].y = iPixelY + 3;
-      TowerPol.vertices[3].y = iPixelY + 3;
-      TowerPol.vertices[3].x = iPixelX + 3;
-      TowerPol.iSurfaceType = SURFACE_FLAG_FLIP_BACKFACE | 0xE7; //0x20E7;          // Set tower polygon properties and draw to screen buffer
-      TowerPol.uiNumVerts = 4;
-      game_render_quad_screen(g_pGameRenderer, &TowerPol, TEXTURE_HANDLE_INVALID, NULL);
+      GameRenderVertex verts[4];
+      float fHalfPixelSize = fClampedZ * 3.0f * 64.0f / ((float)scr_size * (float)VIEWDIST);
+      float viewOffsetX[4] = { fHalfPixelSize, -fHalfPixelSize, -fHalfPixelSize, fHalfPixelSize };
+      float viewOffsetY[4] = { fHalfPixelSize, fHalfPixelSize, -fHalfPixelSize, -fHalfPixelSize };
+      for (int vi = 0; vi < 4; vi++) {
+        verts[vi].x = TowerX[iTowerIdx] + viewOffsetX[vi] * vk1 + viewOffsetY[vi] * vk2;
+        verts[vi].y = TowerY[iTowerIdx] + viewOffsetX[vi] * vk4 + viewOffsetY[vi] * vk5;
+        verts[vi].z = TowerZ[iTowerIdx] + viewOffsetX[vi] * vk7 + viewOffsetY[vi] * vk8;
+        verts[vi].u = 0.0f;
+        verts[vi].v = 0.0f;
+      }
+      game_render_quad_world(
+        g_pGameRenderer,
+        verts,
+        TEXTURE_HANDLE_INVALID,
+        SURFACE_FLAG_FLIP_BACKFACE | 0xE7,
+        1.0f);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Rename the legacy screen-space quad API to `game_render_quad_screen` and route remaining world-space quad callers through `game_render_quad_world` / explicit subdivision-type variants.
- Convert car mesh, func3 car preview/clipping, horizon clouds, and tower markers to the world-quad renderer path.
- Preserve the frontend/menu car preview before renderer initialization by falling back to the legacy software path when `g_pGameRenderer` is null; follow-up architectural issue: #140.
- Update snapshot baselines for the expected world-quad routing pixel differences.

## Test Plan
- [x] `zig build`
- [x] `zig build test-snapshots`
- [x] `zig build run -- --no-crash-handler`
