### PR TITLE
feat(#123): pass explicit car and sky render inputs

### DIFF
--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -1098,7 +1098,7 @@ void draw_road(uint8 *pScrPtr, int iCarIdx, unsigned int uiViewMode, int iCopyIm
       .texHalfRes = gfx_size,
   };
   game_render_set_projection(g_pGameRenderer, &proj);
-  game_render_draw_horizon(g_pGameRenderer);    // Draw sky/horizon background
+  game_render_draw_sky(g_pGameRenderer, &cam, &proj); // Draw sky/horizon background
   CalcVisibleTrack(iCarIdx, uiViewMode);        // Calculate which track segments are visible from current viewpoint
   DrawCars(iCarIdx, uiViewMode);                // Render all visible cars (excluding current player if in chase cam)
   CalcVisibleBuildings();                       // Calculate visibility and prepare building rendering data

--- a/PROJECTS/ROLLER/car.c
+++ b/PROJECTS/ROLLER/car.c
@@ -753,7 +753,9 @@ void DrawCars(int iCarIdx, int iViewMode)
 
 //-------------------------------------------------------------------------------------------------
 //000534A0
-void DisplayCar(int iCarIndex, uint8 *pScreenBuffer, float fDistanceToCar)
+void DisplayCarWithPose(int iCarIndex, uint8 *pScreenBuffer, float fDistanceToCar,
+                        const CarRenderPose *pose,
+                        const CarRenderOptions *options)
 {
   int iMotionX; // ebx
   int iMotionY; // esi
@@ -1075,6 +1077,7 @@ void DisplayCar(int iCarIndex, uint8 *pScreenBuffer, float fDistanceToCar)
   float fRotMat00; // [esp+24Ch] [ebp-4Ch]
   int iYaw; // [esp+250h] [ebp-48h]
   tCar *pCar; // [esp+254h] [ebp-44h]
+  tVec3 renderPosePos;
   float fPolygonVertex1Z; // [esp+264h] [ebp-34h]
   float fPolygonVertex1X; // [esp+268h] [ebp-30h]
   tAnimation *pAnms; // [esp+278h] [ebp-20h]
@@ -1085,6 +1088,7 @@ void DisplayCar(int iCarIndex, uint8 *pScreenBuffer, float fDistanceToCar)
   pScrBuf = pScreenBuffer;
   set_starts(0);
   pCar = &Car[iCarIndex];                       // Get pointer to car data structure
+  renderPosePos = pose->position;
   carDesignIndex = pCar->byCarDesignIdx;        // Get car design index from car data
   iNumCoords = CarDesigns[carDesignIndex].byNumCoords;
   pCarDesign = &CarDesigns[carDesignIndex];
@@ -1100,9 +1104,9 @@ void DisplayCar(int iCarIndex, uint8 *pScreenBuffer, float fDistanceToCar)
     iMotionY = pCar->iPitchMotion;
     iMotionZ = pCar->iYawMotion;
   }
-  nRoll = pCar->iRollCameraOffset + iMotionX + pCar->nRoll + pCar->iRollDynamicOffset;
-  iYawAngle = ((int16)iMotionZ + pCar->nYaw) & 0x3FFF;
-  iPitch = ((uint16)pCar->iPitchCameraOffset + (int16)iMotionY + (uint16)pCar->iPitchDynamicOffset + pCar->nPitch) & 0x3FFF;
+  nRoll = pCar->iRollCameraOffset + iMotionX + pose->roll + pCar->iRollDynamicOffset;
+  iYawAngle = ((int16)iMotionZ + pose->yaw) & 0x3FFF;
+  iPitch = ((uint16)pCar->iPitchCameraOffset + (int16)iMotionY + (uint16)pCar->iPitchDynamicOffset + pose->pitch) & 0x3FFF;
 
   fRotMat00 = tcos[iYawAngle] * tcos[iPitch];   // Calculate 3x3 rotation matrix from car orientation angles
   fRotMat01 = tsin[iYawAngle] * tcos[iPitch];
@@ -1116,14 +1120,15 @@ void DisplayCar(int iCarIndex, uint8 *pScreenBuffer, float fDistanceToCar)
   fRotMat20 = -tcos[iYawAngle] * fRotMat02 * tcos[iRoll] - tsin[iYawAngle] * tsin[iRoll];
   fRotMat11 = -tsin[iYawAngle] * fRotMat02 * tcos[iRoll] + tcos[iYawAngle] * tsin[iRoll];
   dRotMat22 = tcos[iPitch] * tcos[iRoll];
-  fCarPosX = pCar->pos.fX;
-  fCarPosY = pCar->pos.fY;
-  fZ = pCar->pos.fZ;
+  fCarPosX = renderPosePos.fX;
+  fCarPosY = renderPosePos.fY;
+  fZ = renderPosePos.fZ;
   fRotMat22Copy = (float)dRotMat22;
   fCarPosZ = fZ;
   iCurrChunk = pCar->nCurrChunk;
-  uiColorFrom = car_flat_remap[carDesignIndex].uiColorFrom;
-  uiColorTo = car_flat_remap[carDesignIndex].uiColorTo;
+  const uint8 *color_remap = options ? options->color_remap : NULL;
+  uiColorFrom = color_remap ? color_remap[0] : car_flat_remap[carDesignIndex].uiColorFrom;
+  uiColorTo = color_remap ? color_remap[1] : car_flat_remap[carDesignIndex].uiColorTo;
   pAnms = CarDesigns[carDesignIndex].pAnms;
   if (fDistanceToCar >= 8000.0 && VisibleCars >= 4 || (textures_off & 0x100) != 0 || fDistanceToCar <= 0.0 || (pCar->byStatusFlags & 2) != 0)
     goto LABEL_117;                             // Early exit if car is too far, invisible, or textures disabled
@@ -1217,7 +1222,7 @@ void DisplayCar(int iCarIndex, uint8 *pScreenBuffer, float fDistanceToCar)
   carpoint[3].fY = (float)dY;
 LABEL_28:
   if (pCar->nCurrChunk == -1) {
-    p_fX = &pCar->pos.fX;
+    p_fX = &renderPosePos.fX;
     uiCarWorldOffset = 0;
     dTransformMat22 = fRotMat22Copy;
     dTransformMat02 = fRotMat02;
@@ -1256,7 +1261,7 @@ LABEL_28:
       //++i;                                      // replace carpoint assignment with this in for loop
     }
   } else {
-    pCarPosPtr = &pCar->pos.fX;
+    pCarPosPtr = &renderPosePos.fX;
     iCornerIndex = 0;
     dTransformMat22_2 = fRotMat22Copy;
     dTransformMat02_2 = fRotMat02;
@@ -1928,7 +1933,7 @@ LABEL_117:
             if (byTextureIndex >= 4)
               uiTextureSurface = pAnimation->framesAy[iAnimationOffset / 4u];
             else
-              uiTextureSurface = pAnimation->framesAy[(char)pCar->byWheelAnimationFrame];
+              uiTextureSurface = pAnimation->framesAy[(char)(options ? options->anim_frame : 0)];
           }
           // SURFACE_FLAG_BACK
           if ((uiTextureSurface & SURFACE_FLAG_BACK) != 0)
