### PR TITLE
Introduce render_queue_3d start-light tracer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(roller
     PROJECTS/ROLLER/control.c
     PROJECTS/ROLLER/date.c
     PROJECTS/ROLLER/drawtrk3.c
+    PROJECTS/ROLLER/render_queue_3d.c
     PROJECTS/ROLLER/engines.c
     PROJECTS/ROLLER/frontend_config.c
     PROJECTS/ROLLER/frontend_data.c

--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -125,7 +125,6 @@ float ptan[16384];          //001110F0
 float tcos[16384];          //00121128
 char buffer[128];           //00131228
 uint8 blank_line[640];      //001312A8
-tTrackZOrderEntry TrackView[6500]; //00131528
 int p_joyk1[2];             //0013E048
 int p_joyk2[2];             //0013E050
 tMemBlock mem_blocks[MEM_BLOCK_COUNT];  //0013E058

--- a/PROJECTS/ROLLER/3d.h
+++ b/PROJECTS/ROLLER/3d.h
@@ -276,7 +276,6 @@ extern float ptan[16384];
 extern float tcos[16384];
 extern char buffer[128];
 extern uint8 blank_line[640];
-extern tTrackZOrderEntry TrackView[6500];
 extern int p_joyk1[2];
 extern int p_joyk2[2];
 extern tMemBlock mem_blocks[MEM_BLOCK_COUNT];

--- a/PROJECTS/ROLLER/drawtrk3.c
+++ b/PROJECTS/ROLLER/drawtrk3.c
@@ -9,6 +9,8 @@
 #include "building.h"
 #include "tower.h"
 #include "roller.h"
+#include "render_queue_3d.h"
+#define TrackView (render_queue_3d_entries(render_queue_3d_global()))
 #include <math.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -2333,29 +2335,27 @@ LABEL_393:
       num_bits = iBuildingCmdIndex + 1;
     } while (iBuildingNext != -1);
   }
+  render_queue_3d_set_legacy_count(render_queue_3d_global(), num_bits);
   if (countdown > -72 && replaytype != 2 && game_type != 2 && !winner_mode)// Process starting lights for rendering (if countdown active)
   {
     iLightIndex = 0;
-    pLightRenderCmd = &TrackView[num_bits];
     iLightArrayOffset = 3 * iChaseCamIdx_1;
     do {
       fLightZ = (SLight[0][iLightArrayOffset].currentPos.fX - viewx) * vk3
         + (SLight[0][iLightArrayOffset].currentPos.fY - viewy) * vk6
         + (SLight[0][iLightArrayOffset].currentPos.fZ - viewz) * vk9;
       if (fLightZ > 0.0) {
-        pLightRenderCmd->nRenderPriority = 14;
-        ++pLightRenderCmd;
         fLightDepth = fLightZ;
-        iLightCmdIndex = num_bits;
-        pLightRenderCmd[-1].nChunkIdx = iLightIndex;
-        pLightRenderCmd[-1].fZDepth = fLightDepth;
-        num_bits = iLightCmdIndex + 1;
+        pLightRenderCmd = render_queue_3d_add_start_light(render_queue_3d_global(), iLightIndex, fLightDepth);
+        if (pLightRenderCmd != NULL)
+          num_bits = render_queue_3d_count(render_queue_3d_global());
       }
       ++iLightIndex;
       ++iLightArrayOffset;
     } while (iLightIndex < 3);
   }
