### PR TITLE
Route building commands through render_queue_3d

### DIFF
--- a/PROJECTS/ROLLER/drawtrk3.c
+++ b/PROJECTS/ROLLER/drawtrk3.c
@@ -848,9 +848,6 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
   int iNamesDisplayCount; // eax
   tVisibleBuilding *pVisibleBuildingsPtr; // ebx
   tTrackZOrderEntry *pBuildingRenderCmd; // edx
-  int iBuildingCmdIndex; // ecx
-  //int iBuildingValue; // eax
-  int iBuildingNext; // esi
   int iLightIndex; // ebx
   tTrackZOrderEntry *pLightRenderCmd; // ecx
   int iLightArrayOffset; // edx
@@ -2316,26 +2313,18 @@ LABEL_357:
     goto LABEL_392;
   }
 LABEL_393:
+  render_queue_3d_set_legacy_count(render_queue_3d_global(), num_bits);
   pVisibleBuildingsPtr = &VisibleBuildings[0];     // Process building objects for rendering
   if (VisibleBuildings[0].iBuildingIdx != -1) {
-    pBuildingRenderCmd = &TrackView[num_bits];
     do {
-      iBuildingCmdIndex = num_bits;
-      //iBuildingValue = pVisibleBuildingsPtr->fDepth;
-      pBuildingRenderCmd->nRenderPriority = 13;
-      //fOffsetTmp1 = iBuildingValue;
-      //LOWORD(iBuildingValue) = pVisibleBuildingsPtr->iBuildingIdx;
-      pBuildingRenderCmd->nChunkIdx = pVisibleBuildingsPtr->iBuildingIdx;
-      //pBuildingRenderCmd->nChunkIdx = LOWORD(iBuildingValue);
-      pBuildingRenderCmd->fZDepth = pVisibleBuildingsPtr->fDepth;
-      //pBuildingRenderCmd->fZDepth = fOffsetTmp1;
+      pBuildingRenderCmd = render_queue_3d_add_building(render_queue_3d_global(),
+                                                        pVisibleBuildingsPtr->iBuildingIdx,
+                                                        pVisibleBuildingsPtr->fDepth);
+      if (pBuildingRenderCmd != NULL)
+        num_bits = render_queue_3d_count(render_queue_3d_global());
       ++pVisibleBuildingsPtr;
-      ++pBuildingRenderCmd;
-      iBuildingNext = pVisibleBuildingsPtr->iBuildingIdx;
-      num_bits = iBuildingCmdIndex + 1;
-    } while (iBuildingNext != -1);
+    } while (pVisibleBuildingsPtr->iBuildingIdx != -1);
   }