@@ -2124,6 +2129,22 @@ LABEL_117:
       game_render_quad_screen(g_pGameRenderer, &CarPol, TEXTURE_HANDLE_INVALID, NULL);
     }
   }
+}
+
+void DisplayCar(int iCarIndex, uint8 *pScreenBuffer, float fDistanceToCar)
+{
+  tCar *pCar = &Car[iCarIndex];
+  CarRenderPose pose = {
+    .position = pCar->pos,
+    .yaw = pCar->nYaw,
+    .pitch = pCar->nPitch,
+    .roll = pCar->nRoll,
+  };
+  CarRenderOptions options = {
+    .anim_frame = pCar->byWheelAnimationFrame,
+    .color_remap = NULL,
+  };
+  DisplayCarWithPose(iCarIndex, pScreenBuffer, fDistanceToCar, &pose, &options);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/car.h
+++ b/PROJECTS/ROLLER/car.h
@@ -163,6 +163,20 @@ typedef struct
   int iType;
 } tCarSpray;
 
+typedef struct CarRenderPose
+{
+  tVec3 position;
+  int yaw;
+  int pitch;
+  int roll;
+} CarRenderPose;
+
+typedef struct CarRenderOptions
+{
+  int anim_frame;
+  const uint8 *color_remap;
+} CarRenderOptions;
+
 //-------------------------------------------------------------------------------------------------
 
 typedef struct
