### PR TITLE
Extract scene_render seam for frontend car previews

### DIFF
--- a/PROJECTS/ROLLER/func3.c
+++ b/PROJECTS/ROLLER/func3.c
@@ -18,6 +18,7 @@
 #include "function.h"
 #include "loadtrak.h"
 #include "rollercomms.h"
+#include "scene_render.h"
 #include <memory.h>
 #include <fcntl.h>
 #include <math.h>
@@ -93,6 +94,32 @@ int result_p2;            //00188834
 int result_p2_pos;        //00188838
 int result_p1_pos;        //0018883C
 
+static void sync_scene_render_from_legacy_view(SceneRenderer *scene)
+{
+  if (!scene)
+    return;
+
+  SceneRenderCamera cam = {
+    .viewX = viewx,
+    .viewY = viewy,
+    .viewZ = viewz,
+    .cosYaw = fcos,
+    .sinYaw = fsin,
+    .fovScale = (float)VIEWDIST,
+  };
+  SceneRenderProjection proj = {
+    .view = {{vk1, vk2, vk3},
+             {vk4, vk5, vk6},
+             {vk7, vk8, vk9}},
+    .screenScale = scr_size,
+    .centerX = xbase,
+    .centerY = ybase,
+    .texHalfRes = gfx_size,
+  };
+  scene_render_set_camera(scene, &cam);
+  scene_render_set_projection(scene, &proj);
+}
+
 //-------------------------------------------------------------------------------------------------
 //00056070
 int winner_screen(int carDesign, char byFlags)
@@ -117,6 +144,7 @@ int winner_screen(int carDesign, char byFlags)
   int iOldGfxSize; // [esp+4h] [ebp-24h]
   char byAnimFrame; // [esp+8h] [ebp-20h]
   int iDisplayDuration; // [esp+Ch] [ebp-1Ch]
+  SceneRenderer *scene;
 
   tick_on = -1;
   frontend_on = -1;
@@ -155,6 +183,7 @@ int winner_screen(int carDesign, char byFlags)
   Car[0].nRoll = 0;
   Car[0].nPitch = 0;
   set_starts(0);
+  scene = scene_render_create(ROLLERGetGPUDevice(), ROLLERGetWindow());
 
   for (int i = 0; i < 16; ++i) {
     car_texs_loaded[i] = -1;
@@ -180,6 +209,10 @@ int winner_screen(int carDesign, char byFlags)
   }
 
   LoadCarTextures = iTexturesLoaded;
+  if (scene && car_texmap[carDesign] > 0 && cartex_vga[car_texmap[carDesign] - 1]) {
+    scene_render_load_texture(scene, cartex_vga[car_texmap[carDesign] - 1],
+                              256, 0, car_texmap[carDesign], gfx_size);
+  }
   NoOfTextures = 255;
   if ( SVGA_ON )
     scr_size = 128;
@@ -206,7 +239,9 @@ int winner_screen(int carDesign, char byFlags)
     memcpy(scrbuf, front_vga[0], 4 * uiDWordCount);
     memcpy(&pScrBuf[4 * uiDWordCount], &pWinnerImage->iWidth + uiDWordCount, byBufSizeLow & 3);
 
-    DrawCar(scrbuf + 73600, carDesign, 2200.0, 512, byAnimFrame);
+    scene_render_set_target(scene, scrbuf, winw, winw, winh);
+    scene_render_set_viewport(scene, 0, 115, winw, winh - 115);
+    DrawCar(scene, carDesign, 2200.0, 512, byAnimFrame);
     front_text(front_vga[1], driver_names[result_order[0]], font3_ascii, font3_offsets, 320, 120, 0x8Fu, 1u);
     copypic(scrbuf, screen);
     if ( !front_fade )
@@ -249,6 +284,7 @@ int winner_screen(int carDesign, char byFlags)
   }
   while ( ppCartexItr != &cartex_vga[16] );
   remove_mapsels();