-  qsort(TrackView, num_bits, 8u, Zcmp);// Fifth phase: Sort render list by Z-depth and render objects
+  render_queue_3d_set_legacy_count(render_queue_3d_global(), num_bits);
+  render_queue_3d_sort(render_queue_3d_global());// Fifth phase: Sort render list by Z-depth and render objects
   iRenderObjectIndex = 0;
   if (num_bits > 0) {
     iIndexTmp1 = 144 * iChaseCamIdx_1;
@@ -2792,27 +2792,7 @@ int facing_ok(float fX0, float fY0, float fZ0,
 //00027A10
 int Zcmp(const void *pTrackView1, const void *pTrackView2)
 {
-  int iRenderPriorityCmp2; // edx
-  int iRenderPriorityCmp1; // ebx
-  float fZCmp2; // [esp+0h] [ebp-Ch]
-  float fZCmp1; // [esp+4h] [ebp-8h]
-
-  const tTrackZOrderEntry *pTrackZ1 = (const tTrackZOrderEntry *)pTrackView1;
-  const tTrackZOrderEntry *pTrackZ2 = (const tTrackZOrderEntry *)pTrackView2;
-
-  fZCmp1 = pTrackZ1->fZDepth;
-  fZCmp2 = pTrackZ2->fZDepth;
-  iRenderPriorityCmp2 = pTrackZ2->nRenderPriority;
-  iRenderPriorityCmp1 = pTrackZ1->nRenderPriority;
-  if (fZCmp1 < (double)fZCmp2)
-    return -1;
-  if (fZCmp1 == fZCmp2) {
-    if (iRenderPriorityCmp1 == iRenderPriorityCmp2)
-      return 0;
-    if (iRenderPriorityCmp1 >= iRenderPriorityCmp2)
-      return -1;
-  }
-  return 1;
+  return render_queue_3d_compare_legacy_z_order(pTrackView1, pTrackView2);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/render_queue_3d.c
+++ b/PROJECTS/ROLLER/render_queue_3d.c
@@ -1,0 +1,113 @@
+#include "render_queue_3d.h"
+#include <stdlib.h>
+//-------------------------------------------------------------------------------------------------
+
+static RenderQueue3D g_RenderQueue3D;
+
+//-------------------------------------------------------------------------------------------------
+
+RenderQueue3D *render_queue_3d_global(void)
+{
+  return &g_RenderQueue3D;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void render_queue_3d_clear(RenderQueue3D *pQueue)
+{
+  pQueue->count = 0;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+tTrackZOrderEntry *render_queue_3d_entries(RenderQueue3D *pQueue)
+{
+  return pQueue->entries;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+int render_queue_3d_count(const RenderQueue3D *pQueue)
+{
+  return pQueue->count;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void render_queue_3d_set_legacy_count(RenderQueue3D *pQueue, int iCount)
+{
+  pQueue->count = iCount;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+static tTrackZOrderEntry *render_queue_3d_add(RenderQueue3D *pQueue,
+                                              int iLegacyPriority,
+                                              int iChunkIdx,
+                                              float fZDepth)
+{
+  tTrackZOrderEntry *pEntry;
+
+  if (pQueue->count >= RENDER_QUEUE_3D_CAPACITY)
+    return NULL;
+
+  pEntry = &pQueue->entries[pQueue->count];
+  pEntry->nRenderPriority = (int16)iLegacyPriority;
+  pEntry->nChunkIdx = (int16)iChunkIdx;
+  pEntry->fZDepth = fZDepth;
+  ++pQueue->count;
+
+  return pEntry;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+tTrackZOrderEntry *render_queue_3d_add_legacy_priority(RenderQueue3D *pQueue,
+                                                       int iLegacyPriority,
+                                                       int iChunkIdx,
+                                                       float fZDepth)
+{
+  if (iLegacyPriority == RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY)
+    return NULL;
+
+  return render_queue_3d_add(pQueue, iLegacyPriority, iChunkIdx, fZDepth);
+}
+
+//-------------------------------------------------------------------------------------------------
+
+tTrackZOrderEntry *render_queue_3d_add_start_light(RenderQueue3D *pQueue,
+                                                   int iLightIdx,
+                                                   float fZDepth)
+{
+  (void)RENDER_COMMAND_3D_KIND_START_LIGHT;
+  return render_queue_3d_add(pQueue, RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY, iLightIdx, fZDepth);
+}
+
+//-------------------------------------------------------------------------------------------------
+
+int render_queue_3d_compare_legacy_z_order(const void *pCommand1, const void *pCommand2)
+{
+  const tTrackZOrderEntry *pTrackZ1 = (const tTrackZOrderEntry *)pCommand1;
+  const tTrackZOrderEntry *pTrackZ2 = (const tTrackZOrderEntry *)pCommand2;
+  const float fZCmp1 = pTrackZ1->fZDepth;
+  const float fZCmp2 = pTrackZ2->fZDepth;
+  const int iRenderPriorityCmp1 = pTrackZ1->nRenderPriority;
+  const int iRenderPriorityCmp2 = pTrackZ2->nRenderPriority;
+
+  if (fZCmp1 < (double)fZCmp2)
+    return -1;
+  if (fZCmp1 == fZCmp2) {
+    if (iRenderPriorityCmp1 == iRenderPriorityCmp2)
+      return 0;
+    if (iRenderPriorityCmp1 >= iRenderPriorityCmp2)
+      return -1;
+  }
+  return 1;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void render_queue_3d_sort(RenderQueue3D *pQueue)
+{
+  qsort(pQueue->entries, pQueue->count, sizeof(pQueue->entries[0]), render_queue_3d_compare_legacy_z_order);
+}

--- a/PROJECTS/ROLLER/render_queue_3d.h
+++ b/PROJECTS/ROLLER/render_queue_3d.h
@@ -1,0 +1,46 @@
+#ifndef _ROLLER_RENDER_QUEUE_3D_H
+#define _ROLLER_RENDER_QUEUE_3D_H
+//-------------------------------------------------------------------------------------------------
+#include "3d.h"
+//-------------------------------------------------------------------------------------------------
+
+#define RENDER_QUEUE_3D_CAPACITY 6500
+#define RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY 14
+
+// Only implemented gameplay-3D command kinds are named here. Legacy priorities stay on the
+// temporary compatibility path until their renderers migrate to typed queue submission APIs.
+typedef enum
+{
+  RENDER_COMMAND_3D_KIND_START_LIGHT = 0
+} RenderCommand3DKind;
+
+typedef struct
+{
+  tTrackZOrderEntry entries[RENDER_QUEUE_3D_CAPACITY];
+  int count;
+} RenderQueue3D;
+
+//-------------------------------------------------------------------------------------------------
+
+RenderQueue3D *render_queue_3d_global(void);
+void render_queue_3d_clear(RenderQueue3D *pQueue);
+tTrackZOrderEntry *render_queue_3d_entries(RenderQueue3D *pQueue);
+int render_queue_3d_count(const RenderQueue3D *pQueue);
+void render_queue_3d_set_legacy_count(RenderQueue3D *pQueue, int iCount);
+
+// Temporary compatibility API for unmigrated legacy render priorities. Priority 14 is reserved for
+// start lights and must use render_queue_3d_add_start_light().
+tTrackZOrderEntry *render_queue_3d_add_legacy_priority(RenderQueue3D *pQueue,
+                                                       int iLegacyPriority,
+                                                       int iChunkIdx,
+                                                       float fZDepth);
+
+tTrackZOrderEntry *render_queue_3d_add_start_light(RenderQueue3D *pQueue,
+                                                   int iLightIdx,
+                                                   float fZDepth);
+
+int render_queue_3d_compare_legacy_z_order(const void *pCommand1, const void *pCommand2);
+void render_queue_3d_sort(RenderQueue3D *pQueue);
+
+//-------------------------------------------------------------------------------------------------
+#endif

--- a/build.zig
+++ b/build.zig
@@ -42,6 +42,7 @@ pub fn build(b: *std.Build) void {
             "PROJECTS/ROLLER/control.c",
             "PROJECTS/ROLLER/date.c",
             "PROJECTS/ROLLER/drawtrk3.c",
+            "PROJECTS/ROLLER/render_queue_3d.c",
             "PROJECTS/ROLLER/engines.c",
             "PROJECTS/ROLLER/frontend_config.c",
             "PROJECTS/ROLLER/frontend_data.c",
@@ -162,6 +163,8 @@ pub fn build(b: *std.Build) void {
     });
     run_step.dependOn(&wildmidi_config_install.step);
 
+    configureRenderQueue3DTests(b, target, optimize, c_flags);
+
     // Snapshot regression harness: drive the snapshot binary serially across
     // every configured intro replay, writing PNGs straight into the
     // checked-in baseline directory, then run `git diff --exit-code` against
@@ -171,6 +174,55 @@ pub fn build(b: *std.Build) void {
     // refresh run produces a clean exit before the developer commits.
     configureSnapshotTests(b, exe, assets_path);
 }
+
+fn configureRenderQueue3DTests(
+    b: *Build,
+    target: ResolvedTarget,
+    optimize: OptimizeMode,
+    c_flags: []const []const u8,
+) void {
+    const test_mod = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    const sdl = b.dependency("sdl", .{
+        .target = target,
+        .optimize = optimize,
+        .lto = .none,
+    });
+    test_mod.addIncludePath(sdl.builder.path("include"));
+    test_mod.addIncludePath(b.path("PROJECTS/ROLLER"));
+    test_mod.addCSourceFiles(.{
+        .flags = c_flags,
+        .files = &.{
+            "PROJECTS/ROLLER/render_queue_3d.c",
+            "tests/render_queue_3d_test.c",
+        },
+    });
+
+    const test_exe = b.addExecutable(.{
+        .name = "render_queue_3d_test",
+        .root_module = test_mod,
+    });
+    const run_unit = b.addRunArtifact(test_exe);
+
+    const seam_check = b.addSystemCommand(&.{
+        "python3",
+        "tools/check_render_queue_3d_seams.py",
+    });
+
+    const render_queue_tests = b.step(
+        "test-render-queue-3d",
+        "Run render_queue_3d sort/mapping tests and seam checks",
+    );
+    render_queue_tests.dependOn(&run_unit.step);
+    render_queue_tests.dependOn(&seam_check.step);
+
+    const test_step = b.step("test", "Run focused unit and seam tests");
+    test_step.dependOn(render_queue_tests);
+}
+
 
 const SnapshotReplay = struct {
     name: []const u8,

--- a/tests/render_queue_3d_test.c
+++ b/tests/render_queue_3d_test.c
@@ -1,0 +1,52 @@
+#include "render_queue_3d.h"
+#include <assert.h>
+#include <stddef.h>
+
+static void test_sort_matches_legacy_zcmp(void)
+{
+  RenderQueue3D queue;
+  render_queue_3d_clear(&queue);
+
+  assert(render_queue_3d_add_legacy_priority(&queue, 5, 100, 10.0f) != NULL);
+  assert(render_queue_3d_add_legacy_priority(&queue, 2, 101, 4.0f) != NULL);
+  assert(render_queue_3d_add_legacy_priority(&queue, 13, 102, 10.0f) != NULL);
+  assert(render_queue_3d_add_legacy_priority(&queue, 6, 103, 10.0f) != NULL);
+
+  render_queue_3d_sort(&queue);
+
+  assert(render_queue_3d_count(&queue) == 4);
+  assert(queue.entries[0].nChunkIdx == 101);
+  assert(queue.entries[1].nChunkIdx == 102);
+  assert(queue.entries[2].nChunkIdx == 103);
+  assert(queue.entries[3].nChunkIdx == 100);
+}
+
+static void test_start_light_priority_mapping_and_legacy_guard(void)
+{
+  RenderQueue3D queue;
+  tTrackZOrderEntry *entry;
+  render_queue_3d_clear(&queue);
+
+  entry = render_queue_3d_add_start_light(&queue, 2, 42.0f);
+  assert(entry != NULL);
+  assert(entry->nRenderPriority == RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY);
+  assert(entry->nChunkIdx == 2);
+  assert(entry->fZDepth == 42.0f);
+  assert(render_queue_3d_count(&queue) == 1);
+
+  assert(render_queue_3d_add_legacy_priority(&queue,
+                                             RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY,
+                                             7,
+                                             42.0f) == NULL);
+  assert(render_queue_3d_count(&queue) == 1);
+}
+
+int main(int argc, const char **argv, const char **envp)
+{
+  (void)argc;
+  (void)argv;
+  (void)envp;
+  test_sort_matches_legacy_zcmp();
+  test_start_light_priority_mapping_and_legacy_guard();
+  return 0;
+}

--- a/tools/check_render_queue_3d_seams.py
+++ b/tools/check_render_queue_3d_seams.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Pin the first render_queue_3d tracer-bullet migration.
+
+Start lights are the first gameplay-3D command migrated away from raw legacy
+priority submission. Keep priority 14 out of drawtrk3's direct writes and out of
+the temporary legacy-priority compatibility path.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DRAWTRK3 = ROOT / "PROJECTS" / "ROLLER" / "drawtrk3.c"
+
+
+def fail(message: str) -> int:
+    print(f"render_queue_3d seam check failed: {message}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    drawtrk3 = DRAWTRK3.read_text(encoding="utf-8")
+
+    if re.search(r"\.nRenderPriority\s*=\s*14\b|->nRenderPriority\s*=\s*14\b", drawtrk3):
+        return fail("drawtrk3.c writes start-light legacy priority 14 directly")
+
+    if "render_queue_3d_add_start_light" not in drawtrk3:
+        return fail("drawtrk3.c does not submit start lights through render_queue_3d_add_start_light")
+
+    legacy_priority_14 = re.compile(r"render_queue_3d_add_legacy_priority\s*\([^;]*\b14\b", re.DOTALL)
+    for path in (ROOT / "PROJECTS" / "ROLLER").glob("*.c"):
+        if path.name == "render_queue_3d.c":
+            continue
+        text = path.read_text(encoding="utf-8")
+        if legacy_priority_14.search(text):
+            return fail(f"{path.relative_to(ROOT)} submits priority 14 through legacy compatibility API")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- introduce `render_queue_3d.{c,h}` as the gameplay 3D sorted command-list wrapper
- migrate start-light submissions to `render_queue_3d_add_start_light(...)`
- keep legacy sorting compatibility and add guardrails against priority-14 legacy submissions

## Tests
- `zig build test-render-queue-3d`
- `zig build test`
- `zig build`
- `zig build test-snapshots -Dscratch=true`

Closes #153