@@ -224,6 +238,9 @@ void InitCars();
 void placecars();
 void DrawCars(int iCarIdx, int iViewMode);
 void DisplayCar(int iCarIndex, uint8 *pScreenBuffer, float fDistanceToCar);
+void DisplayCarWithPose(int iCarIndex, uint8 *pScreenBuffer, float fDistanceToCar,
+                        const CarRenderPose *pose,
+                        const CarRenderOptions *options);
 int carZcmp(const void *pCar1, const void *pCar2);
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/drawtrk3.c
+++ b/PROJECTS/ROLLER/drawtrk3.c
@@ -2716,11 +2716,19 @@ LABEL_393:
           }
           goto LABEL_1271;
         case 0xB:
-          if (CarsLeft < 7 && CarsLeft > -3 || winner_mode || replaytype == 2 || g_bForceMaxDraw)
-            game_render_draw_car(g_pGameRenderer, iSectionNum,
-                                 Car[iSectionNum].nYaw, Car[iSectionNum].nPitch, Car[iSectionNum].nRoll,
-                                 Car[iSectionNum].pos.fX, Car[iSectionNum].pos.fY, Car[iSectionNum].pos.fZ,
-                                 0, NULL);
+          if (CarsLeft < 7 && CarsLeft > -3 || winner_mode || replaytype == 2 || g_bForceMaxDraw) {
+            GameRenderCarPose pose = {
+              .position = Car[iSectionNum].pos,
+              .yaw = Car[iSectionNum].nYaw,
+              .pitch = Car[iSectionNum].nPitch,
+              .roll = Car[iSectionNum].nRoll,
+            };
+            GameRenderCarOptions options = {
+              .anim_frame = Car[iSectionNum].byWheelAnimationFrame,
+              .color_remap = NULL,
+            };
+            game_render_draw_car(g_pGameRenderer, iSectionNum, &pose, &options);
+          }
           --CarsLeft;
           if (names_on && (names_on == 1 || human_control[iSectionNum]))
             --NamesLeft;

--- a/PROJECTS/ROLLER/game_render.c
+++ b/PROJECTS/ROLLER/game_render.c
@@ -179,18 +179,21 @@ void game_render_quad_world_subdivide_type(GameRenderer *renderer,
 }
 
 void game_render_draw_car(GameRenderer *renderer, int carIdx,
-                          int yaw, int pitch, int roll,
-                          float worldX, float worldY, float worldZ,
-                          int animFrame, const uint8 *color_remap) {
+                          const GameRenderCarPose *pose,
+                          const GameRenderCarOptions *options) {
+    if (!renderer || !pose)
+        return;
     if (renderer->mode == GAME_RENDER_SOFTWARE)
-        game_render_sw_draw_car(renderer->sw, carIdx, yaw, pitch, roll,
-                                worldX, worldY, worldZ, animFrame,
-                                color_remap);
+        game_render_sw_draw_car(renderer->sw, carIdx, pose, options);
 }
 