+  scene_render_destroy(scene);
   gfx_size = iOldGfxSize;
   if ( !iRetVal )
   {
@@ -2175,7 +2211,7 @@ void show_3dmap(float fZ, int iElevation, int iYaw)
 
 //-------------------------------------------------------------------------------------------------
 //0005A400
-void DrawCar(uint8 *pScrBuf, int iCarDesignIndex, float fDistance, int iAngle, char byAnimFrame)
+void DrawCar(SceneRenderer *scene, int iCarDesignIndex, float fDistance, int iAngle, char byAnimFrame)
 {
   int iNumCoords; // ecx
   int iYaw; // eax
@@ -2261,7 +2297,6 @@ void DrawCar(uint8 *pScrBuf, int iCarDesignIndex, float fDistance, int iAngle, c
   double dBoxX; // [esp+5Ch] [ebp-140h]
   uint32 uiColorFrom; // [esp+64h] [ebp-138h]
   int iNumPols; // [esp+68h] [ebp-134h]
-  uint8 *pScreenBuffer; // [esp+6Ch] [ebp-130h]
   float fRotMat01; // [esp+70h] [ebp-12Ch]
   float fClippedZ; // [esp+74h] [ebp-128h]
   float fNearClip; // [esp+78h] [ebp-124h]
@@ -2320,7 +2355,8 @@ void DrawCar(uint8 *pScrBuf, int iCarDesignIndex, float fDistance, int iAngle, c
   int iTexturesEnabled; // [esp+180h] [ebp-1Ch]
   tAnimation *pAnms; // [esp+184h] [ebp-18h]
 
-  pScreenBuffer = pScrBuf;
+  if (!scene)
+    return;
   carDesign = iCarDesignIndex;
 
   // Calculate world position from angle and distance
@@ -2334,6 +2370,7 @@ void DrawCar(uint8 *pScrBuf, int iCarDesignIndex, float fDistance, int iAngle, c
 
   // Set up view transformation
   calculatetransform(-1, 0, -iAngle & 0x3FFF, 0, worldx, 0.0, worldz, 0.0, 0.0, 0.0);
+  sync_scene_render_from_legacy_view(scene);
   worlddirn = vdirection;
   worldelev = velevation;
   worldtilt = vtilt;
@@ -2419,13 +2456,23 @@ void DrawCar(uint8 *pScrBuf, int iCarDesignIndex, float fDistance, int iAngle, c
   } while (uiVertIdx != 32);
 
   // Draw car shadow
-  CarPol.vertices[0] = CarPt[0].screen;
-  CarPol.vertices[1] = CarPt[1].screen;
-  CarPol.vertices[2] = CarPt[2].screen;
-  CarPol.vertices[3] = CarPt[3].screen;
-  CarPol.iSurfaceType = SURFACE_FLAG_FLIP_BACKFACE | SURFACE_FLAG_TRANSPARENT | 2; //0x202002
-  CarPol.uiNumVerts = 4;
-  POLYFLAT(pScreenBuffer, &CarPol);
+  {
+    SceneRenderVertex shadowVerts[4];
+    for (int vi = 0; vi < 4; vi++) {
+      shadowVerts[vi].x = CarPt[vi].world.fX;
+      shadowVerts[vi].y = CarPt[vi].world.fY;
+      shadowVerts[vi].z = CarPt[vi].world.fZ;
+      shadowVerts[vi].u = 0.0f;
+      shadowVerts[vi].v = 0.0f;
+    }
+    SceneRenderLegacyQuadOptions shadowOptions = {
+      .subdivideType = carDesign + 3,
+      .subThreshold = 1.0f,
+    };
+    scene_render_quad_world_legacy(scene, shadowVerts, SCENE_TEXTURE_HANDLE_INVALID,
+                                   SURFACE_FLAG_FLIP_BACKFACE | SURFACE_FLAG_TRANSPARENT | 2,
+                                   shadowOptions);
+  }
 
   // Calculate car center position in view space
   dCarCenterX = fCarPosX - viewx;
@@ -2753,57 +2800,27 @@ void DrawCar(uint8 *pScrBuf, int iCarDesignIndex, float fDistance, int iAngle, c
 
       CarPol.iSurfaceType = uiTex;
 
-      // Render pol
-      if (g_pGameRenderer) {
-        GameRenderVertex verts[4];
-        for (int vi = 0; vi < 4; vi++) {
-          verts[vi].x = screenVertAy[vi]->world.fX;
-          verts[vi].y = screenVertAy[vi]->world.fY;
-          verts[vi].z = screenVertAy[vi]->world.fZ;
-          verts[vi].u = 0.0f;
-          verts[vi].v = 0.0f;
-        }
-        TextureHandle carPolyTexture = TEXTURE_HANDLE_INVALID;
-        if ((uiTex & SURFACE_FLAG_APPLY_TEXTURE) != 0 && iTexturesEnabled) {
-          iCartexOffset = car_texmap[uiCarDesignIdxTimes4 / 4];
-          iGfxSize = gfx_size;
-          carPolyTexture = game_render_get_texture_handle(g_pGameRenderer, iCartexOffset);
-        }
-        game_render_quad_world_subdivide_type(
-          g_pGameRenderer,
-          verts,
-          carPolyTexture,
-          uiTex,
-          iSubPolType,
-          fMinViewZ >= 1.0 ? 1.0f : 0.0f);
-      } else if (fMinViewZ >= 1.0) {
-        if ((uiTex & SURFACE_FLAG_APPLY_TEXTURE) != 0 && iTexturesEnabled) {
-          iCartexOffset = car_texmap[uiCarDesignIdxTimes4 / 4];
-          iGfxSize = gfx_size;
-          POLYTEX(cartex_vga[iCartexOffset - 1], pScreenBuffer, &CarPol, iCartexOffset, gfx_size);
-        } else {
-          POLYFLAT(pScreenBuffer, &CarPol);
-        }
-      } else {
-        iGfxSize = gfx_size;
-        subdivide(
-          pScreenBuffer,
-          &CarPol,
-          screenVertAy[0]->view.fX,
-          screenVertAy[0]->view.fY,
-          screenVertAy[0]->view.fZ,
-          screenVertAy[1]->view.fX,
-          screenVertAy[1]->view.fY,
-          screenVertAy[1]->view.fZ,
-          screenVertAy[2]->view.fX,
-          screenVertAy[2]->view.fY,
-          screenVertAy[2]->view.fZ,
-          screenVertAy[3]->view.fX,
-          screenVertAy[3]->view.fY,
-          screenVertAy[3]->view.fZ,
-          iSubPolType,
-          gfx_size);
+      // Render pol through the explicit scene seam. Missing renderers are
+      // handled at the seam as a no-op; there is no implicit legacy fallback.
+      SceneRenderVertex verts[4];
+      for (int vi = 0; vi < 4; vi++) {
+        verts[vi].x = screenVertAy[vi]->world.fX;
+        verts[vi].y = screenVertAy[vi]->world.fY;
+        verts[vi].z = screenVertAy[vi]->world.fZ;
+        verts[vi].u = 0.0f;
+        verts[vi].v = 0.0f;
       }
+      SceneTextureHandle carPolyTexture = SCENE_TEXTURE_HANDLE_INVALID;
+      if ((uiTex & SURFACE_FLAG_APPLY_TEXTURE) != 0 && iTexturesEnabled) {
+        iCartexOffset = car_texmap[uiCarDesignIdxTimes4 / 4];
+        iGfxSize = gfx_size;
+        carPolyTexture = scene_render_get_texture_handle(scene, iCartexOffset);
+      }
+      SceneRenderLegacyQuadOptions options = {
+        .subdivideType = iSubPolType,
+        .subThreshold = fMinViewZ >= 1.0 ? 1.0f : 0.0f,
+      };
+      scene_render_quad_world_legacy(scene, verts, carPolyTexture, uiTex, options);
       iDrawIdx += 12;
     } while (iDrawIdx < iTotalZOrderBytes);
   }

--- a/PROJECTS/ROLLER/func3.h
+++ b/PROJECTS/ROLLER/func3.h
@@ -2,6 +2,7 @@
 #define _ROLLER_FUNC3_H
 //-------------------------------------------------------------------------------------------------
 #include "types.h"
+typedef struct SceneRenderer SceneRenderer;
 //-------------------------------------------------------------------------------------------------
 
 typedef struct
@@ -63,7 +64,7 @@ void ChampionshipStandings();
 void TeamStandings();
 void ShowLapRecords();
 void show_3dmap(float fZ, int iElevation, int iYaw);
-void DrawCar(uint8 *pScrBuf, int iCarDesignIndex, float fDistance, int iAngle, char byAnimFrame);
+void DrawCar(SceneRenderer *scene, int iCarDesignIndex, float fDistance, int iAngle, char byAnimFrame);
 void championship_winner();
 void print_mem_used(const char *szMsg);
 uint8 *try_load_picture(const char *szFile);

--- a/PROJECTS/ROLLER/game_render.c
+++ b/PROJECTS/ROLLER/game_render.c
@@ -1,25 +1,35 @@
 #include "game_render.h"
 #include "game_render_software.h"
+#include "3d.h"
+#include "func2.h"
+#include "roller.h"
 
 #include <stdlib.h>
 
 struct GameRenderer {
     GameRenderMode mode;
     GameRendererSoftware *sw;
+    SceneRenderer *scene;
     SDL_GPUDevice *device;
     SDL_Window *window;
 };
 
 GameRenderer *game_render_create(SDL_GPUDevice *device, SDL_Window *window) {
     GameRenderer *r = calloc(1, sizeof(GameRenderer));
+    if (!r)
+        return NULL;
     r->device = device;
     r->window = window;
     r->sw = game_render_sw_create(device, window);
+    r->scene = scene_render_create(device, window);
     r->mode = GAME_RENDER_SOFTWARE;
     return r;
 }
 
 void game_render_destroy(GameRenderer *renderer) {
+    if (!renderer)
+        return;
+    scene_render_destroy(renderer->scene);
     game_render_sw_destroy(renderer->sw);
     free(renderer);
 }
@@ -50,24 +60,34 @@ void game_render_end_frame(GameRenderer *renderer) {
 
 void game_render_set_viewport(GameRenderer *renderer,
                               int x, int y, int w, int h) {
+    if (!renderer)
+        return;
     if (renderer->mode == GAME_RENDER_SOFTWARE)
         game_render_sw_set_viewport(renderer->sw, x, y, w, h);
+    scene_render_set_viewport(renderer->scene, x, y, w, h);
 }
 
 // Camera
 
 void game_render_set_camera(GameRenderer *renderer,
                             const GameRenderCamera *camera) {
+    if (!renderer || !camera)
+        return;
     if (renderer->mode == GAME_RENDER_SOFTWARE)
         game_render_sw_set_camera(renderer->sw, camera);
+    scene_render_set_camera(renderer->scene, camera);
 }
 
 // Projection
 
 void game_render_set_projection(GameRenderer *renderer,
                                 const GameRenderProjection *proj) {
+    if (!renderer || !proj)
+        return;
     if (renderer->mode == GAME_RENDER_SOFTWARE)
         game_render_sw_set_projection(renderer->sw, proj);
+    scene_render_set_target(renderer->scene, screen_pointer, winw, winw, winh);
+    scene_render_set_projection(renderer->scene, proj);
 }
 
 // Asset loading
@@ -78,14 +98,18 @@ TextureHandle game_render_load_texture(GameRenderer *renderer,
                                        int tex_idx, int gfx_size) {
     if (!renderer)
         return TEXTURE_HANDLE_INVALID;
-    return game_render_sw_load_texture(renderer->sw, pixelData,
-                                       width, height, tex_idx, gfx_size);
+    TextureHandle swHandle = game_render_sw_load_texture(renderer->sw, pixelData,
+                                                         width, height, tex_idx, gfx_size);
+    TextureHandle sceneHandle = scene_render_load_texture(renderer->scene, pixelData,
+                                                          width, height, tex_idx, gfx_size);
+    return sceneHandle != TEXTURE_HANDLE_INVALID ? sceneHandle : swHandle;
 }
 
 void game_render_free_texture(GameRenderer *renderer,
                               TextureHandle handle) {
     if (!renderer)
         return;
+    scene_render_free_texture(renderer->scene, handle);
     game_render_sw_free_texture(renderer->sw, handle);
 }
 
@@ -93,7 +117,8 @@ TextureHandle game_render_get_texture_handle(GameRenderer *renderer,
                                              int tex_idx) {
     if (!renderer)
         return TEXTURE_HANDLE_INVALID;
-    return game_render_sw_get_texture_handle(renderer->sw, tex_idx);
+    TextureHandle handle = scene_render_get_texture_handle(renderer->scene, tex_idx);
+    return handle != TEXTURE_HANDLE_INVALID ? handle : game_render_sw_get_texture_handle(renderer->sw, tex_idx);
 }
 
 TextureHandle game_render_load_blocks(GameRenderer *renderer, int slot,
@@ -139,10 +164,12 @@ void game_render_quad_world_subdivide_type(GameRenderer *renderer,
                                            float subThreshold) {
     if (!renderer)
         return;
-    if (renderer->mode == GAME_RENDER_SOFTWARE)
-        game_render_sw_quad_world_subdivide_type(renderer->sw, verts, handle,
-                                                 surfaceFlags, subdivideType,
-                                                 subThreshold);
+    SceneRenderLegacyQuadOptions options = {
+        .subdivideType = subdivideType,
+        .subThreshold = subThreshold,
+    };
+    scene_render_quad_world_legacy(renderer->scene, verts, handle,
+                                   surfaceFlags, options);
 }
 
 void game_render_draw_car(GameRenderer *renderer, int carIdx,

--- a/PROJECTS/ROLLER/game_render.h
+++ b/PROJECTS/ROLLER/game_render.h
@@ -5,44 +5,22 @@
 #include "types.h"
 #include "func3.h"
 #include "polyf.h"
+#include "scene_render.h"
 
 typedef enum {
     GAME_RENDER_GPU,
     GAME_RENDER_SOFTWARE
 } GameRenderMode;
 
-typedef int TextureHandle;
-#define TEXTURE_HANDLE_INVALID 0
+typedef SceneTextureHandle TextureHandle;
+#define TEXTURE_HANDLE_INVALID SCENE_TEXTURE_HANDLE_INVALID
 
-/* Texture bank indices passed to game_render_load_texture / get_texture_handle.
- * These identify which asset category a texture belongs to. */
-#define TEXTURE_BANK_TRACK    0
-#define TEXTURE_BANK_BUILDING 17
-#define TEXTURE_BANK_CARGEN   18
+typedef SceneRenderVertex GameRenderVertex;
+typedef SceneRenderCamera GameRenderCamera;
+typedef SceneRenderProjection GameRenderProjection;
 
-typedef struct {
-    float x, y, z;  // world-space position
-    float u, v;     // texture coordinates
-} GameRenderVertex;
-
-#define GAME_RENDER_SUBDIVIDE_TYPE_AUTO (-2147483647 - 1)
-#define GAME_RENDER_SUBDIVIDE_TYPE_CLOUD (-2147483647)
-
-typedef struct {
-    float viewX, viewY, viewZ;
-    float cosYaw, sinYaw;
-    float fovScale;
-} GameRenderCamera;
-
-// Column-major 3×3 view matrix + screen-space projection state.
-// view[col][row] maps to GLSL mat3 for direct GPU upload.
-typedef struct {
-    float view[3][3];
-    int   screenScale;   // 6-bit fixed-point scale (was scr_size)
-    int   centerX;       // projection origin X (was xbase)
-    int   centerY;       // projection origin Y (was ybase)
-    int   texHalfRes;    // 0=64×64, 1=32×32 (was gfx_size)
-} GameRenderProjection;
+#define GAME_RENDER_SUBDIVIDE_TYPE_AUTO SCENE_RENDER_SUBDIVIDE_TYPE_AUTO
+#define GAME_RENDER_SUBDIVIDE_TYPE_CLOUD SCENE_RENDER_SUBDIVIDE_TYPE_CLOUD
 
 typedef struct GameRenderer GameRenderer;
 

--- a/PROJECTS/ROLLER/menu_render_software.c
+++ b/PROJECTS/ROLLER/menu_render_software.c
@@ -4,13 +4,23 @@
 #include "roller.h"
 #include "sound.h"
 #include "carplans.h"
+#include "car.h"
+#include "graphics.h"
+#include "scene_render.h"
 #include <stdlib.h>
 #include <string.h>
 
 struct MenuRendererSoftware {
+    SceneRenderer *scene;
     int loadedCarIdx; // stored by _sw_load_car_mesh for DrawCar()
     int fadeInPending; // deferred fade-in (so content is drawn before the fade)
 };
+
+// Legacy software preview origin: old code rendered at scrbuf + 34640,
+// i.e. row 54, column 80 in the 640-wide frontend buffer. Keep the placement
+// explicit at the scene seam instead of smuggling it as a destination pointer.
+#define MENU_SW_CAR_PREVIEW_X 80
+#define MENU_SW_CAR_PREVIEW_Y 54
 
 // ---------------------------------------------------------------------------
 // Lifecycle
@@ -18,13 +28,18 @@ struct MenuRendererSoftware {
 
 MenuRendererSoftware *menu_render_sw_create(SDL_GPUDevice *device,
                                             SDL_Window *window) {
-    (void)device;
-    (void)window;
     MenuRendererSoftware *sw = calloc(1, sizeof(MenuRendererSoftware));
+    if (!sw)
+        return NULL;
+    sw->loadedCarIdx = -1;
+    sw->scene = scene_render_create(device, window);
     return sw;
 }
 
 void menu_render_sw_destroy(MenuRendererSoftware *sw) {
+    if (!sw)
+        return;
+    scene_render_destroy(sw->scene);
     free(sw);
 }
 
@@ -162,6 +177,13 @@ void menu_render_sw_load_car_mesh(MenuRendererSoftware *sw, int carIdx,
                                   const tColor *palette) {
     (void)palette;
     sw->loadedCarIdx = carIdx;
+    if (!sw->scene || carIdx < 0 || carIdx > CAR_DESIGN_DEATH)
+        return;
+    int texIdx = car_texmap[carIdx];
+    if (texIdx > 0 && cartex_vga[texIdx - 1]) {
+        scene_render_load_texture(sw->scene, cartex_vga[texIdx - 1],
+                                  256, 0, texIdx, gfx_size);
+    }
 }
 
 void menu_render_sw_free_car_mesh(MenuRendererSoftware *sw) {
@@ -176,12 +198,12 @@ void menu_render_sw_draw_car_preview(MenuRendererSoftware *sw, float angle,
     (void)carYaw;
     (void)destX;
     (void)destY;
-    (void)destW;
-    (void)destH;
-    // Original code: DrawCar(scrbuf + 34640, ...) — offset 34640 = row 54, col 80 in 640-wide buffer
     if (sw->loadedCarIdx < 0 || sw->loadedCarIdx > CAR_DESIGN_DEATH) return;
     if (!CarDesigns[sw->loadedCarIdx].pCoords) return;
-    DrawCar(scrbuf + 34640, sw->loadedCarIdx, distance, (int)angle, 0);
+    scene_render_set_target(sw->scene, scrbuf, winw, winw, winh);
+    scene_render_set_viewport(sw->scene, MENU_SW_CAR_PREVIEW_X,
+                              MENU_SW_CAR_PREVIEW_Y, destW, destH);
+    DrawCar(sw->scene, sw->loadedCarIdx, distance, (int)angle, 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/scene_render.c
+++ b/PROJECTS/ROLLER/scene_render.c
@@ -1,0 +1,95 @@
+#include "scene_render.h"
+#include "scene_render_software.h"
+
+#include <stdlib.h>
+
+struct SceneRenderer {
+    SceneRendererSoftware *sw;
+    SDL_GPUDevice *device;
+    SDL_Window *window;
+};
+
+SceneRenderer *scene_render_create(SDL_GPUDevice *device, SDL_Window *window) {
+    SceneRenderer *r = calloc(1, sizeof(SceneRenderer));
+    if (!r)
+        return NULL;
+    r->device = device;
+    r->window = window;
+    r->sw = scene_render_sw_create(device, window);
+    if (!r->sw) {
+        free(r);
+        return NULL;
+    }
+    return r;
+}
+
+void scene_render_destroy(SceneRenderer *renderer) {
+    if (!renderer)
+        return;
+    scene_render_sw_destroy(renderer->sw);
+    free(renderer);
+}
+
+void scene_render_set_target(SceneRenderer *renderer, uint8 *buffer,
+                             int stride, int width, int height) {
+    if (!renderer)
+        return;
+    scene_render_sw_set_target(renderer->sw, buffer, stride, width, height);
+}
+
+void scene_render_set_viewport(SceneRenderer *renderer,
+                               int x, int y, int w, int h) {
+    if (!renderer)
+        return;
+    scene_render_sw_set_viewport(renderer->sw, x, y, w, h);
+}
+
+void scene_render_set_camera(SceneRenderer *renderer,
+                             const SceneRenderCamera *camera) {
+    if (!renderer || !camera)
+        return;
+    scene_render_sw_set_camera(renderer->sw, camera);
+}
+
+void scene_render_set_projection(SceneRenderer *renderer,
+                                 const SceneRenderProjection *projection) {
+    if (!renderer || !projection)
+        return;
+    scene_render_sw_set_projection(renderer->sw, projection);
+}
+
+SceneTextureHandle scene_render_load_texture(SceneRenderer *renderer,
+                                             uint8 *pixelData,
+                                             int width, int height,
+                                             int tex_idx,
+                                             int texHalfRes) {
+    if (!renderer)
+        return SCENE_TEXTURE_HANDLE_INVALID;
+    return scene_render_sw_load_texture(renderer->sw, pixelData, width, height,
+                                        tex_idx, texHalfRes);
+}
+
+void scene_render_free_texture(SceneRenderer *renderer,
+                               SceneTextureHandle handle) {
+    if (!renderer)
+        return;
+    scene_render_sw_free_texture(renderer->sw, handle);
+}
+
+SceneTextureHandle scene_render_get_texture_handle(SceneRenderer *renderer,
+                                                   int tex_idx) {
+    if (!renderer)
+        return SCENE_TEXTURE_HANDLE_INVALID;
+    return scene_render_sw_get_texture_handle(renderer->sw, tex_idx);
+}
+
+void scene_render_quad_world_legacy(SceneRenderer *renderer,
+                                    const SceneRenderVertex verts[4],
+                                    SceneTextureHandle texture,
+                                    int surfaceFlags,
+                                    SceneRenderLegacyQuadOptions options) {
+    if (!renderer || !verts)
+        return;
+    scene_render_sw_quad_world_legacy(renderer->sw, verts, texture,
+                                      surfaceFlags, options);
+}

--- a/PROJECTS/ROLLER/scene_render.h
+++ b/PROJECTS/ROLLER/scene_render.h
@@ -1,0 +1,74 @@
+#ifndef SCENE_RENDER_H
+#define SCENE_RENDER_H
+
+#include <SDL3/SDL.h>
+#include "types.h"
+
+/* Texture bank indices passed to scene_render_load_texture / get_texture_handle.
+ * These identify which legacy asset category a texture belongs to. */
+#define TEXTURE_BANK_TRACK    0
+#define TEXTURE_BANK_BUILDING 17
+#define TEXTURE_BANK_CARGEN   18
+
+typedef struct SceneRenderer SceneRenderer;
+typedef int SceneTextureHandle;
+#define SCENE_TEXTURE_HANDLE_INVALID 0
+
+typedef struct {
+    float x, y, z;  // world-space position
+    float u, v;     // texture coordinates
+} SceneRenderVertex;
+
+#define SCENE_RENDER_SUBDIVIDE_TYPE_AUTO  (-2147483647 - 1)
+#define SCENE_RENDER_SUBDIVIDE_TYPE_CLOUD (-2147483647)
+
+typedef struct {
+    float viewX, viewY, viewZ;
+    float cosYaw, sinYaw;
+    float fovScale;
+} SceneRenderCamera;
+
+// Column-major 3×3 view matrix + screen-space projection state.
+// view[col][row] maps to GLSL mat3 for direct GPU upload.
+typedef struct {
+    float view[3][3];
+    int   screenScale;   // 6-bit fixed-point scale (was scr_size)
+    int   centerX;       // projection origin X (was xbase)
+    int   centerY;       // projection origin Y (was ybase)
+    int   texHalfRes;    // 0=64×64, 1=32×32 (was gfx_size)
+} SceneRenderProjection;
+
+typedef struct {
+    int subdivideType;
+    float subThreshold;
+} SceneRenderLegacyQuadOptions;
+
+SceneRenderer *scene_render_create(SDL_GPUDevice *device, SDL_Window *window);
+void scene_render_destroy(SceneRenderer *renderer);
+
+void scene_render_set_target(SceneRenderer *renderer, uint8 *buffer,
+                             int stride, int width, int height);
+void scene_render_set_viewport(SceneRenderer *renderer,
+                               int x, int y, int w, int h);
+void scene_render_set_camera(SceneRenderer *renderer,
+                             const SceneRenderCamera *camera);
+void scene_render_set_projection(SceneRenderer *renderer,
+                                 const SceneRenderProjection *projection);
+
+SceneTextureHandle scene_render_load_texture(SceneRenderer *renderer,
+                                             uint8 *pixelData,
+                                             int width, int height,
+                                             int tex_idx,
+                                             int texHalfRes);
+void scene_render_free_texture(SceneRenderer *renderer,
+                               SceneTextureHandle handle);
+SceneTextureHandle scene_render_get_texture_handle(SceneRenderer *renderer,
+                                                   int tex_idx);
+
+void scene_render_quad_world_legacy(SceneRenderer *renderer,
+                                    const SceneRenderVertex verts[4],
+                                    SceneTextureHandle texture,
+                                    int surfaceFlags,
+                                    SceneRenderLegacyQuadOptions options);
+
+#endif

--- a/PROJECTS/ROLLER/scene_render_software.c
+++ b/PROJECTS/ROLLER/scene_render_software.c
@@ -1,0 +1,296 @@
+#include "scene_render_software.h"
+#include "3d.h"
+#include "drawtrk3.h"
+#include "graphics.h"
+#include "func2.h"
+#include "polytex.h"
+#include "roller.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#define SCENE_RENDER_MAX_TEXTURE_SLOTS 32
+
+/* SubpolyType values passed to dodivide for texture routing.
+ * -1 = wide wall (2048x1024), 0 = standard track (1024x1024),
+ * 666 = building (other_texture[] lookup). */
+#define SUBPOLY_WALL     (-1)
+#define SUBPOLY_STANDARD   0
+#define SUBPOLY_BUILDING 666
+
+typedef struct {
+    uint8 *pixels;
+    int width;
+    int height;
+    int tex_idx;
+    int texHalfRes;
+    int in_use;
+} SceneTextureSlot;
+
+struct SceneRendererSoftware {
+    SceneRenderCamera camera;
+    SceneRenderProjection proj;
+
+    uint8 *targetBuffer;
+    int targetStride;
+    int targetWidth;
+    int targetHeight;
+    int viewportX;
+    int viewportY;
+    int viewportW;
+    int viewportH;
+
+    SceneTextureSlot texSlots[SCENE_RENDER_MAX_TEXTURE_SLOTS];
+    SceneTextureHandle texIdxToHandle[32];
+};
+
+static void scene_render_sw_bind_target(SceneRendererSoftware *sw) {
+    if (!sw || !sw->targetBuffer)
+        return;
+    screen_pointer = sw->targetBuffer + sw->viewportY * sw->targetStride + sw->viewportX;
+}
+
+SceneRendererSoftware *scene_render_sw_create(SDL_GPUDevice *device,
+                                              SDL_Window *window) {
+    (void)device;
+    (void)window;
+    SceneRendererSoftware *sw = calloc(1, sizeof(SceneRendererSoftware));
+    return sw;
+}
+
+void scene_render_sw_destroy(SceneRendererSoftware *sw) {
+    free(sw);
+}
+
+void scene_render_sw_set_target(SceneRendererSoftware *sw, uint8 *buffer,
+                                int stride, int width, int height) {
+    if (!sw)
+        return;
+    sw->targetBuffer = buffer;
+    sw->targetStride = stride;
+    sw->targetWidth = width;
+    sw->targetHeight = height;
+    if (sw->viewportW == 0 && sw->viewportH == 0) {
+        sw->viewportX = 0;
+        sw->viewportY = 0;
+        sw->viewportW = width;
+        sw->viewportH = height;
+    }
+    scene_render_sw_bind_target(sw);
+}
+
+void scene_render_sw_set_viewport(SceneRendererSoftware *sw,
+                                  int x, int y, int w, int h) {
+    if (!sw)
+        return;
+    sw->viewportX = x;
+    sw->viewportY = y;
+    sw->viewportW = w;
+    sw->viewportH = h;
+    scene_render_sw_bind_target(sw);
+}
+
+void scene_render_sw_set_camera(SceneRendererSoftware *sw,
+                                const SceneRenderCamera *camera) {
+    extern float viewx, viewy, viewz;
+    extern float fcos, fsin;
+    extern int VIEWDIST;
+    if (!sw || !camera)
+        return;
+    sw->camera = *camera;
+    viewx = camera->viewX;
+    viewy = camera->viewY;
+    viewz = camera->viewZ;
+    fcos = camera->cosYaw;
+    fsin = camera->sinYaw;
+    VIEWDIST = (int)camera->fovScale;
+}
+
+void scene_render_sw_set_projection(SceneRendererSoftware *sw,
+                                    const SceneRenderProjection *proj) {
+    extern float vk1, vk2, vk3, vk4, vk5, vk6, vk7, vk8, vk9;
+    extern int scr_size, xbase, ybase, gfx_size;
+    if (!sw || !proj)
+        return;
+    sw->proj = *proj;
+    // Write through to globals for legacy code (subdivide, POLYTEX, etc.)
+    vk1 = proj->view[0][0]; vk2 = proj->view[0][1]; vk3 = proj->view[0][2];
+    vk4 = proj->view[1][0]; vk5 = proj->view[1][1]; vk6 = proj->view[1][2];
+    vk7 = proj->view[2][0]; vk8 = proj->view[2][1]; vk9 = proj->view[2][2];
+    scr_size = proj->screenScale;
+    xbase = proj->centerX;
+    ybase = proj->centerY;
+    gfx_size = proj->texHalfRes;
+}
+
+SceneTextureHandle scene_render_sw_load_texture(SceneRendererSoftware *sw,
+                                                uint8 *pixelData,
+                                                int width, int height,
+                                                int tex_idx, int texHalfRes) {
+    if (!sw)
+        return SCENE_TEXTURE_HANDLE_INVALID;
+
+    if (tex_idx >= 0 && tex_idx < 32) {
+        SceneTextureHandle old = sw->texIdxToHandle[tex_idx];
+        if (old != SCENE_TEXTURE_HANDLE_INVALID)
+            scene_render_sw_free_texture(sw, old);
+    }
+
+    for (int i = 1; i < SCENE_RENDER_MAX_TEXTURE_SLOTS; i++) {
+        if (!sw->texSlots[i].in_use) {
+            sw->texSlots[i].pixels = pixelData;
+            sw->texSlots[i].width = width;
+            sw->texSlots[i].height = height;
+            sw->texSlots[i].tex_idx = tex_idx;
+            sw->texSlots[i].texHalfRes = texHalfRes;
+            sw->texSlots[i].in_use = 1;
+            if (tex_idx >= 0 && tex_idx < 32)
+                sw->texIdxToHandle[tex_idx] = i;
+            return (SceneTextureHandle)i;
+        }
+    }
+    return SCENE_TEXTURE_HANDLE_INVALID;
+}
+
+void scene_render_sw_free_texture(SceneRendererSoftware *sw,
+                                  SceneTextureHandle handle) {
+    if (!sw || handle <= 0 || handle >= SCENE_RENDER_MAX_TEXTURE_SLOTS)
+        return;
+    int tex_idx = sw->texSlots[handle].tex_idx;
+    if (tex_idx >= 0 && tex_idx < 32 && sw->texIdxToHandle[tex_idx] == handle)
+        sw->texIdxToHandle[tex_idx] = SCENE_TEXTURE_HANDLE_INVALID;
+    memset(&sw->texSlots[handle], 0, sizeof(SceneTextureSlot));
+}
+
+SceneTextureHandle scene_render_sw_get_texture_handle(SceneRendererSoftware *sw,
+                                                      int tex_idx) {
+    if (!sw)
+        return SCENE_TEXTURE_HANDLE_INVALID;
+    if (tex_idx >= 0 && tex_idx < 32)
+        return sw->texIdxToHandle[tex_idx];
+    return SCENE_TEXTURE_HANDLE_INVALID;
+}
+
+void scene_render_sw_quad_world_legacy(SceneRendererSoftware *sw,
+                                       const SceneRenderVertex *verts,
+                                       SceneTextureHandle handle,
+                                       int surfaceFlags,
+                                       SceneRenderLegacyQuadOptions options) {
+    if (!sw || !verts || !sw->targetBuffer)
+        return;
+
+    scene_render_sw_bind_target(sw);
+
+    const SceneRenderCamera *cam = &sw->camera;
+    const SceneRenderProjection *proj = &sw->proj;
+
+    int useCloudProjection = options.subdivideType == SCENE_RENDER_SUBDIVIDE_TYPE_CLOUD;
+    int subpolyType;
+    if (useCloudProjection) {
+        subpolyType = SUBPOLY_STANDARD;
+    } else if (options.subdivideType != SCENE_RENDER_SUBDIVIDE_TYPE_AUTO) {
+        subpolyType = options.subdivideType;
+    } else if (handle > 0 && handle < SCENE_RENDER_MAX_TEXTURE_SLOTS
+        && sw->texSlots[handle].in_use
+        && sw->texSlots[handle].tex_idx == TEXTURE_BANK_BUILDING) {
+        subpolyType = SUBPOLY_BUILDING;
+    } else if ((surfaceFlags & SURFACE_FLAG_TEXTURE_PAIR) && wide_on) {
+        subpolyType = SUBPOLY_WALL;
+    } else {
+        subpolyType = SUBPOLY_STANDARD;
+    }
+
+    tPolyParams poly;
+    poly.iSurfaceType = surfaceFlags;
+    poly.uiNumVerts = 4;
+
+    float subVx[4], subVy[4], subVz[4];
+
+    if (subpolyType == SUBPOLY_BUILDING) {
+        int iVx[4], iVy[4], iVz[4];
+        int clippedCount = 0;
+        for (int i = 0; i < 4; i++) {
+            double dx = floor((double)verts[i].x - cam->viewX);
+            double dy = floor((double)verts[i].y - cam->viewY);
+            double dz = floor((double)verts[i].z - cam->viewZ);
+            iVx[i] = (int)(dx * proj->view[0][0] + dy * proj->view[1][0] + dz * proj->view[2][0]);
+            iVy[i] = (int)(dx * proj->view[0][1] + dy * proj->view[1][1] + dz * proj->view[2][1]);
+            iVz[i] = (int)(dx * proj->view[0][2] + dy * proj->view[1][2] + dz * proj->view[2][2]);
+        }
+        int viewDist = (int)cam->fovScale;
+        for (int i = 0; i < 4; i++) {
+            if (iVz[i] < 80) {
+                iVz[i] = 80;
+                clippedCount++;
+            }
+            int xp = iVx[i] * viewDist / iVz[i] + proj->centerX;
+            int yp = iVy[i] * viewDist / iVz[i] + proj->centerY;
+            poly.vertices[i].x = (proj->screenScale * xp) >> 6;
+            poly.vertices[i].y = (proj->screenScale * (199 - yp)) >> 6;
+            subVx[i] = (float)iVx[i];
+            subVy[i] = (float)iVy[i];
+            subVz[i] = (float)iVz[i];
+        }
+        if (clippedCount >= 4)
+            return;
+    } else {
+        int useCarProjection = subpolyType >= 3;
+        double viewDist = (double)cam->fovScale;
+        for (int i = 0; i < 4; i++) {
+            double dx = (double)(verts[i].x - cam->viewX);
+            double dy = (double)(verts[i].y - cam->viewY);
+            double dz = (double)(verts[i].z - cam->viewZ);
+            float fVx = (float)(dx * proj->view[0][0] + dy * proj->view[1][0] + dz * proj->view[2][0]);
+            float fVy = (float)(dx * proj->view[0][1] + dy * proj->view[1][1] + dz * proj->view[2][1]);
+            double dCameraZ = dx * proj->view[0][2] + dy * proj->view[1][2] + dz * proj->view[2][2];
+            float fVz = (float)dCameraZ;
+            float fProjectedZ = fVz;
+            if (fProjectedZ < 80.0f) fProjectedZ = 80.0f;
+            double dInvZ = 1.0 / (double)fProjectedZ;
+            int xp;
+            int yp;
+            if (useCarProjection || useCloudProjection) {
+                xp = (int)(viewDist * (double)fVx * dInvZ + (double)proj->centerX);
+                yp = (int)(dInvZ * (viewDist * (double)fVy) + (double)proj->centerY);
+            } else {
+                xp = (int)round(viewDist * (double)fVx * dInvZ + (double)proj->centerX);
+                yp = (int)round(dInvZ * (viewDist * (double)fVy) + (double)proj->centerY);
+            }
+            poly.vertices[i].x = (xp * proj->screenScale) >> 6;
+            poly.vertices[i].y = (proj->screenScale * (199 - yp)) >> 6;
+            subVx[i] = fVx;
+            subVy[i] = fVy;
+            subVz[i] = (useCarProjection || useCloudProjection) ? fVz : (float)((int)round(dCameraZ));
+        }
+    }
+
+    if (subpolyType == SUBPOLY_WALL) set_starts(1u);
+
+    int useDirect = 0;
+    if (options.subThreshold > 0.0f) {
+        float minZ = subVz[0];
+        if (subVz[1] < minZ) minZ = subVz[1];
+        if (subVz[2] < minZ) minZ = subVz[2];
+        if (subVz[3] < minZ) minZ = subVz[3];
+        if (options.subThreshold <= minZ)
+            useDirect = 1;
+    }
+
+    if (useDirect && handle == SCENE_TEXTURE_HANDLE_INVALID) {
+        POLYFLAT(screen_pointer, &poly);
+    } else if (useDirect) {
+        SceneTextureSlot *slot = &sw->texSlots[handle];
+        POLYTEX(slot->pixels, screen_pointer, &poly,
+                slot->tex_idx, slot->texHalfRes);
+    } else {
+        subdivide(screen_pointer, &poly,
+                  subVx[0], subVy[0], subVz[0],
+                  subVx[1], subVy[1], subVz[1],
+                  subVx[2], subVy[2], subVz[2],
+                  subVx[3], subVy[3], subVz[3],
+                  subpolyType, proj->texHalfRes);
+    }
+
+    if (subpolyType == SUBPOLY_WALL) set_starts(0);
+}

--- a/PROJECTS/ROLLER/scene_render_software.h
+++ b/PROJECTS/ROLLER/scene_render_software.h
@@ -1,0 +1,37 @@
+#ifndef SCENE_RENDER_SOFTWARE_H
+#define SCENE_RENDER_SOFTWARE_H
+
+#include <SDL3/SDL.h>
+#include "scene_render.h"
+
+typedef struct SceneRendererSoftware SceneRendererSoftware;
+
+SceneRendererSoftware *scene_render_sw_create(SDL_GPUDevice *device,
+                                              SDL_Window *window);
+void scene_render_sw_destroy(SceneRendererSoftware *sw);
+
+void scene_render_sw_set_target(SceneRendererSoftware *sw, uint8 *buffer,
+                                int stride, int width, int height);
+void scene_render_sw_set_viewport(SceneRendererSoftware *sw,
+                                  int x, int y, int w, int h);
+void scene_render_sw_set_camera(SceneRendererSoftware *sw,
+                                const SceneRenderCamera *camera);
+void scene_render_sw_set_projection(SceneRendererSoftware *sw,
+                                    const SceneRenderProjection *proj);
+
+SceneTextureHandle scene_render_sw_load_texture(SceneRendererSoftware *sw,
+                                                uint8 *pixelData,
+                                                int width, int height,
+                                                int tex_idx, int texHalfRes);
+void scene_render_sw_free_texture(SceneRendererSoftware *sw,
+                                  SceneTextureHandle handle);
+SceneTextureHandle scene_render_sw_get_texture_handle(SceneRendererSoftware *sw,
+                                                      int tex_idx);
+
+void scene_render_sw_quad_world_legacy(SceneRendererSoftware *sw,
+                                       const SceneRenderVertex *verts,
+                                       SceneTextureHandle handle,
+                                       int surfaceFlags,
+                                       SceneRenderLegacyQuadOptions options);
+
+#endif

--- a/build.zig
+++ b/build.zig
@@ -64,6 +64,8 @@ pub fn build(b: *std.Build) void {
             "PROJECTS/ROLLER/menu_render_software.c",
             "PROJECTS/ROLLER/game_render.c",
             "PROJECTS/ROLLER/game_render_software.c",
+            "PROJECTS/ROLLER/scene_render.c",
+            "PROJECTS/ROLLER/scene_render_software.c",
             "PROJECTS/ROLLER/mouse.c",
             "PROJECTS/ROLLER/moving.c",
             "PROJECTS/ROLLER/network.c",

--- a/tests/scene_render_seam_check.py
+++ b/tests/scene_render_seam_check.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Static seam checks for issue #142.
+
+These checks pin the architectural dependency we are changing: frontend car
+previews must receive an explicit SceneRenderer and must not fall back to
+legacy software rasterization through g_pGameRenderer == NULL.
+"""
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(rel: str) -> str:
+    return (ROOT / rel).read_text()
+
+
+def extract_function(source: str, name: str) -> str:
+    match = re.search(rf"^[\w\s\*]+\b{name}\s*\([^)]*\)\s*\{{", source, re.M)
+    if not match:
+        raise AssertionError(f"function {name} not found")
+    start = match.start()
+    brace = source.find("{", match.end() - 1)
+    depth = 0
+    for pos in range(brace, len(source)):
+        ch = source[pos]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : pos + 1]
+    raise AssertionError(f"function {name} body not closed")
+
+
+def assert_true(cond: bool, msg: str) -> None:
+    if not cond:
+        raise AssertionError(msg)
+
+
+def main() -> int:
+    for rel in [
+        "PROJECTS/ROLLER/scene_render.h",
+        "PROJECTS/ROLLER/scene_render.c",
+        "PROJECTS/ROLLER/scene_render_software.h",
+        "PROJECTS/ROLLER/scene_render_software.c",
+    ]:
+        assert_true((ROOT / rel).exists(), f"missing {rel}")
+
+    func3_h = read("PROJECTS/ROLLER/func3.h")
+    assert_true(
+        "SceneRenderer *" in func3_h and "DrawCar(" in func3_h,
+        "DrawCar must take an explicit SceneRenderer * in func3.h",
+    )
+
+    func3 = read("PROJECTS/ROLLER/func3.c")
+    draw_car = extract_function(func3, "DrawCar")
+    for forbidden in ["g_pGameRenderer", "subdivide(", "POLYTEX("]:
+        assert_true(forbidden not in draw_car, f"DrawCar still uses {forbidden}")
+    # POLYFLAT is allowed elsewhere in func3.c, but not in the preview car path.
+    assert_true("POLYFLAT(" not in draw_car, "DrawCar still uses POLYFLAT directly")
+
+    winner_screen = extract_function(func3, "winner_screen")
+    assert_true("SceneRenderer *" in winner_screen, "winner_screen must own an explicit SceneRenderer")
+    assert_true("DrawCar(scene" in winner_screen, "winner_screen must pass its SceneRenderer to DrawCar")
+
+    menu_sw = read("PROJECTS/ROLLER/menu_render_software.c")
+    assert_true("SceneRenderer *scene" in menu_sw, "software menu renderer must own a SceneRenderer")
+    assert_true("scene_render_set_target" in menu_sw, "menu car preview must set an explicit scene target")
+    assert_true("DrawCar(sw->scene" in menu_sw, "menu car preview must pass SceneRenderer to DrawCar")
+    assert_true("DrawCar(scrbuf +" not in menu_sw, "menu car preview still uses magic pointer offset")
+
+    game_render = read("PROJECTS/ROLLER/game_render.c")
+    assert_true("SceneRenderer *scene" in game_render, "game renderer must own a SceneRenderer")
+    assert_true("scene_render_quad_world_legacy" in game_render, "game renderer must delegate world quads to scene_render")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AssertionError as exc:
+        print(f"scene_render_seam_check: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Add a `scene_render` facade/software adapter with explicit target, viewport, camera, projection, texture, and legacy world-quad APIs.
- Compose `game_render` with a `SceneRenderer` for world-space scene quads while preserving existing gameplay call sites.
- Route software menu and winner-screen car previews through explicit `SceneRenderer` instances; `DrawCar` no longer depends on `g_pGameRenderer` or direct preview fallback rasterization.

## Follow-up
- #143 tracks consolidating duplicated world-quad software logic behind `scene_render` composition before #116 is considered complete.

## Test Plan
- [x] `git diff --check`
- [x] `python3 tests/scene_render_seam_check.py`
- [x] `zig build`
- [x] `zig build test-snapshots`

Closes #142