-  render_queue_3d_set_legacy_count(render_queue_3d_global(), num_bits);
   if (countdown > -72 && replaytype != 2 && game_type != 2 && !winner_mode)// Process starting lights for rendering (if countdown active)
   {
     iLightIndex = 0;

--- a/PROJECTS/ROLLER/render_queue_3d.c
+++ b/PROJECTS/ROLLER/render_queue_3d.c
@@ -67,10 +67,23 @@ tTrackZOrderEntry *render_queue_3d_add_legacy_priority(RenderQueue3D *pQueue,
                                                        int iChunkIdx,
                                                        float fZDepth)
 {
-  if (iLegacyPriority == RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY)
+  switch (iLegacyPriority) {
+  case RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY:
     return NULL;
+  }
 
   return render_queue_3d_add(pQueue, iLegacyPriority, iChunkIdx, fZDepth);
+}
+
+//-------------------------------------------------------------------------------------------------
+
+tTrackZOrderEntry *render_queue_3d_add_building(RenderQueue3D *pQueue,
+                                                int iBuildingIdx,
+                                                float fZDepth)
+{
+  (void)RENDER_COMMAND_3D_KIND_BUILDING;
+  return render_queue_3d_add(pQueue, RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY, iBuildingIdx, fZDepth);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/render_queue_3d.h
+++ b/PROJECTS/ROLLER/render_queue_3d.h
@@ -5,13 +5,15 @@
 //-------------------------------------------------------------------------------------------------
 
 #define RENDER_QUEUE_3D_CAPACITY 6500
+#define RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY 13
 #define RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY 14
 
 // Only implemented gameplay-3D command kinds are named here. Legacy priorities stay on the
 // temporary compatibility path until their renderers migrate to typed queue submission APIs.
 typedef enum
 {
-  RENDER_COMMAND_3D_KIND_START_LIGHT = 0
+  RENDER_COMMAND_3D_KIND_BUILDING = 0,
+  RENDER_COMMAND_3D_KIND_START_LIGHT
 } RenderCommand3DKind;
 
 typedef struct
@@ -28,12 +30,17 @@ tTrackZOrderEntry *render_queue_3d_entries(RenderQueue3D *pQueue);
 int render_queue_3d_count(const RenderQueue3D *pQueue);
 void render_queue_3d_set_legacy_count(RenderQueue3D *pQueue, int iCount);
 
-// Temporary compatibility API for unmigrated legacy render priorities. Priority 14 is reserved for
-// start lights and must use render_queue_3d_add_start_light().
+// Temporary compatibility API for unmigrated legacy render priorities. Priorities with named
+// command APIs must use those APIs instead.
 tTrackZOrderEntry *render_queue_3d_add_legacy_priority(RenderQueue3D *pQueue,
                                                        int iLegacyPriority,
                                                        int iChunkIdx,
                                                        float fZDepth);
+
+tTrackZOrderEntry *render_queue_3d_add_building(RenderQueue3D *pQueue,
+                                                int iBuildingIdx,
+                                                float fZDepth);
+
 
 tTrackZOrderEntry *render_queue_3d_add_start_light(RenderQueue3D *pQueue,
                                                    int iLightIdx,

--- a/tests/render_queue_3d_test.c
+++ b/tests/render_queue_3d_test.c
@@ -9,7 +9,7 @@ static void test_sort_matches_legacy_zcmp(void)
 
   assert(render_queue_3d_add_legacy_priority(&queue, 5, 100, 10.0f) != NULL);
   assert(render_queue_3d_add_legacy_priority(&queue, 2, 101, 4.0f) != NULL);
-  assert(render_queue_3d_add_legacy_priority(&queue, 13, 102, 10.0f) != NULL);
+  assert(render_queue_3d_add_building(&queue, 102, 10.0f) != NULL);
   assert(render_queue_3d_add_legacy_priority(&queue, 6, 103, 10.0f) != NULL);
 
   render_queue_3d_sort(&queue);
@@ -20,6 +20,27 @@ static void test_sort_matches_legacy_zcmp(void)
   assert(queue.entries[2].nChunkIdx == 103);
   assert(queue.entries[3].nChunkIdx == 100);
 }
+
+static void test_building_priority_mapping_and_legacy_guard(void)
+{
+  RenderQueue3D queue;
+  tTrackZOrderEntry *entry;
+  render_queue_3d_clear(&queue);
+
+  entry = render_queue_3d_add_building(&queue, 17, 123.0f);
+  assert(entry != NULL);
+  assert(entry->nRenderPriority == RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY);
+  assert(entry->nChunkIdx == 17);
+  assert(entry->fZDepth == 123.0f);
+  assert(render_queue_3d_count(&queue) == 1);
+
+  assert(render_queue_3d_add_legacy_priority(&queue,
+                                             RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY,
+                                             7,
+                                             123.0f) == NULL);
+  assert(render_queue_3d_count(&queue) == 1);
+}
+
 
 static void test_start_light_priority_mapping_and_legacy_guard(void)
 {
@@ -47,6 +68,7 @@ int main(int argc, const char **argv, const char **envp)
   (void)argv;
   (void)envp;
   test_sort_matches_legacy_zcmp();
+  test_building_priority_mapping_and_legacy_guard();
   test_start_light_priority_mapping_and_legacy_guard();
   return 0;
 }

--- a/tools/check_render_queue_3d_seams.py
+++ b/tools/check_render_queue_3d_seams.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Pin the first render_queue_3d tracer-bullet migration.
+"""Pin migrated render_queue_3d command seams.
 
-Start lights are the first gameplay-3D command migrated away from raw legacy
-priority submission. Keep priority 14 out of drawtrk3's direct writes and out of
-the temporary legacy-priority compatibility path.
+Buildings and start lights have migrated away from raw legacy priority submission.
+Keep priorities 13 and 14 out of drawtrk3's direct writes and out of the temporary
+legacy-priority compatibility path.
 """
 from __future__ import annotations
 
@@ -23,19 +23,25 @@ def fail(message: str) -> int:
 def main() -> int:
     drawtrk3 = DRAWTRK3.read_text(encoding="utf-8")
 
+    if re.search(r"\.nRenderPriority\s*=\s*13\b|->nRenderPriority\s*=\s*13\b", drawtrk3):
+        return fail("drawtrk3.c writes building legacy priority 13 directly")
+
     if re.search(r"\.nRenderPriority\s*=\s*14\b|->nRenderPriority\s*=\s*14\b", drawtrk3):
         return fail("drawtrk3.c writes start-light legacy priority 14 directly")
+
+    if "render_queue_3d_add_building" not in drawtrk3:
+        return fail("drawtrk3.c does not submit buildings through render_queue_3d_add_building")
 
     if "render_queue_3d_add_start_light" not in drawtrk3:
         return fail("drawtrk3.c does not submit start lights through render_queue_3d_add_start_light")
 
-    legacy_priority_14 = re.compile(r"render_queue_3d_add_legacy_priority\s*\([^;]*\b14\b", re.DOTALL)
+    legacy_named_priority = re.compile(r"render_queue_3d_add_legacy_priority\s*\([^;]*\b(?:13|14)\b", re.DOTALL)
     for path in (ROOT / "PROJECTS" / "ROLLER").glob("*.c"):
         if path.name == "render_queue_3d.c":
             continue
         text = path.read_text(encoding="utf-8")
-        if legacy_priority_14.search(text):
-            return fail(f"{path.relative_to(ROOT)} submits priority 14 through legacy compatibility API")
+        if legacy_named_priority.search(text):
+            return fail(f"{path.relative_to(ROOT)} submits priority 13 or 14 through legacy compatibility API")
 
     return 0
 


### PR DESCRIPTION
## Summary
- add a named building command kind/API to `render_queue_3d`
- route visible building submissions through `render_queue_3d_add_building(...)`
- block building priority `13` from the temporary legacy-priority API
- extend focused queue tests and seam checks for building submissions

## Snapshots
- Snapshot baselines are unchanged.

## Tests
- `zig build test-render-queue-3d`
- `zig build`
- `zig build test`
- `zig build test-snapshots -Dscratch=true`
- `zig build test-snapshots`

Closes #154