-void game_render_draw_horizon(GameRenderer *renderer) {
+void game_render_draw_sky(GameRenderer *renderer,
+                          const GameRenderCamera *camera,
+                          const GameRenderProjection *projection) {
+    if (!renderer || !camera || !projection)
+        return;
     if (renderer->mode == GAME_RENDER_SOFTWARE)
-        game_render_sw_draw_horizon(renderer->sw);
+        game_render_sw_draw_sky(renderer->sw, camera, projection);
 }
 
 void game_render_sprite(GameRenderer *renderer, int slot, int blockIdx,

--- a/PROJECTS/ROLLER/game_render.h
+++ b/PROJECTS/ROLLER/game_render.h
@@ -19,6 +19,18 @@ typedef SceneRenderVertex GameRenderVertex;
 typedef SceneRenderCamera GameRenderCamera;
 typedef SceneRenderProjection GameRenderProjection;
 
+typedef struct GameRenderCarPose {
+    tVec3 position;
+    int yaw;
+    int pitch;
+    int roll;
+} GameRenderCarPose;
+
+typedef struct GameRenderCarOptions {
+    int anim_frame;
+    const uint8 *color_remap;
+} GameRenderCarOptions;
+
 #define GAME_RENDER_SUBDIVIDE_TYPE_AUTO SCENE_RENDER_SUBDIVIDE_TYPE_AUTO
 #define GAME_RENDER_SUBDIVIDE_TYPE_CLOUD SCENE_RENDER_SUBDIVIDE_TYPE_CLOUD
 
@@ -97,12 +109,13 @@ void game_render_quad_world_subdivide_type(GameRenderer *renderer,
 
 // Draw — car mesh
 void game_render_draw_car(GameRenderer *renderer, int carIdx,
-                          int yaw, int pitch, int roll,
-                          float worldX, float worldY, float worldZ,
-                          int animFrame, const uint8 *color_remap);
+                          const GameRenderCarPose *pose,
+                          const GameRenderCarOptions *options);
 
-// Draw — horizon
-void game_render_draw_horizon(GameRenderer *renderer);
+// Draw — sky/horizon background
+void game_render_draw_sky(GameRenderer *renderer,
+                          const GameRenderCamera *camera,
+                          const GameRenderProjection *projection);
 
 // Draw — HUD sprites
 void game_render_sprite(GameRenderer *renderer, int slot, int blockIdx,

--- a/PROJECTS/ROLLER/game_render_software.c
+++ b/PROJECTS/ROLLER/game_render_software.c
@@ -219,23 +219,36 @@ void game_render_sw_quad_screen(GameRendererSoftware *sw, tPolyParams *poly,
 }
 
 void game_render_sw_draw_car(GameRendererSoftware *sw, int carIdx,
-                             int yaw, int pitch, int roll,
-                             float worldX, float worldY, float worldZ,
-                             int animFrame, const uint8 *color_remap) {
-    (void)yaw; (void)pitch; (void)roll;
-    (void)animFrame; (void)color_remap;
-    // Compute distance from camera to car for LOD.
-    // DisplayCar reads car state from global Car[] array.
+                             const GameRenderCarPose *pose,
+                             const GameRenderCarOptions *options) {
+    if (!sw || !pose)
+        return;
+    // Compute distance from camera to car for LOD using the explicit pose.
     const GameRenderCamera *cam = &sw->camera;
-    float dx = worldX - cam->viewX;
-    float dy = worldY - cam->viewY;
-    float dz = worldZ - cam->viewZ;
+    float dx = pose->position.fX - cam->viewX;
+    float dy = pose->position.fY - cam->viewY;
+    float dz = pose->position.fZ - cam->viewZ;
     float dist = sqrtf(dx * dx + dy * dy + dz * dz);
-    DisplayCar(carIdx, screen_pointer, dist);
+    CarRenderPose car_pose = {
+        .position = pose->position,
+        .yaw = pose->yaw,
+        .pitch = pose->pitch,
+        .roll = pose->roll,
+    };
+    CarRenderOptions car_options = {
+        .anim_frame = options ? options->anim_frame : 0,
+        .color_remap = options ? options->color_remap : NULL,
+    };
+    DisplayCarWithPose(carIdx, screen_pointer, dist, &car_pose, &car_options);
 }
 
-void game_render_sw_draw_horizon(GameRendererSoftware *sw) {
-    (void)sw;
+void game_render_sw_draw_sky(GameRendererSoftware *sw,
+                             const GameRenderCamera *camera,
+                             const GameRenderProjection *projection) {
+    if (!sw || !camera || !projection)
+        return;
+    game_render_sw_set_camera(sw, camera);
+    game_render_sw_set_projection(sw, projection);
     DrawHorizon(screen_pointer);
 }
 

--- a/PROJECTS/ROLLER/game_render_software.h
+++ b/PROJECTS/ROLLER/game_render_software.h
@@ -49,10 +49,11 @@ void game_render_sw_quad_screen(GameRendererSoftware *sw, tPolyParams *poly,
                          TextureHandle handle,
                          const uint8 *palette_remap);
 void game_render_sw_draw_car(GameRendererSoftware *sw, int carIdx,
-                             int yaw, int pitch, int roll,
-                             float worldX, float worldY, float worldZ,
-                             int animFrame, const uint8 *color_remap);
-void game_render_sw_draw_horizon(GameRendererSoftware *sw);
+                             const GameRenderCarPose *pose,
+                             const GameRenderCarOptions *options);
+void game_render_sw_draw_sky(GameRendererSoftware *sw,
+                              const GameRenderCamera *camera,
+                              const GameRenderProjection *projection);
 void game_render_sw_sprite(GameRendererSoftware *sw, int slot, int blockIdx,
                            int x, int y, int transparentColorIndex,
                            const tColor *palette);

--- a/tests/scene_render_seam_check.py
+++ b/tests/scene_render_seam_check.py
@@ -81,6 +81,7 @@ def main() -> int:
     assert_true("DrawCar(sw->scene" in menu_sw, "menu car preview must pass SceneRenderer to DrawCar")
     assert_true("DrawCar(scrbuf +" not in menu_sw, "menu car preview still uses magic pointer offset")
 
+    game_render_h = read("PROJECTS/ROLLER/game_render.h")
     game_render = read("PROJECTS/ROLLER/game_render.c")
     assert_true("SceneRenderer *scene" in game_render, "game renderer must own a SceneRenderer")
     assert_true("scene_render_quad_world_legacy" in game_render, "game renderer must delegate world quads to scene_render")
@@ -94,6 +95,26 @@ def main() -> int:
         "game_render_set_target" in game_render,
         "game renderer must expose an explicit target binding API",
     )
+    assert_true("typedef struct GameRenderCarPose" in game_render_h, "public API must name the grouped car pose")
+    assert_true("typedef struct GameRenderCarOptions" in game_render_h, "public API must name grouped car options")
+    assert_true("tVec3 position" in game_render_h, "car pose position field must use idiomatic C naming")
+    assert_true("int anim_frame" in game_render_h, "car options animation field must use idiomatic C naming")
+    assert_true("const GameRenderCarPose *pose" in game_render_h, "game_render_draw_car must receive a grouped pose")
+    assert_true("const GameRenderCarOptions *options" in game_render_h, "game_render_draw_car must receive grouped options")
+    assert_true("worldX" not in game_render_h and "animFrame" not in game_render_h,
+                "game_render_draw_car must not expose raw/camelCase car render arguments")
+
+    assert_true("game_render_draw_horizon" not in game_render_h, "public API must replace game_render_draw_horizon")
+    assert_true("game_render_draw_sky(GameRenderer *renderer," in game_render_h, "public API must expose game_render_draw_sky")
+    assert_true(
+        "const GameRenderCamera *camera" in game_render_h and "const GameRenderProjection *projection" in game_render_h,
+        "game_render_draw_sky must receive explicit camera/projection",
+    )
+    draw_sky = extract_function(game_render, "game_render_draw_sky")
+    assert_true(
+        "game_render_sw_draw_sky(renderer->sw, camera, projection)" in draw_sky,
+        "game_render_draw_sky must pass explicit camera/projection to software backend",
+    )
 
     game_render_sw_h = read("PROJECTS/ROLLER/game_render_software.h")
     game_render_sw = read("PROJECTS/ROLLER/game_render_software.c")
@@ -105,6 +126,25 @@ def main() -> int:
         assert_true(forbidden not in game_render_sw_h, f"{forbidden} still exposed by game_render_software.h")
         assert_true(forbidden not in game_render_sw, f"{forbidden} still implemented by game_render_software.c")
     assert_true("subdivide(" not in game_render_sw, "game_render_software still owns direct subdivide dispatch")
+    assert_true("game_render_sw_draw_horizon" not in game_render_sw_h, "software API must replace draw_horizon")
+    assert_true("game_render_sw_draw_horizon" not in game_render_sw, "software backend must replace draw_horizon")
+    assert_true("game_render_sw_draw_sky(GameRendererSoftware *sw," in game_render_sw_h, "software API must expose draw_sky")
+    assert_true(
+        "const GameRenderCamera *camera" in game_render_sw_h and "const GameRenderProjection *projection" in game_render_sw_h,
+        "software draw_sky must receive camera/projection",
+    )
+    sw_draw_sky = extract_function(game_render_sw, "game_render_sw_draw_sky")
+    assert_true("game_render_sw_set_camera(sw, camera)" in sw_draw_sky, "software sky draw must install supplied camera before DrawHorizon")
+    assert_true("game_render_sw_set_projection(sw, projection)" in sw_draw_sky, "software sky draw must install supplied projection before DrawHorizon")
+
+    assert_true("const GameRenderCarPose *pose" in game_render_sw_h,
+                "software car draw must receive grouped public pose")
+    assert_true("const GameRenderCarOptions *options" in game_render_sw_h,
+                "software car draw must receive grouped public options")
+    sw_draw_car = extract_function(game_render_sw, "game_render_sw_draw_car")
+    for used in ["pose", "options"]:
+        assert_true(f"(void){used}" not in sw_draw_car, f"game_render_sw_draw_car still discards {used}")
+    assert_true("DisplayCarWithPose" in sw_draw_car, "software car draw must pass explicit pose to legacy car renderer")
 
     drawtrk3_h = read("PROJECTS/ROLLER/drawtrk3.h")
     drawtrk3 = read("PROJECTS/ROLLER/drawtrk3.c")
@@ -121,6 +161,25 @@ def main() -> int:
     assert_true("subdivide(" not in car, "car.c must not call subdivide directly")
     assert_true("POLYTEX(" not in car, "car.c must not use POLYTEX fallback directly")
     assert_true("POLYFLAT(" not in car, "car.c must not use POLYFLAT fallback directly")
+    car_h = read("PROJECTS/ROLLER/car.h")
+    assert_true("typedef struct CarRenderPose" in car_h,
+                "legacy car API must name the grouped render pose")
+    assert_true("typedef struct CarRenderOptions" in car_h,
+                "legacy car API must name grouped render options")
+    assert_true("tVec3 position" in car_h and "int anim_frame" in car_h,
+                "legacy grouped car render fields must use idiomatic C naming")
+    assert_true("const CarRenderPose *pose" in car_h,
+                "DisplayCarWithPose must receive grouped car pose")
+    assert_true("const CarRenderOptions *options" in car_h,
+                "DisplayCarWithPose must receive grouped car options")
+    display_car_pose_start = car.find("void DisplayCarWithPose")
+    assert_true(display_car_pose_start >= 0, "car.c must define DisplayCarWithPose")
+    display_car_pose_end = car.find("\nvoid DisplayCar(", display_car_pose_start)
+    assert_true(display_car_pose_end > display_car_pose_start, "DisplayCar wrapper must remain separate from DisplayCarWithPose")
+    display_car_pose = car[display_car_pose_start:display_car_pose_end]
+    for forbidden_pose_read in ["pCar->pos", "pCar->nYaw", "pCar->nPitch", "pCar->nRoll", "pCar->byWheelAnimationFrame"]:
+        assert_true(forbidden_pose_read not in display_car_pose,
+                    f"DisplayCarWithPose still reads pose from Car[] via {forbidden_pose_read}")
     assert_true(
         re.search(r"^static\s+void\s+subdivide\s*\(", scene_render_sw, re.M),
         "scene_render_software.c must own static subdivide",


### PR DESCRIPTION
## Summary
- replace `game_render_draw_horizon` with `game_render_draw_sky` that takes explicit camera/projection inputs
- route software sky rendering through the supplied camera/projection state before legacy `DrawHorizon`
- add grouped car render pose/options structs with idiomatic C field names (`position`, `anim_frame`)
- make `game_render_sw_draw_car` and the legacy car bridge use grouped explicit pose/animation/remap inputs instead of discarding them
- extend seam checks for the sky API and grouped explicit car pose boundary

## Test Plan
- [x] `python3 tests/scene_render_seam_check.py`
- [x] `zig build`
- [x] `zig build test-snapshots` (worktree has ignored `fatdata` symlink to local asset root)

Closes #123