### PR TITLE
Route car commands through render_queue_3d

### DIFF
--- a/PROJECTS/ROLLER/drawtrk3.c
+++ b/PROJECTS/ROLLER/drawtrk3.c
@@ -839,6 +839,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
   tTrackZOrderEntry *pCarRenderCmd; // eax
   int iCarDrawOrderStatus; // edx
   float iCarDrawOrderIndex; // edx
+  int iCarCommandIdx; // edx
   int iCarProcessingFlag; // ecx
   int iCarsRenderedCount; // esi
   int iCarLoopIndex; // ebx
@@ -854,6 +855,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
   float fLightDepth; // eax
   int iLightCmdIndex; // esi
   tTrackZOrderEntry *pRenderCommand; // eax
+  const RenderCommand3D *pTypedRenderCommand; // eax
   int iSectionNum; // esi
   int iSectionCommand; // eax
   float iSectionTypeIndex; // eax
@@ -1699,6 +1701,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
   }
   iTrackLoopCounter = TrackSize;                // Second phase: Build render list by traversing track backwards
   num_bits = 0;
+  render_queue_3d_clear(render_queue_3d_global());
   if (TrackSize >= 0) {
     while (iTrackLoopCounter > first_size && iTrackLoopCounter < gap_size) {
     LABEL_356:
@@ -2237,22 +2240,34 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
     goto LABEL_356;
   }
 LABEL_357:
+  render_queue_3d_set_legacy_count(render_queue_3d_global(), num_bits);
   iCarIndex = 0;                                // Third phase: Process car objects for rendering
   if (numcars > 0) {
     iCarArrayIndex = 0;
-    pCarRenderCmd = &TrackView[num_bits];
     do {
       iCarDrawOrderStatus = car_draw_order[iCarArrayIndex].iChunkIdx;
       if (iCarDrawOrderStatus == -3 || iCarDrawOrderStatus >= 0) {
         iCarDrawOrderIndex = car_draw_order[iCarArrayIndex].fMinZDepth;
-        pCarRenderCmd->nRenderPriority = 11;
         fOffsetTmp1 = iCarDrawOrderIndex;
         iCarProcessingFlag = cars_drawn;
-        pCarRenderCmd->nChunkIdx = car_draw_order[iCarArrayIndex].iCarIdx;
-        pCarRenderCmd->fZDepth = fOffsetTmp1;
-        ++pCarRenderCmd;
-        cars_drawn = iCarProcessingFlag + 1;
-        ++num_bits;
+        iCarCommandIdx = car_draw_order[iCarArrayIndex].iCarIdx;
+        {
+          GameRenderCarPose pose = {
+            .position = Car[iCarCommandIdx].pos,
+            .yaw = Car[iCarCommandIdx].nYaw,
+            .pitch = Car[iCarCommandIdx].nPitch,
+            .roll = Car[iCarCommandIdx].nRoll,
+          };
+          GameRenderCarOptions options = {
+            .anim_frame = Car[iCarCommandIdx].byWheelAnimationFrame,
+            .color_remap = NULL,
+          };
+          pCarRenderCmd = render_queue_3d_add_car(render_queue_3d_global(), iCarCommandIdx, fOffsetTmp1, &pose, &options);
+        }
+        if (pCarRenderCmd != NULL) {
+          cars_drawn = iCarProcessingFlag + 1;
+          num_bits = render_queue_3d_count(render_queue_3d_global());
+        }
       }
       ++iCarIndex;
       ++iCarArrayIndex;
@@ -2313,7 +2328,6 @@ LABEL_357:
     goto LABEL_392;
   }
 LABEL_393:
-  render_queue_3d_set_legacy_count(render_queue_3d_global(), num_bits);
   pVisibleBuildingsPtr = &VisibleBuildings[0];     // Process building objects for rendering
   if (VisibleBuildings[0].iBuildingIdx != -1) {
     do {
@@ -2343,13 +2357,13 @@ LABEL_393:
       ++iLightArrayOffset;
     } while (iLightIndex < 3);
   }
-  render_queue_3d_set_legacy_count(render_queue_3d_global(), num_bits);
   render_queue_3d_sort(render_queue_3d_global());// Fifth phase: Sort render list by Z-depth and render objects
   iRenderObjectIndex = 0;
   if (num_bits > 0) {
     iIndexTmp1 = 144 * iChaseCamIdx_1;
     while (1) {
       pRenderCommand = &TrackView[num_bits - 1 - iRenderObjectIndex];
+      pTypedRenderCommand = render_queue_3d_command_at(render_queue_3d_global(), num_bits - 1 - iRenderObjectIndex);
       fRenderDepth = pRenderCommand->fZDepth;
       iSectionNum = pRenderCommand->nChunkIdx;
       pScreenCoord_1 = NULL;
@@ -2705,22 +2719,32 @@ LABEL_393:
           }
           goto LABEL_1271;
         case 0xB:
-          if (CarsLeft < 7 && CarsLeft > -3 || winner_mode || replaytype == 2 || g_bForceMaxDraw) {
-            GameRenderCarPose pose = {
-              .position = Car[iSectionNum].pos,
-              .yaw = Car[iSectionNum].nYaw,
-              .pitch = Car[iSectionNum].nPitch,
-              .roll = Car[iSectionNum].nRoll,
-            };
-            GameRenderCarOptions options = {
-              .anim_frame = Car[iSectionNum].byWheelAnimationFrame,
-              .color_remap = NULL,
-            };
-            game_render_draw_car(g_pGameRenderer, iSectionNum, &pose, &options);
+          {
+            int iCarRenderIdx = iSectionNum;
+            GameRenderCarPose pose;
+            GameRenderCarOptions options;
+            const GameRenderCarPose *pCarPose;
+            const GameRenderCarOptions *pCarOptions;
+            if (pTypedRenderCommand != NULL && pTypedRenderCommand->kind == RENDER_COMMAND_3D_KIND_CAR) {
+              iCarRenderIdx = pTypedRenderCommand->payload.car.car_idx;
+              pCarPose = &pTypedRenderCommand->payload.car.pose;
+              pCarOptions = &pTypedRenderCommand->payload.car.options;
+            } else {
+              pose.position = Car[iSectionNum].pos;
+              pose.yaw = Car[iSectionNum].nYaw;
+              pose.pitch = Car[iSectionNum].nPitch;
+              pose.roll = Car[iSectionNum].nRoll;
+              options.anim_frame = Car[iSectionNum].byWheelAnimationFrame;
+              options.color_remap = NULL;
+              pCarPose = &pose;
+              pCarOptions = &options;
+            }
+            if (CarsLeft < 7 && CarsLeft > -3 || winner_mode || replaytype == 2 || g_bForceMaxDraw)
+              game_render_draw_car(g_pGameRenderer, iCarRenderIdx, pCarPose, pCarOptions);
+            --CarsLeft;
+            if (names_on && (names_on == 1 || human_control[iCarRenderIdx]))
+              --NamesLeft;
           }
-          --CarsLeft;
-          if (names_on && (names_on == 1 || human_control[iSectionNum]))
-            --NamesLeft;
           goto LABEL_1271;
         case 0xC:
           DrawTower(iSectionNum, pScrPtr_1);

--- a/PROJECTS/ROLLER/render_queue_3d.c
+++ b/PROJECTS/ROLLER/render_queue_3d.c
@@ -4,6 +4,13 @@
 
 static RenderQueue3D g_RenderQueue3D;
 
+typedef struct
+{
+  tTrackZOrderEntry entry;
+  RenderCommand3D command;
+  int has_typed_command;
+} RenderQueue3DSortEntry;
+
 //-------------------------------------------------------------------------------------------------
 
 RenderQueue3D *render_queue_3d_global(void)
@@ -27,6 +34,17 @@ tTrackZOrderEntry *render_queue_3d_entries(RenderQueue3D *pQueue)
 
 //-------------------------------------------------------------------------------------------------
 
+const RenderCommand3D *render_queue_3d_command_at(const RenderQueue3D *pQueue, int iIndex)
+{
+  if (iIndex < 0 || iIndex >= pQueue->count)
+    return NULL;
+  if (!pQueue->has_typed_command[iIndex])
+    return NULL;
+  return &pQueue->commands[iIndex];
+}
+
+//-------------------------------------------------------------------------------------------------
+
 int render_queue_3d_count(const RenderQueue3D *pQueue)
 {
   return pQueue->count;
@@ -36,6 +54,16 @@ int render_queue_3d_count(const RenderQueue3D *pQueue)
 
 void render_queue_3d_set_legacy_count(RenderQueue3D *pQueue, int iCount)
 {
+  int iCommandIndex;
+
+  if (iCount < 0)
+    iCount = 0;
+  if (iCount > RENDER_QUEUE_3D_CAPACITY)
+    iCount = RENDER_QUEUE_3D_CAPACITY;
+
+  for (iCommandIndex = 0; iCommandIndex < iCount; ++iCommandIndex)
+    pQueue->has_typed_command[iCommandIndex] = 0;
+
   pQueue->count = iCount;
 }
 
@@ -55,6 +83,7 @@ static tTrackZOrderEntry *render_queue_3d_add(RenderQueue3D *pQueue,
   pEntry->nRenderPriority = (int16)iLegacyPriority;
   pEntry->nChunkIdx = (int16)iChunkIdx;
   pEntry->fZDepth = fZDepth;
+  pQueue->has_typed_command[pQueue->count] = 0;
   ++pQueue->count;
 
   return pEntry;
@@ -68,6 +97,7 @@ tTrackZOrderEntry *render_queue_3d_add_legacy_priority(RenderQueue3D *pQueue,
                                                        float fZDepth)
 {
   switch (iLegacyPriority) {
+  case RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY:
     return NULL;
@@ -82,9 +112,52 @@ tTrackZOrderEntry *render_queue_3d_add_building(RenderQueue3D *pQueue,
                                                 int iBuildingIdx,
                                                 float fZDepth)
 {
-  (void)RENDER_COMMAND_3D_KIND_BUILDING;
-  return render_queue_3d_add(pQueue, RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY, iBuildingIdx, fZDepth);
+  tTrackZOrderEntry *pEntry = render_queue_3d_add(pQueue, RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY, iBuildingIdx, fZDepth);
+  if (pEntry != NULL) {
+    RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
+    pCommand->kind = RENDER_COMMAND_3D_KIND_BUILDING;
+    pCommand->payload.building.building_idx = iBuildingIdx;
+    pCommand->payload.building.depth = fZDepth;
+    pQueue->has_typed_command[pQueue->count - 1] = 1;
+  }
+  return pEntry;
 }
+
+tTrackZOrderEntry *render_queue_3d_add_car(RenderQueue3D *pQueue,
+                                           int iCarIdx,
+                                           float fZDepth,
+                                           const GameRenderCarPose *pPose,
+                                           const GameRenderCarOptions *pOptions)
+{
+  tTrackZOrderEntry *pEntry = render_queue_3d_add(pQueue, RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY, iCarIdx, fZDepth);
+  if (pEntry != NULL) {
+    RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
+    pCommand->kind = RENDER_COMMAND_3D_KIND_CAR;
+    pCommand->payload.car.car_idx = iCarIdx;
+    pCommand->payload.car.depth = fZDepth;
+    if (pPose != NULL) {
+      pCommand->payload.car.pose = *pPose;
+    } else {
+      pCommand->payload.car.pose.position.fX = 0.0f;
+      pCommand->payload.car.pose.position.fY = 0.0f;
+      pCommand->payload.car.pose.position.fZ = 0.0f;
+      pCommand->payload.car.pose.yaw = 0;
+      pCommand->payload.car.pose.pitch = 0;
+      pCommand->payload.car.pose.roll = 0;
+    }
+    if (pOptions != NULL) {
+      pCommand->payload.car.options = *pOptions;
+    } else {
+      pCommand->payload.car.options.anim_frame = 0;
+      pCommand->payload.car.options.color_remap = NULL;
+    }
+    pQueue->has_typed_command[pQueue->count - 1] = 1;
+  }
+  return pEntry;
+}
+
+//-------------------------------------------------------------------------------------------------
+
 
 //-------------------------------------------------------------------------------------------------
 
@@ -92,8 +165,15 @@ tTrackZOrderEntry *render_queue_3d_add_start_light(RenderQueue3D *pQueue,
                                                    int iLightIdx,
                                                    float fZDepth)
 {
-  (void)RENDER_COMMAND_3D_KIND_START_LIGHT;
-  return render_queue_3d_add(pQueue, RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY, iLightIdx, fZDepth);
+  tTrackZOrderEntry *pEntry = render_queue_3d_add(pQueue, RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY, iLightIdx, fZDepth);
+  if (pEntry != NULL) {
+    RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
+    pCommand->kind = RENDER_COMMAND_3D_KIND_START_LIGHT;
+    pCommand->payload.start_light.light_idx = iLightIdx;
+    pCommand->payload.start_light.depth = fZDepth;
+    pQueue->has_typed_command[pQueue->count - 1] = 1;
+  }
+  return pEntry;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -120,7 +200,44 @@ int render_queue_3d_compare_legacy_z_order(const void *pCommand1, const void *pC
 
 //-------------------------------------------------------------------------------------------------
 
+static int render_queue_3d_compare_sort_entries(const void *pCommand1, const void *pCommand2)
+{
+  const RenderQueue3DSortEntry *pSortEntry1 = (const RenderQueue3DSortEntry *)pCommand1;
+  const RenderQueue3DSortEntry *pSortEntry2 = (const RenderQueue3DSortEntry *)pCommand2;
+  return render_queue_3d_compare_legacy_z_order(&pSortEntry1->entry, &pSortEntry2->entry);
+}
+
+//-------------------------------------------------------------------------------------------------
+
 void render_queue_3d_sort(RenderQueue3D *pQueue)
 {
-  qsort(pQueue->entries, pQueue->count, sizeof(pQueue->entries[0]), render_queue_3d_compare_legacy_z_order);
+  int iCommandIndex;
+  RenderQueue3DSortEntry *pSortEntries;
+
+  if (pQueue->count <= 1)
+    return;
+
+  pSortEntries = (RenderQueue3DSortEntry *)malloc(sizeof(*pSortEntries) * pQueue->count);
+  if (pSortEntries == NULL) {
+    qsort(pQueue->entries, pQueue->count, sizeof(pQueue->entries[0]), render_queue_3d_compare_legacy_z_order);
+    for (iCommandIndex = 0; iCommandIndex < pQueue->count; ++iCommandIndex)
+      pQueue->has_typed_command[iCommandIndex] = 0;
+    return;
+  }
+
+  for (iCommandIndex = 0; iCommandIndex < pQueue->count; ++iCommandIndex) {
+    pSortEntries[iCommandIndex].entry = pQueue->entries[iCommandIndex];
+    pSortEntries[iCommandIndex].command = pQueue->commands[iCommandIndex];
+    pSortEntries[iCommandIndex].has_typed_command = pQueue->has_typed_command[iCommandIndex];
+  }
+
+  qsort(pSortEntries, pQueue->count, sizeof(pSortEntries[0]), render_queue_3d_compare_sort_entries);
+
+  for (iCommandIndex = 0; iCommandIndex < pQueue->count; ++iCommandIndex) {
+    pQueue->entries[iCommandIndex] = pSortEntries[iCommandIndex].entry;
+    pQueue->commands[iCommandIndex] = pSortEntries[iCommandIndex].command;
+    pQueue->has_typed_command[iCommandIndex] = pSortEntries[iCommandIndex].has_typed_command;
+  }
+
+  free(pSortEntries);
 }

--- a/PROJECTS/ROLLER/render_queue_3d.h
+++ b/PROJECTS/ROLLER/render_queue_3d.h
@@ -5,6 +5,7 @@
 //-------------------------------------------------------------------------------------------------
 
 #define RENDER_QUEUE_3D_CAPACITY 6500
+#define RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY 11
 #define RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY 13
 #define RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY 14
 
@@ -13,12 +14,47 @@
 typedef enum
 {
   RENDER_COMMAND_3D_KIND_BUILDING = 0,
+  RENDER_COMMAND_3D_KIND_CAR,
   RENDER_COMMAND_3D_KIND_START_LIGHT
 } RenderCommand3DKind;
 
 typedef struct
 {
+  int building_idx;
+  float depth;
+} RenderCommand3DBuilding;
+
+typedef struct
+{
+  int car_idx;
+  float depth;
+  GameRenderCarPose pose;
+  GameRenderCarOptions options;
+} RenderCommand3DCar;
+
+typedef struct
+{
+  int light_idx;
+  float depth;
+} RenderCommand3DStartLight;
+
+typedef struct
+{
+  RenderCommand3DKind kind;
+  union
+  {
+    RenderCommand3DBuilding building;
+    RenderCommand3DCar car;
+    RenderCommand3DStartLight start_light;
+  } payload;
+} RenderCommand3D;
+
+
+typedef struct
+{
   tTrackZOrderEntry entries[RENDER_QUEUE_3D_CAPACITY];
+  RenderCommand3D commands[RENDER_QUEUE_3D_CAPACITY];
+  int has_typed_command[RENDER_QUEUE_3D_CAPACITY];
   int count;
 } RenderQueue3D;
 
@@ -27,6 +63,7 @@ typedef struct
 RenderQueue3D *render_queue_3d_global(void);
 void render_queue_3d_clear(RenderQueue3D *pQueue);
 tTrackZOrderEntry *render_queue_3d_entries(RenderQueue3D *pQueue);
+const RenderCommand3D *render_queue_3d_command_at(const RenderQueue3D *pQueue, int iIndex);
 int render_queue_3d_count(const RenderQueue3D *pQueue);
 void render_queue_3d_set_legacy_count(RenderQueue3D *pQueue, int iCount);
 
@@ -36,6 +73,12 @@ tTrackZOrderEntry *render_queue_3d_add_legacy_priority(RenderQueue3D *pQueue,
                                                        int iLegacyPriority,
                                                        int iChunkIdx,
                                                        float fZDepth);
+
+tTrackZOrderEntry *render_queue_3d_add_car(RenderQueue3D *pQueue,
+                                           int iCarIdx,
+                                           float fZDepth,
+                                           const GameRenderCarPose *pPose,
+                                           const GameRenderCarOptions *pOptions);
 
 tTrackZOrderEntry *render_queue_3d_add_building(RenderQueue3D *pQueue,
                                                 int iBuildingIdx,

--- a/tests/render_queue_3d_test.c
+++ b/tests/render_queue_3d_test.c
@@ -62,6 +62,88 @@ static void test_start_light_priority_mapping_and_legacy_guard(void)
   assert(render_queue_3d_count(&queue) == 1);
 }
 
+static void test_car_priority_mapping_payload_and_legacy_guard(void)
+{
+  RenderQueue3D queue;
+  tTrackZOrderEntry *entry;
+  const RenderCommand3D *command;
+  const uint8 color_remap[2] = {3, 9};
+  const GameRenderCarPose pose = {
+    .position = {10.0f, 20.0f, 30.0f},
+    .yaw = 100,
+    .pitch = 200,
+    .roll = 300,
+  };
+  const GameRenderCarOptions options = {
+    .anim_frame = 7,
+    .color_remap = color_remap,
+  };
+  render_queue_3d_clear(&queue);
+
+  entry = render_queue_3d_add_car(&queue, 5, 321.0f, &pose, &options);
+  assert(entry != NULL);
+  assert(entry->nRenderPriority == RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY);
+  assert(entry->nChunkIdx == 5);
+  assert(entry->fZDepth == 321.0f);
+  assert(render_queue_3d_count(&queue) == 1);
+
+  command = render_queue_3d_command_at(&queue, 0);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_CAR);
+  assert(command->payload.car.car_idx == 5);
+  assert(command->payload.car.depth == 321.0f);
+  assert(command->payload.car.pose.position.fX == 10.0f);
+  assert(command->payload.car.pose.position.fY == 20.0f);
+  assert(command->payload.car.pose.position.fZ == 30.0f);
+  assert(command->payload.car.pose.yaw == 100);
+  assert(command->payload.car.pose.pitch == 200);
+  assert(command->payload.car.pose.roll == 300);
+  assert(command->payload.car.options.anim_frame == 7);
+  assert(command->payload.car.options.color_remap == color_remap);
+
+  assert(render_queue_3d_add_legacy_priority(&queue,
+                                             RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY,
+                                             7,
+                                             321.0f) == NULL);
+  assert(render_queue_3d_count(&queue) == 1);
+}
+
+static void test_sort_keeps_typed_car_payload_with_sorted_entry(void)
+{
+  RenderQueue3D queue;
+  const RenderCommand3D *command;
+  const GameRenderCarPose pose = {
+    .position = {1.0f, 2.0f, 3.0f},
+    .yaw = 4,
+    .pitch = 5,
+    .roll = 6,
+  };
+  const GameRenderCarOptions options = {
+    .anim_frame = 8,
+    .color_remap = NULL,
+  };
+  render_queue_3d_clear(&queue);
+
+  assert(render_queue_3d_add_car(&queue, 4, 20.0f, &pose, &options) != NULL);
+  assert(render_queue_3d_add_legacy_priority(&queue, 2, 101, 10.0f) != NULL);
+
+  render_queue_3d_sort(&queue);
+
+  assert(render_queue_3d_count(&queue) == 2);
+  assert(queue.entries[0].nChunkIdx == 101);
+  assert(render_queue_3d_command_at(&queue, 0) == NULL);
+  assert(queue.entries[1].nRenderPriority == RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY);
+  assert(queue.entries[1].nChunkIdx == 4);
+  command = render_queue_3d_command_at(&queue, 1);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_CAR);
+  assert(command->payload.car.car_idx == 4);
+  assert(command->payload.car.depth == 20.0f);
+  assert(command->payload.car.pose.roll == 6);
+  assert(command->payload.car.options.anim_frame == 8);
+}
+
+
 int main(int argc, const char **argv, const char **envp)
 {
   (void)argc;
@@ -70,5 +152,7 @@ int main(int argc, const char **argv, const char **envp)
   test_sort_matches_legacy_zcmp();
   test_building_priority_mapping_and_legacy_guard();
   test_start_light_priority_mapping_and_legacy_guard();
+  test_car_priority_mapping_payload_and_legacy_guard();
+  test_sort_keeps_typed_car_payload_with_sorted_entry();
   return 0;
 }

--- a/tools/check_render_queue_3d_seams.py
+++ b/tools/check_render_queue_3d_seams.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Pin migrated render_queue_3d command seams.
 
-Buildings and start lights have migrated away from raw legacy priority submission.
-Keep priorities 13 and 14 out of drawtrk3's direct writes and out of the temporary
+Cars, buildings, and start lights have migrated away from raw legacy priority submission.
+Keep priorities 11, 13, and 14 out of drawtrk3's direct writes and out of the temporary
 legacy-priority compatibility path.
 """
 from __future__ import annotations
@@ -23,6 +23,9 @@ def fail(message: str) -> int:
 def main() -> int:
     drawtrk3 = DRAWTRK3.read_text(encoding="utf-8")
 
+    if re.search(r"\.nRenderPriority\s*=\s*11\b|->nRenderPriority\s*=\s*11\b", drawtrk3):
+        return fail("drawtrk3.c writes car legacy priority 11 directly")
+
     if re.search(r"\.nRenderPriority\s*=\s*13\b|->nRenderPriority\s*=\s*13\b", drawtrk3):
         return fail("drawtrk3.c writes building legacy priority 13 directly")
 
@@ -35,13 +38,16 @@ def main() -> int:
     if "render_queue_3d_add_start_light" not in drawtrk3:
         return fail("drawtrk3.c does not submit start lights through render_queue_3d_add_start_light")
 
-    legacy_named_priority = re.compile(r"render_queue_3d_add_legacy_priority\s*\([^;]*\b(?:13|14)\b", re.DOTALL)
+    if "render_queue_3d_add_car" not in drawtrk3:
+        return fail("drawtrk3.c does not submit cars through render_queue_3d_add_car")
+
+    legacy_named_priority = re.compile(r"render_queue_3d_add_legacy_priority\s*\([^;]*\b(?:11|13|14)\b", re.DOTALL)
     for path in (ROOT / "PROJECTS" / "ROLLER").glob("*.c"):
         if path.name == "render_queue_3d.c":
             continue
         text = path.read_text(encoding="utf-8")
         if legacy_named_priority.search(text):
-            return fail(f"{path.relative_to(ROOT)} submits priority 13 or 14 through legacy compatibility API")
+            return fail(f"{path.relative_to(ROOT)} submits priority 11, 13, or 14 through legacy compatibility API")
 
     return 0
 


### PR DESCRIPTION
## Summary

- Add a typed car command kind and `render_queue_3d_add_car(...)` API with legacy priority 11 compatibility.
- Route outer car command submission in `DrawTrack3` through `render_queue_3d` while preserving `DrawCars()` / `car_draw_order[]` production and car draw gates.
- Extend focused queue tests and seam checks to block raw car priority 11 submissions.

## Test Plan

- [x] `zig build test-render-queue-3d`
- [x] `zig build`
- [x] `zig build test`
- [x] `zig build test-snapshots -Dscratch=true`
- [x] `zig build test-snapshots`

Closes #156.
