### PR TITLE
Route road lanes through render_queue_3d

### DIFF
--- a/PROJECTS/ROLLER/drawtrk3.c
+++ b/PROJECTS/ROLLER/drawtrk3.c
@@ -56,7 +56,6 @@ int CarsLeft;       //001446A0
 int VisibleCars;    //001446A4
 int num_pols;       //001446A8
 int small_poly;     //001446AC
-int num_bits;       //001446B0
 
 //-------------------------------------------------------------------------------------------------
 //0001D740
@@ -765,78 +764,57 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
   float fTrackDepthChoice1; // eax
   float fTrackDepthChoice2; // eax
   float fTrackDepthFinal; // eax
-  tTrackZOrderEntry *pGroundRenderCmd; // eax
   float fGroundRenderDepth; // edx
-  int iGroundRenderIndex; // ebx
   float fRoadCenterDepthMax1; // eax
   float fRoadCenterDepthMax2; // eax
   float fRoadCenterDepthSelected; // eax
-  tTrackZOrderEntry *pRoadCenterCmd; // eax
   float fRoadCenterCmdDepth; // edx
-  int iRoadCenterCmdIndex; // ebx
   float fLeftRoadDepthMax1; // eax
   float fLeftRoadDepthMax2; // eax
   float fLeftRoadDepthSelected; // eax
-  tTrackZOrderEntry *pLeftRoadCmd; // eax
   float fLeftRoadCmdDepth; // edx
-  int iLeftRoadCmdIndex; // ebx
   float fRightRoadDepthMax1; // eax
   float fRightRoadDepthMax2; // eax
   float fRightRoadDepthSelected; // eax
-  tTrackZOrderEntry *pRightRoadCmd; // eax
   float fRightRoadCmdDepth; // edx
-  int iRightRoadCmdIndex; // ebx
   int iRoofTypeCheck; // eax
   float fRoof1OuterDepth; // eax
   float fRoof1InnerDepth; // eax
   float fRoof1SelectedDepth; // eax
-  tTrackZOrderEntry *pRoof1RenderCmd; // eax
   float fRoof1CmdDepth; // edx
   int iRoofType; // ebx
   double dRoof2WallDepth1; // st7
   double dRoof2WallDepth2; // st7
   float fRoof2WallMinDepth; // eax
   float fRoof2SelectedDepth; // eax
-  tTrackZOrderEntry *pRoof2RenderCmd; // eax
   float fRoof2CmdDepth; // edx
   float fRoof3OuterDepth; // eax
   float fRoof3InnerDepth; // eax
   float fRoof3SelectedDepth; // eax
-  int iRoof3CmdIndex; // ebx
   float fLeftLowerWallDepth1; // eax
   float fLeftLowerWallDepth2; // eax
   float fLeftLowerWallSelected; // eax
-  tTrackZOrderEntry *pLeftLowerWallCmd; // eax
   float fLeftLowerWallCmdDepth; // edx
   float fRightLowerWallDepth1; // eax
   float fRightLowerWallDepth2; // eax
   float fRightLowerWallSelected; // eax
-  tTrackZOrderEntry *pRightLowerWallCmd; // eax
   float fRightLowerWallCmdDepth; // edx
   float fLeftWallDepthMax1; // eax
   float fLeftWallDepthMax2; // eax
   float fLeftWallDepthSelected; // eax
-  tTrackZOrderEntry *pLeftWallCmd; // eax
-  int iLeftWallCmdIndex; // edx
   float fRightWallDepthMax1; // eax
   float fRightWallDepthMax2; // eax
   float fRightWallDepthSelected; // eax
-  tTrackZOrderEntry *pRightWallCmd; // eax
   float fRightWallCmdDepth; // edx
   float fRightWallBasicDepth1; // eax
   float fRightWallBasicDepth2; // eax
   float fRightWallBasicSelected; // eax
-  tTrackZOrderEntry *pRightWallBasicCmd; // eax
   float fRightWallBasicCmdDepth; // edx
-  int iRightWallBasicCmdIndex; // ebx
   float fRightWallRoofDepth1; // eax
   float fRightWallRoofDepth2; // eax
   float fRightWallRoofSelected; // eax
-  tTrackZOrderEntry *pRightWallRoofCmd; // eax
-  int iRightWallRoofCmdIndex; // edx
   int iCarIndex; // esi
   int iCarArrayIndex; // ebx
-  tTrackZOrderEntry *pCarRenderCmd; // eax
   int iCarDrawOrderStatus; // edx
   float iCarDrawOrderIndex; // edx
   int iCarCommandIdx; // edx
@@ -848,12 +826,9 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
   int iCarVisibilityCount; // esi
   int iNamesDisplayCount; // eax
   tVisibleBuilding *pVisibleBuildingsPtr; // ebx
-  tTrackZOrderEntry *pBuildingRenderCmd; // edx
   int iLightIndex; // ebx
-  tTrackZOrderEntry *pLightRenderCmd; // ecx
   int iLightArrayOffset; // edx
   float fLightDepth; // eax
-  int iLightCmdIndex; // esi
   tTrackZOrderEntry *pRenderCommand; // eax
   const RenderCommand3D *pTypedRenderCommand; // eax
   int iSectionNum; // esi
@@ -1286,6 +1261,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
   float fRightWallCameraX; // [esp+340h] [ebp-1B4h]
   float fLeftWallCameraX; // [esp+344h] [ebp-1B0h]
   int iRenderObjectIndex; // [esp+348h] [ebp-1ACh]
+  int iRenderQueueCount;
   float fObjectDepthA1; // [esp+34Ch] [ebp-1A8h]
   float fObjectDepthA2; // [esp+350h] [ebp-1A4h]
   float fObjectDepthA3; // [esp+354h] [ebp-1A0h]
@@ -1700,7 +1676,6 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
     }
   }
   iTrackLoopCounter = TrackSize;                // Second phase: Build render list by traversing track backwards
-  num_bits = 0;
   render_queue_3d_clear(render_queue_3d_global());
   if (TrackSize >= 0) {
     while (iTrackLoopCounter > first_size && iTrackLoopCounter < gap_size) {
@@ -1790,13 +1765,8 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
         fGroundDepthTmp2 = fGroundDepthSelected;
         fProjectionZ = fGroundDepthSelected;
       }
-      pGroundRenderCmd = &TrackView[num_bits];  // Add ground floor polygon to render list
       fGroundRenderDepth = fProjectionZ;
-      iGroundRenderIndex = num_bits;
-      pGroundRenderCmd->nRenderPriority = 2;
-      pGroundRenderCmd->nChunkIdx = iCurrentSect;
-      num_bits = iGroundRenderIndex + 1;
-      pGroundRenderCmd->fZDepth = fGroundRenderDepth;
+      render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 2, iCurrentSect, fGroundRenderDepth); // ground, migrate in #159
     }
     if (pScreenCoord_1->iClipCount != 99 && pScreenCoord->iClipCount != 99 && Road_On) {
       if (pScreenCoord_1->screenPtAy[2].projected.fZ <= (double)pScreenCoord_1->screenPtAy[1].projected.fZ)
@@ -1823,13 +1793,8 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
         fRoadCenterDepthNear = fRoadCenterDepthSelected;
       }
       fRoadCenterFinalDepth = fRoadCenterDepthSelected;
-      pRoadCenterCmd = &TrackView[num_bits];    // Add road center polygon to render list
       fRoadCenterCmdDepth = fRoadCenterFinalDepth;
-      iRoadCenterCmdIndex = num_bits;
-      pRoadCenterCmd->nRenderPriority = 5;
-      pRoadCenterCmd->nChunkIdx = iCurrentSect;
-      num_bits = iRoadCenterCmdIndex + 1;
-      pRoadCenterCmd->fZDepth = fRoadCenterCmdDepth;
+      render_queue_3d_add_road_center(render_queue_3d_global(), iCurrentSect, fRoadCenterCmdDepth);
     }
     if (pScreenCoord_1->iClipCount != 99 && pScreenCoord->iClipCount != 99 && Road_On) {
       if (pScreenCoord_1->screenPtAy[0].projected.fZ <= (double)pScreenCoord_1->screenPtAy[1].projected.fZ)
@@ -1856,13 +1821,8 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
         fLeftRoadTmp1 = fLeftRoadDepthSelected;
       }
       fLeftRoadFinalDepth = fLeftRoadDepthSelected;
-      pLeftRoadCmd = &TrackView[num_bits];      // Add road left side polygon to render list
       fLeftRoadCmdDepth = fLeftRoadFinalDepth;
-      iLeftRoadCmdIndex = num_bits;
-      pLeftRoadCmd->nRenderPriority = 6;
-      pLeftRoadCmd->nChunkIdx = iCurrentSect;
-      num_bits = iLeftRoadCmdIndex + 1;
-      pLeftRoadCmd->fZDepth = fLeftRoadCmdDepth;
+      render_queue_3d_add_left_lane(render_queue_3d_global(), iCurrentSect, fLeftRoadCmdDepth);
     }
     if (pScreenCoord_1->iClipCount != 99 && pScreenCoord->iClipCount != 99 && Road_On) {
       if (pScreenCoord_1->screenPtAy[2].projected.fZ <= (double)pScreenCoord_1->screenPtAy[3].projected.fZ)
@@ -1889,13 +1849,8 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
         fRightRoadDepthNear = fRightRoadDepthSelected;
       }
       fRightRoadFinalDepth = fRightRoadDepthSelected;
-      pRightRoadCmd = &TrackView[num_bits];     // Add road right side polygon to render list
       fRightRoadCmdDepth = fRightRoadFinalDepth;
-      iRightRoadCmdIndex = num_bits;
-      pRightRoadCmd->nRenderPriority = 7;
-      pRightRoadCmd->nChunkIdx = iCurrentSect;
-      num_bits = iRightRoadCmdIndex + 1;
-      pRightRoadCmd->fZDepth = fRightRoadCmdDepth;
+      render_queue_3d_add_right_lane(render_queue_3d_global(), iCurrentSect, fRightRoadCmdDepth);
     }
     if (pScreenCoord_1->iClipCount != 99 && pScreenCoord->iClipCount != 99) {
       if (Walls_On) {
@@ -1928,12 +1883,8 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
               fRoof1DepthOuter = fRoof1SelectedDepth;
             }
             fRoof1DepthSelected = fRoof1SelectedDepth;
-            pRoof1RenderCmd = &TrackView[num_bits];// Add roof/ceiling polygon to render list
-            pRoof1RenderCmd->nRenderPriority = 10;
             fRoof1CmdDepth = fRoof1DepthSelected;
-            pRoof1RenderCmd->nChunkIdx = iCurrentSect;
-            pRoof1RenderCmd->fZDepth = fRoof1CmdDepth;
-            ++num_bits;
+            render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 10, iCurrentSect, fRoof1CmdDepth); // roof, migrate in #159
             goto LABEL_238;
           }
           iRoofType = TrakColour[iNextSectionIndex][TRAK_COLOUR_ROOF];
@@ -1964,7 +1915,6 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
               fRoof3DepthOuter = fRoof3SelectedDepth;
             }
             fRoof3DepthSelected = fRoof3SelectedDepth;
-            pRoof2RenderCmd = &TrackView[num_bits];
             fRoof2CmdDepth = fRoof3DepthSelected;
           } else {
             if (TrakColour[iCurrentSect][TRAK_COLOUR_RIGHT_WALL] >= 0)
@@ -2002,14 +1952,9 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
                 iRoof2WallDepthChoice = iRightWallFlags;
               fRoof2DepthSelected = (float)iRoof2WallDepthChoice;
             }
-            pRoof2RenderCmd = &TrackView[num_bits];
             fRoof2CmdDepth = fRoof2DepthSelected;
           }
-          iRoof3CmdIndex = num_bits;
-          pRoof2RenderCmd->nRenderPriority = 10;
-          pRoof2RenderCmd->nChunkIdx = iCurrentSect;
-          num_bits = iRoof3CmdIndex + 1;
-          pRoof2RenderCmd->fZDepth = fRoof2CmdDepth;
+          render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 10, iCurrentSect, fRoof2CmdDepth); // roof, migrate in #159
         }
       }
     }
@@ -2039,12 +1984,8 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
         fLeftLowerWallDepthTmp1 = fLeftLowerWallSelected;
       }
       fLeftLowerWallDepthSelected = fLeftLowerWallSelected;
-      pLeftLowerWallCmd = &TrackView[num_bits]; // Add left lower wall polygon to render list
-      pLeftLowerWallCmd->nRenderPriority = 3;
       fLeftLowerWallCmdDepth = fLeftLowerWallDepthSelected;
-      pLeftLowerWallCmd->nChunkIdx = iCurrentSect;
-      pLeftLowerWallCmd->fZDepth = fLeftLowerWallCmdDepth;
-      ++num_bits;
+      render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 3, iCurrentSect, fLeftLowerWallCmdDepth); // lower wall, migrate in #158
     }
     if (GroundColour[iCurrentSect][GROUND_COLOUR_RLOWALL] != -1 && bGroundVisible) {
       if (pNextGroundScreen->screenPtAy[3].projected.fZ <= (double)pNextGroundScreen->screenPtAy[4].projected.fZ)
@@ -2071,12 +2012,8 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
         fRightLowerWallDepthTmp1 = fRightLowerWallSelected;
       }
       fRightLowerWallDepthSelected = fRightLowerWallSelected;
-      pRightLowerWallCmd = &TrackView[num_bits];// Add right lower wall polygon to render list
-      pRightLowerWallCmd->nRenderPriority = 4;
       fRightLowerWallCmdDepth = fRightLowerWallDepthSelected;
-      pRightLowerWallCmd->nChunkIdx = iCurrentSect;
-      pRightLowerWallCmd->fZDepth = fRightLowerWallCmdDepth;
-      ++num_bits;
+      render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 4, iCurrentSect, fRightLowerWallCmdDepth); // lower wall, migrate in #158
     }
     if (pScreenCoord_1->iClipCount != 99 && pScreenCoord->iClipCount != 99) {
       if (Walls_On) {
@@ -2116,12 +2053,8 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
                                   + pScreenCoord_1->screenPtAy[4].projected.fZ)
                 * 0.25f;
             }
-            pRightWallCmd = &TrackView[num_bits];
-            pRightWallCmd->nRenderPriority = 8;
             fRightWallCmdDepth = fLeftWallRoofDepth;
-            pRightWallCmd->nChunkIdx = iCurrentSect;
-            pRightWallCmd->fZDepth = fRightWallCmdDepth;
-            ++num_bits;
+            render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 8, iCurrentSect, fRightWallCmdDepth); // wall, migrate in #158
           } else {
             if (pScreenCoord_1->screenPtAy[0].projected.fZ <= (double)pScreenCoord_1->screenPtAy[1].projected.fZ)
               fLeftWallDepthMax1 = pScreenCoord_1->screenPtAy[1].projected.fZ;
@@ -2147,12 +2080,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
               fLeftWallDepthTmp1 = fLeftWallDepthSelected;
             }
             fLeftWallFinalDepth = fLeftWallDepthSelected;
-            pLeftWallCmd = &TrackView[num_bits];// Add left wall polygon to render list
-            pLeftWallCmd->fZDepth = fLeftWallFinalDepth;
-            iLeftWallCmdIndex = num_bits;
-            pLeftWallCmd->nRenderPriority = 0;
-            pLeftWallCmd->nChunkIdx = iCurrentSect;
-            num_bits = iLeftWallCmdIndex + 1;
+            render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 0, iCurrentSect, fLeftWallFinalDepth); // wall, migrate in #158
           }
         }
       }
@@ -2195,12 +2123,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
                                    + pScreenCoord->screenPtAy[5].projected.fZ)
                 * 0.25f;
             }
-            pRightWallRoofCmd = &TrackView[num_bits];
-            pRightWallRoofCmd->fZDepth = fRightWallRoofDepth;
-            iRightWallRoofCmdIndex = num_bits;
-            pRightWallRoofCmd->nRenderPriority = 9;
-            pRightWallRoofCmd->nChunkIdx = iCurrentSect;
-            num_bits = iRightWallRoofCmdIndex + 1;
+            render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 9, iCurrentSect, fRightWallRoofDepth); // wall, migrate in #158
           } else {
             if (pScreenCoord_1->screenPtAy[2].projected.fZ <= (double)pScreenCoord_1->screenPtAy[3].projected.fZ)
               fRightWallBasicDepth1 = pScreenCoord_1->screenPtAy[3].projected.fZ;
@@ -2226,13 +2149,8 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
               fRightWallDepthTmp1 = fRightWallBasicSelected;
             }
             fRightWallFinalDepth = fRightWallBasicSelected;
-            pRightWallBasicCmd = &TrackView[num_bits];// Add right wall polygon to render list
             fRightWallBasicCmdDepth = fRightWallFinalDepth;
-            iRightWallBasicCmdIndex = num_bits;
-            pRightWallBasicCmd->nRenderPriority = 1;
-            pRightWallBasicCmd->nChunkIdx = iCurrentSect;
-            num_bits = iRightWallBasicCmdIndex + 1;
-            pRightWallBasicCmd->fZDepth = fRightWallBasicCmdDepth;
+            render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 1, iCurrentSect, fRightWallBasicCmdDepth); // wall, migrate in #158
           }
         }
       }
@@ -2240,7 +2158,6 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
     goto LABEL_356;
   }
 LABEL_357:
-  render_queue_3d_set_legacy_count(render_queue_3d_global(), num_bits);
   iCarIndex = 0;                                // Third phase: Process car objects for rendering
   if (numcars > 0) {
     iCarArrayIndex = 0;
@@ -2262,12 +2179,9 @@ LABEL_357:
             .anim_frame = Car[iCarCommandIdx].byWheelAnimationFrame,
             .color_remap = NULL,
           };
-          pCarRenderCmd = render_queue_3d_add_car(render_queue_3d_global(), iCarCommandIdx, fOffsetTmp1, &pose, &options);
+          render_queue_3d_add_car(render_queue_3d_global(), iCarCommandIdx, fOffsetTmp1, &pose, &options);
         }
-        if (pCarRenderCmd != NULL) {
-          cars_drawn = iCarProcessingFlag + 1;
-          num_bits = render_queue_3d_count(render_queue_3d_global());
-        }
+        cars_drawn = iCarProcessingFlag + 1;
       }
       ++iCarIndex;
       ++iCarArrayIndex;
@@ -2331,11 +2245,9 @@ LABEL_393:
   pVisibleBuildingsPtr = &VisibleBuildings[0];     // Process building objects for rendering
   if (VisibleBuildings[0].iBuildingIdx != -1) {
     do {
-      pBuildingRenderCmd = render_queue_3d_add_building(render_queue_3d_global(),
-                                                        pVisibleBuildingsPtr->iBuildingIdx,
-                                                        pVisibleBuildingsPtr->fDepth);
-      if (pBuildingRenderCmd != NULL)
-        num_bits = render_queue_3d_count(render_queue_3d_global());
+      render_queue_3d_add_building(render_queue_3d_global(),
+                                   pVisibleBuildingsPtr->iBuildingIdx,
+                                   pVisibleBuildingsPtr->fDepth);
       ++pVisibleBuildingsPtr;
     } while (pVisibleBuildingsPtr->iBuildingIdx != -1);
   }
@@ -2349,9 +2261,7 @@ LABEL_393:
         + (SLight[0][iLightArrayOffset].currentPos.fZ - viewz) * vk9;
       if (fLightZ > 0.0) {
         fLightDepth = fLightZ;
-        pLightRenderCmd = render_queue_3d_add_start_light(render_queue_3d_global(), iLightIndex, fLightDepth);
-        if (pLightRenderCmd != NULL)
-          num_bits = render_queue_3d_count(render_queue_3d_global());
+        render_queue_3d_add_start_light(render_queue_3d_global(), iLightIndex, fLightDepth);
       }
       ++iLightIndex;
       ++iLightArrayOffset;
@@ -2359,11 +2269,12 @@ LABEL_393:
   }
   render_queue_3d_sort(render_queue_3d_global());// Fifth phase: Sort render list by Z-depth and render objects
   iRenderObjectIndex = 0;
-  if (num_bits > 0) {
+  iRenderQueueCount = render_queue_3d_count(render_queue_3d_global());
+  if (iRenderQueueCount > 0) {
     iIndexTmp1 = 144 * iChaseCamIdx_1;
     while (1) {
-      pRenderCommand = &TrackView[num_bits - 1 - iRenderObjectIndex];
-      pTypedRenderCommand = render_queue_3d_command_at(render_queue_3d_global(), num_bits - 1 - iRenderObjectIndex);
+      pRenderCommand = &TrackView[iRenderQueueCount - 1 - iRenderObjectIndex];
+      pTypedRenderCommand = render_queue_3d_command_at(render_queue_3d_global(), iRenderQueueCount - 1 - iRenderObjectIndex);
       fRenderDepth = pRenderCommand->fZDepth;
       iSectionNum = pRenderCommand->nChunkIdx;
       pScreenCoord_1 = NULL;
@@ -2434,7 +2345,7 @@ LABEL_393:
           }
           goto LABEL_1271;
         LABEL_1271:
-          if (++iRenderObjectIndex >= num_bits)
+          if (++iRenderObjectIndex >= iRenderQueueCount)
             return;
           break;
         case 2:
@@ -2601,7 +2512,7 @@ LABEL_393:
             }
           }
           goto LABEL_1271;
-        case 5:
+        case RENDER_QUEUE_3D_ROAD_CENTER_LEGACY_PRIORITY:
           {
             int sf = TrakColour[iSectionNum][TRAK_COLOUR_CENTER];
             if ((textures_off & TEX_OFF_ROAD_TEXTURES) != 0 && (sf & SURFACE_FLAG_APPLY_TEXTURE) != 0)
@@ -2619,7 +2530,7 @@ LABEL_393:
           goto LABEL_1271;
         LABEL_1203:
           goto LABEL_1271;
-        case 6:
+        case RENDER_QUEUE_3D_LEFT_LANE_LEGACY_PRIORITY:
           {
             int sf = TrakColour[iSectionNum][TRAK_COLOUR_LEFT_LANE];
             if (sf < 0)
@@ -2637,7 +2548,7 @@ LABEL_393:
             }
           }
           goto LABEL_1271;
-        case 7:
+        case RENDER_QUEUE_3D_RIGHT_LANE_LEGACY_PRIORITY:
           {
             int sf = TrakColour[iSectionNum][TRAK_COLOUR_RIGHT_LANE];
             if (sf < 0)

--- a/PROJECTS/ROLLER/drawtrk3.h
+++ b/PROJECTS/ROLLER/drawtrk3.h
@@ -46,7 +46,6 @@ extern int CarsLeft;
 extern int VisibleCars;
 extern int num_pols;
 extern int small_poly;
-extern int num_bits;
 
 //-------------------------------------------------------------------------------------------------
 

--- a/PROJECTS/ROLLER/render_queue_3d.c
+++ b/PROJECTS/ROLLER/render_queue_3d.c
@@ -1,4 +1,5 @@
 #include "render_queue_3d.h"
+#include <assert.h>
 #include <stdlib.h>
 //-------------------------------------------------------------------------------------------------
 
@@ -10,6 +11,32 @@ typedef struct
   RenderCommand3D command;
   int has_typed_command;
 } RenderQueue3DSortEntry;
+
+//-------------------------------------------------------------------------------------------------
+
+static void render_queue_3d_require(int iCondition)
+{
+  if (!iCondition) {
+    assert(iCondition);
+    abort();
+  }
+}
+
+//-------------------------------------------------------------------------------------------------
+
+static int render_queue_3d_is_named_priority(int iLegacyPriority)
+{
+  switch (iLegacyPriority) {
+  case RENDER_QUEUE_3D_ROAD_CENTER_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_LEFT_LANE_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_RIGHT_LANE_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY:
+    return 1;
+  }
+  return 0;
+}
 
 //-------------------------------------------------------------------------------------------------
 
@@ -52,32 +79,14 @@ int render_queue_3d_count(const RenderQueue3D *pQueue)
 
 //-------------------------------------------------------------------------------------------------
 
-void render_queue_3d_set_legacy_count(RenderQueue3D *pQueue, int iCount)
-{
-  int iCommandIndex;
-
-  if (iCount < 0)
-    iCount = 0;
-  if (iCount > RENDER_QUEUE_3D_CAPACITY)
-    iCount = RENDER_QUEUE_3D_CAPACITY;
-
-  for (iCommandIndex = 0; iCommandIndex < iCount; ++iCommandIndex)
-    pQueue->has_typed_command[iCommandIndex] = 0;
-
-  pQueue->count = iCount;
-}
-
-//-------------------------------------------------------------------------------------------------
-
-static tTrackZOrderEntry *render_queue_3d_add(RenderQueue3D *pQueue,
-                                              int iLegacyPriority,
-                                              int iChunkIdx,
-                                              float fZDepth)
+static tTrackZOrderEntry *render_queue_3d_add_required(RenderQueue3D *pQueue,
+                                                       int iLegacyPriority,
+                                                       int iChunkIdx,
+                                                       float fZDepth)
 {
   tTrackZOrderEntry *pEntry;
 
-  if (pQueue->count >= RENDER_QUEUE_3D_CAPACITY)
-    return NULL;
+  render_queue_3d_require(pQueue->count < RENDER_QUEUE_3D_CAPACITY);
 
   pEntry = &pQueue->entries[pQueue->count];
   pEntry->nRenderPriority = (int16)iLegacyPriority;
@@ -91,69 +100,107 @@ static tTrackZOrderEntry *render_queue_3d_add(RenderQueue3D *pQueue,
 
 //-------------------------------------------------------------------------------------------------
 
-tTrackZOrderEntry *render_queue_3d_add_legacy_priority(RenderQueue3D *pQueue,
-                                                       int iLegacyPriority,
-                                                       int iChunkIdx,
-                                                       float fZDepth)
+void render_queue_3d_add_unmigrated_legacy_priority(RenderQueue3D *pQueue,
+                                                     int iLegacyPriority,
+                                                     int iChunkIdx,
+                                                     float fZDepth)
 {
-  switch (iLegacyPriority) {
-  case RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY:
-    return NULL;
-  }
-
-  return render_queue_3d_add(pQueue, iLegacyPriority, iChunkIdx, fZDepth);
+  render_queue_3d_require(!render_queue_3d_is_named_priority(iLegacyPriority));
+  render_queue_3d_add_required(pQueue, iLegacyPriority, iChunkIdx, fZDepth);
 }
 
 //-------------------------------------------------------------------------------------------------
 
-tTrackZOrderEntry *render_queue_3d_add_building(RenderQueue3D *pQueue,
-                                                int iBuildingIdx,
-                                                float fZDepth)
+static void render_queue_3d_add_road_surface(RenderQueue3D *pQueue,
+                                             int iLegacyPriority,
+                                             int iSectionIdx,
+                                             float fZDepth,
+                                             RenderCommand3DRoadSurfaceKind surfaceKind)
 {
-  tTrackZOrderEntry *pEntry = render_queue_3d_add(pQueue, RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY, iBuildingIdx, fZDepth);
-  if (pEntry != NULL) {
-    RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
-    pCommand->kind = RENDER_COMMAND_3D_KIND_BUILDING;
-    pCommand->payload.building.building_idx = iBuildingIdx;
-    pCommand->payload.building.depth = fZDepth;
-    pQueue->has_typed_command[pQueue->count - 1] = 1;
-  }
-  return pEntry;
+  render_queue_3d_add_required(pQueue, iLegacyPriority, iSectionIdx, fZDepth);
+  RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
+  pCommand->kind = RENDER_COMMAND_3D_KIND_ROAD_SURFACE;
+  pCommand->payload.road_surface.section_idx = iSectionIdx;
+  pCommand->payload.road_surface.depth = fZDepth;
+  pCommand->payload.road_surface.surface_kind = surfaceKind;
+  pQueue->has_typed_command[pQueue->count - 1] = 1;
 }
 
-tTrackZOrderEntry *render_queue_3d_add_car(RenderQueue3D *pQueue,
-                                           int iCarIdx,
-                                           float fZDepth,
-                                           const GameRenderCarPose *pPose,
-                                           const GameRenderCarOptions *pOptions)
+void render_queue_3d_add_road_center(RenderQueue3D *pQueue,
+                                      int iSectionIdx,
+                                      float fZDepth)
 {
-  tTrackZOrderEntry *pEntry = render_queue_3d_add(pQueue, RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY, iCarIdx, fZDepth);
-  if (pEntry != NULL) {
-    RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
-    pCommand->kind = RENDER_COMMAND_3D_KIND_CAR;
-    pCommand->payload.car.car_idx = iCarIdx;
-    pCommand->payload.car.depth = fZDepth;
-    if (pPose != NULL) {
-      pCommand->payload.car.pose = *pPose;
-    } else {
-      pCommand->payload.car.pose.position.fX = 0.0f;
-      pCommand->payload.car.pose.position.fY = 0.0f;
-      pCommand->payload.car.pose.position.fZ = 0.0f;
-      pCommand->payload.car.pose.yaw = 0;
-      pCommand->payload.car.pose.pitch = 0;
-      pCommand->payload.car.pose.roll = 0;
-    }
-    if (pOptions != NULL) {
-      pCommand->payload.car.options = *pOptions;
-    } else {
-      pCommand->payload.car.options.anim_frame = 0;
-      pCommand->payload.car.options.color_remap = NULL;
-    }
-    pQueue->has_typed_command[pQueue->count - 1] = 1;
+  render_queue_3d_add_road_surface(pQueue,
+                                   RENDER_QUEUE_3D_ROAD_CENTER_LEGACY_PRIORITY,
+                                   iSectionIdx,
+                                   fZDepth,
+                                   RENDER_COMMAND_3D_ROAD_SURFACE_CENTER);
+}
+
+void render_queue_3d_add_left_lane(RenderQueue3D *pQueue,
+                                    int iSectionIdx,
+                                    float fZDepth)
+{
+  render_queue_3d_add_road_surface(pQueue,
+                                   RENDER_QUEUE_3D_LEFT_LANE_LEGACY_PRIORITY,
+                                   iSectionIdx,
+                                   fZDepth,
+                                   RENDER_COMMAND_3D_ROAD_SURFACE_LEFT_LANE);
+}
+
+void render_queue_3d_add_right_lane(RenderQueue3D *pQueue,
+                                     int iSectionIdx,
+                                     float fZDepth)
+{
+  render_queue_3d_add_road_surface(pQueue,
+                                   RENDER_QUEUE_3D_RIGHT_LANE_LEGACY_PRIORITY,
+                                   iSectionIdx,
+                                   fZDepth,
+                                   RENDER_COMMAND_3D_ROAD_SURFACE_RIGHT_LANE);
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void render_queue_3d_add_building(RenderQueue3D *pQueue,
+                                   int iBuildingIdx,
+                                   float fZDepth)
+{
+  render_queue_3d_add_required(pQueue, RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY, iBuildingIdx, fZDepth);
+  RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
+  pCommand->kind = RENDER_COMMAND_3D_KIND_BUILDING;
+  pCommand->payload.building.building_idx = iBuildingIdx;
+  pCommand->payload.building.depth = fZDepth;
+  pQueue->has_typed_command[pQueue->count - 1] = 1;
+}
+
+void render_queue_3d_add_car(RenderQueue3D *pQueue,
+                              int iCarIdx,
+                              float fZDepth,
+                              const GameRenderCarPose *pPose,
+                              const GameRenderCarOptions *pOptions)
+{
+  render_queue_3d_add_required(pQueue, RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY, iCarIdx, fZDepth);
+  RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
+  pCommand->kind = RENDER_COMMAND_3D_KIND_CAR;
+  pCommand->payload.car.car_idx = iCarIdx;
+  pCommand->payload.car.depth = fZDepth;
+  if (pPose != NULL) {
+    pCommand->payload.car.pose = *pPose;
+  } else {
+    pCommand->payload.car.pose.position.fX = 0.0f;
+    pCommand->payload.car.pose.position.fY = 0.0f;
+    pCommand->payload.car.pose.position.fZ = 0.0f;
+    pCommand->payload.car.pose.yaw = 0;
+    pCommand->payload.car.pose.pitch = 0;
+    pCommand->payload.car.pose.roll = 0;
   }
-  return pEntry;
+  if (pOptions != NULL) {
+    pCommand->payload.car.options = *pOptions;
+  } else {
+    pCommand->payload.car.options.anim_frame = 0;
+    pCommand->payload.car.options.color_remap = NULL;
+  }
+  pQueue->has_typed_command[pQueue->count - 1] = 1;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -161,19 +208,16 @@ tTrackZOrderEntry *render_queue_3d_add_car(RenderQueue3D *pQueue,
 
 //-------------------------------------------------------------------------------------------------
 
-tTrackZOrderEntry *render_queue_3d_add_start_light(RenderQueue3D *pQueue,
-                                                   int iLightIdx,
-                                                   float fZDepth)
+void render_queue_3d_add_start_light(RenderQueue3D *pQueue,
+                                      int iLightIdx,
+                                      float fZDepth)
 {
-  tTrackZOrderEntry *pEntry = render_queue_3d_add(pQueue, RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY, iLightIdx, fZDepth);
-  if (pEntry != NULL) {
-    RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
-    pCommand->kind = RENDER_COMMAND_3D_KIND_START_LIGHT;
-    pCommand->payload.start_light.light_idx = iLightIdx;
-    pCommand->payload.start_light.depth = fZDepth;
-    pQueue->has_typed_command[pQueue->count - 1] = 1;
-  }
-  return pEntry;
+  render_queue_3d_add_required(pQueue, RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY, iLightIdx, fZDepth);
+  RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
+  pCommand->kind = RENDER_COMMAND_3D_KIND_START_LIGHT;
+  pCommand->payload.start_light.light_idx = iLightIdx;
+  pCommand->payload.start_light.depth = fZDepth;
+  pQueue->has_typed_command[pQueue->count - 1] = 1;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/render_queue_3d.h
+++ b/PROJECTS/ROLLER/render_queue_3d.h
@@ -5,6 +5,9 @@
 //-------------------------------------------------------------------------------------------------
 
 #define RENDER_QUEUE_3D_CAPACITY 6500
+#define RENDER_QUEUE_3D_ROAD_CENTER_LEGACY_PRIORITY 5
+#define RENDER_QUEUE_3D_LEFT_LANE_LEGACY_PRIORITY 6
+#define RENDER_QUEUE_3D_RIGHT_LANE_LEGACY_PRIORITY 7
 #define RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY 11
 #define RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY 13
 #define RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY 14
@@ -15,6 +18,7 @@ typedef enum
 {
   RENDER_COMMAND_3D_KIND_BUILDING = 0,
   RENDER_COMMAND_3D_KIND_CAR,
+  RENDER_COMMAND_3D_KIND_ROAD_SURFACE,
   RENDER_COMMAND_3D_KIND_START_LIGHT
 } RenderCommand3DKind;
 
@@ -32,6 +36,20 @@ typedef struct
   GameRenderCarOptions options;
 } RenderCommand3DCar;
 
+typedef enum
+{
+  RENDER_COMMAND_3D_ROAD_SURFACE_CENTER = 0,
+  RENDER_COMMAND_3D_ROAD_SURFACE_LEFT_LANE,
+  RENDER_COMMAND_3D_ROAD_SURFACE_RIGHT_LANE
+} RenderCommand3DRoadSurfaceKind;
+
+typedef struct
+{
+  int section_idx;
+  float depth;
+  RenderCommand3DRoadSurfaceKind surface_kind;
+} RenderCommand3DRoadSurface;
+
 typedef struct
 {
   int light_idx;
@@ -45,6 +63,7 @@ typedef struct
   {
     RenderCommand3DBuilding building;
     RenderCommand3DCar car;
+    RenderCommand3DRoadSurface road_surface;
     RenderCommand3DStartLight start_light;
   } payload;
 } RenderCommand3D;
@@ -65,29 +84,40 @@ void render_queue_3d_clear(RenderQueue3D *pQueue);
 tTrackZOrderEntry *render_queue_3d_entries(RenderQueue3D *pQueue);
 const RenderCommand3D *render_queue_3d_command_at(const RenderQueue3D *pQueue, int iIndex);
 int render_queue_3d_count(const RenderQueue3D *pQueue);
-void render_queue_3d_set_legacy_count(RenderQueue3D *pQueue, int iCount);
 
 // Temporary compatibility API for unmigrated legacy render priorities. Priorities with named
 // command APIs must use those APIs instead.
-tTrackZOrderEntry *render_queue_3d_add_legacy_priority(RenderQueue3D *pQueue,
-                                                       int iLegacyPriority,
-                                                       int iChunkIdx,
-                                                       float fZDepth);
+void render_queue_3d_add_unmigrated_legacy_priority(RenderQueue3D *pQueue,
+                                                     int iLegacyPriority,
+                                                     int iChunkIdx,
+                                                     float fZDepth);
 
-tTrackZOrderEntry *render_queue_3d_add_car(RenderQueue3D *pQueue,
-                                           int iCarIdx,
-                                           float fZDepth,
-                                           const GameRenderCarPose *pPose,
-                                           const GameRenderCarOptions *pOptions);
+void render_queue_3d_add_road_center(RenderQueue3D *pQueue,
+                                      int iSectionIdx,
+                                      float fZDepth);
 
-tTrackZOrderEntry *render_queue_3d_add_building(RenderQueue3D *pQueue,
-                                                int iBuildingIdx,
-                                                float fZDepth);
+void render_queue_3d_add_left_lane(RenderQueue3D *pQueue,
+                                    int iSectionIdx,
+                                    float fZDepth);
+
+void render_queue_3d_add_right_lane(RenderQueue3D *pQueue,
+                                     int iSectionIdx,
+                                     float fZDepth);
+
+void render_queue_3d_add_car(RenderQueue3D *pQueue,
+                              int iCarIdx,
+                              float fZDepth,
+                              const GameRenderCarPose *pPose,
+                              const GameRenderCarOptions *pOptions);
+
+void render_queue_3d_add_building(RenderQueue3D *pQueue,
+                                   int iBuildingIdx,
+                                   float fZDepth);
 
 
-tTrackZOrderEntry *render_queue_3d_add_start_light(RenderQueue3D *pQueue,
-                                                   int iLightIdx,
-                                                   float fZDepth);
+void render_queue_3d_add_start_light(RenderQueue3D *pQueue,
+                                      int iLightIdx,
+                                      float fZDepth);
 
 int render_queue_3d_compare_legacy_z_order(const void *pCommand1, const void *pCommand2);
 void render_queue_3d_sort(RenderQueue3D *pQueue);

--- a/tests/render_queue_3d_test.c
+++ b/tests/render_queue_3d_test.c
@@ -7,10 +7,10 @@ static void test_sort_matches_legacy_zcmp(void)
   RenderQueue3D queue;
   render_queue_3d_clear(&queue);
 
-  assert(render_queue_3d_add_legacy_priority(&queue, 5, 100, 10.0f) != NULL);
-  assert(render_queue_3d_add_legacy_priority(&queue, 2, 101, 4.0f) != NULL);
-  assert(render_queue_3d_add_building(&queue, 102, 10.0f) != NULL);
-  assert(render_queue_3d_add_legacy_priority(&queue, 6, 103, 10.0f) != NULL);
+  render_queue_3d_add_road_center(&queue, 100, 10.0f);
+  render_queue_3d_add_unmigrated_legacy_priority(&queue, 2, 101, 4.0f);
+  render_queue_3d_add_building(&queue, 102, 10.0f);
+  render_queue_3d_add_left_lane(&queue, 103, 10.0f);
 
   render_queue_3d_sort(&queue);
 
@@ -21,51 +21,78 @@ static void test_sort_matches_legacy_zcmp(void)
   assert(queue.entries[3].nChunkIdx == 100);
 }
 
-static void test_building_priority_mapping_and_legacy_guard(void)
+static void test_road_lane_priority_mapping_payloads(void)
 {
   RenderQueue3D queue;
-  tTrackZOrderEntry *entry;
+  const RenderCommand3D *command;
   render_queue_3d_clear(&queue);
 
-  entry = render_queue_3d_add_building(&queue, 17, 123.0f);
-  assert(entry != NULL);
-  assert(entry->nRenderPriority == RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY);
-  assert(entry->nChunkIdx == 17);
-  assert(entry->fZDepth == 123.0f);
-  assert(render_queue_3d_count(&queue) == 1);
+  render_queue_3d_add_road_center(&queue, 17, 123.0f);
+  render_queue_3d_add_left_lane(&queue, 18, 124.0f);
+  render_queue_3d_add_right_lane(&queue, 19, 125.0f);
 
-  assert(render_queue_3d_add_legacy_priority(&queue,
-                                             RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY,
-                                             7,
-                                             123.0f) == NULL);
+  assert(render_queue_3d_count(&queue) == 3);
+
+  assert(queue.entries[0].nRenderPriority == RENDER_QUEUE_3D_ROAD_CENTER_LEGACY_PRIORITY);
+  assert(queue.entries[0].nChunkIdx == 17);
+  assert(queue.entries[0].fZDepth == 123.0f);
+  command = render_queue_3d_command_at(&queue, 0);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_ROAD_SURFACE);
+  assert(command->payload.road_surface.surface_kind == RENDER_COMMAND_3D_ROAD_SURFACE_CENTER);
+  assert(command->payload.road_surface.section_idx == 17);
+  assert(command->payload.road_surface.depth == 123.0f);
+
+  assert(queue.entries[1].nRenderPriority == RENDER_QUEUE_3D_LEFT_LANE_LEGACY_PRIORITY);
+  assert(queue.entries[1].nChunkIdx == 18);
+  assert(queue.entries[1].fZDepth == 124.0f);
+  command = render_queue_3d_command_at(&queue, 1);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_ROAD_SURFACE);
+  assert(command->payload.road_surface.surface_kind == RENDER_COMMAND_3D_ROAD_SURFACE_LEFT_LANE);
+  assert(command->payload.road_surface.section_idx == 18);
+  assert(command->payload.road_surface.depth == 124.0f);
+
+  assert(queue.entries[2].nRenderPriority == RENDER_QUEUE_3D_RIGHT_LANE_LEGACY_PRIORITY);
+  assert(queue.entries[2].nChunkIdx == 19);
+  assert(queue.entries[2].fZDepth == 125.0f);
+  command = render_queue_3d_command_at(&queue, 2);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_ROAD_SURFACE);
+  assert(command->payload.road_surface.surface_kind == RENDER_COMMAND_3D_ROAD_SURFACE_RIGHT_LANE);
+  assert(command->payload.road_surface.section_idx == 19);
+  assert(command->payload.road_surface.depth == 125.0f);
+}
+
+static void test_building_priority_mapping(void)
+{
+  RenderQueue3D queue;
+  render_queue_3d_clear(&queue);
+
+  render_queue_3d_add_building(&queue, 17, 123.0f);
+
+  assert(queue.entries[0].nRenderPriority == RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY);
+  assert(queue.entries[0].nChunkIdx == 17);
+  assert(queue.entries[0].fZDepth == 123.0f);
   assert(render_queue_3d_count(&queue) == 1);
 }
 
-
-static void test_start_light_priority_mapping_and_legacy_guard(void)
+static void test_start_light_priority_mapping(void)
 {
   RenderQueue3D queue;
-  tTrackZOrderEntry *entry;
   render_queue_3d_clear(&queue);
 
-  entry = render_queue_3d_add_start_light(&queue, 2, 42.0f);
-  assert(entry != NULL);
-  assert(entry->nRenderPriority == RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY);
-  assert(entry->nChunkIdx == 2);
-  assert(entry->fZDepth == 42.0f);
-  assert(render_queue_3d_count(&queue) == 1);
+  render_queue_3d_add_start_light(&queue, 2, 42.0f);
 
-  assert(render_queue_3d_add_legacy_priority(&queue,
-                                             RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY,
-                                             7,
-                                             42.0f) == NULL);
+  assert(queue.entries[0].nRenderPriority == RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY);
+  assert(queue.entries[0].nChunkIdx == 2);
+  assert(queue.entries[0].fZDepth == 42.0f);
   assert(render_queue_3d_count(&queue) == 1);
 }
 
-static void test_car_priority_mapping_payload_and_legacy_guard(void)
+static void test_car_priority_mapping_payload(void)
 {
   RenderQueue3D queue;
-  tTrackZOrderEntry *entry;
   const RenderCommand3D *command;
   const uint8 color_remap[2] = {3, 9};
   const GameRenderCarPose pose = {
@@ -80,11 +107,11 @@ static void test_car_priority_mapping_payload_and_legacy_guard(void)
   };
   render_queue_3d_clear(&queue);
 
-  entry = render_queue_3d_add_car(&queue, 5, 321.0f, &pose, &options);
-  assert(entry != NULL);
-  assert(entry->nRenderPriority == RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY);
-  assert(entry->nChunkIdx == 5);
-  assert(entry->fZDepth == 321.0f);
+  render_queue_3d_add_car(&queue, 5, 321.0f, &pose, &options);
+
+  assert(queue.entries[0].nRenderPriority == RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY);
+  assert(queue.entries[0].nChunkIdx == 5);
+  assert(queue.entries[0].fZDepth == 321.0f);
   assert(render_queue_3d_count(&queue) == 1);
 
   command = render_queue_3d_command_at(&queue, 0);
@@ -100,15 +127,9 @@ static void test_car_priority_mapping_payload_and_legacy_guard(void)
   assert(command->payload.car.pose.roll == 300);
   assert(command->payload.car.options.anim_frame == 7);
   assert(command->payload.car.options.color_remap == color_remap);
-
-  assert(render_queue_3d_add_legacy_priority(&queue,
-                                             RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY,
-                                             7,
-                                             321.0f) == NULL);
-  assert(render_queue_3d_count(&queue) == 1);
 }
 
-static void test_sort_keeps_typed_car_payload_with_sorted_entry(void)
+static void test_sort_keeps_typed_payloads_with_sorted_entries(void)
 {
   RenderQueue3D queue;
   const RenderCommand3D *command;
@@ -124,12 +145,13 @@ static void test_sort_keeps_typed_car_payload_with_sorted_entry(void)
   };
   render_queue_3d_clear(&queue);
 
-  assert(render_queue_3d_add_car(&queue, 4, 20.0f, &pose, &options) != NULL);
-  assert(render_queue_3d_add_legacy_priority(&queue, 2, 101, 10.0f) != NULL);
+  render_queue_3d_add_car(&queue, 4, 20.0f, &pose, &options);
+  render_queue_3d_add_unmigrated_legacy_priority(&queue, 2, 101, 10.0f);
+  render_queue_3d_add_right_lane(&queue, 77, 30.0f);
 
   render_queue_3d_sort(&queue);
 
-  assert(render_queue_3d_count(&queue) == 2);
+  assert(render_queue_3d_count(&queue) == 3);
   assert(queue.entries[0].nChunkIdx == 101);
   assert(render_queue_3d_command_at(&queue, 0) == NULL);
   assert(queue.entries[1].nRenderPriority == RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY);
@@ -141,8 +163,15 @@ static void test_sort_keeps_typed_car_payload_with_sorted_entry(void)
   assert(command->payload.car.depth == 20.0f);
   assert(command->payload.car.pose.roll == 6);
   assert(command->payload.car.options.anim_frame == 8);
+  assert(queue.entries[2].nRenderPriority == RENDER_QUEUE_3D_RIGHT_LANE_LEGACY_PRIORITY);
+  assert(queue.entries[2].nChunkIdx == 77);
+  command = render_queue_3d_command_at(&queue, 2);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_ROAD_SURFACE);
+  assert(command->payload.road_surface.surface_kind == RENDER_COMMAND_3D_ROAD_SURFACE_RIGHT_LANE);
+  assert(command->payload.road_surface.section_idx == 77);
+  assert(command->payload.road_surface.depth == 30.0f);
 }
-
 
 int main(int argc, const char **argv, const char **envp)
 {
@@ -150,9 +179,10 @@ int main(int argc, const char **argv, const char **envp)
   (void)argv;
   (void)envp;
   test_sort_matches_legacy_zcmp();
-  test_building_priority_mapping_and_legacy_guard();
-  test_start_light_priority_mapping_and_legacy_guard();
-  test_car_priority_mapping_payload_and_legacy_guard();
-  test_sort_keeps_typed_car_payload_with_sorted_entry();
+  test_road_lane_priority_mapping_payloads();
+  test_building_priority_mapping();
+  test_start_light_priority_mapping();
+  test_car_priority_mapping_payload();
+  test_sort_keeps_typed_payloads_with_sorted_entries();
   return 0;
 }

--- a/tools/check_render_queue_3d_seams.py
+++ b/tools/check_render_queue_3d_seams.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Pin migrated render_queue_3d command seams.
 
-Cars, buildings, and start lights have migrated away from raw legacy priority submission.
-Keep priorities 11, 13, and 14 out of drawtrk3's direct writes and out of the temporary
-legacy-priority compatibility path.
+Cars, buildings, start lights, and road/lane surfaces have migrated away from raw legacy
+priority submission. Keep priorities 5, 6, 7, 11, 13, and 14 out of drawtrk3's direct
+writes and out of the temporary unmigrated-priority compatibility path.
 """
 from __future__ import annotations
 
@@ -13,6 +13,25 @@ import sys
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 DRAWTRK3 = ROOT / "PROJECTS" / "ROLLER" / "drawtrk3.c"
+ROLLER_SRC = ROOT / "PROJECTS" / "ROLLER"
+
+MIGRATED_PRIORITIES = {
+    5: "road-center",
+    6: "left-lane",
+    7: "right-lane",
+    11: "car",
+    13: "building",
+    14: "start-light",
+}
+
+REQUIRED_DRAWTRK3_APIS = {
+    "render_queue_3d_add_road_center": "road center",
+    "render_queue_3d_add_left_lane": "left lane",
+    "render_queue_3d_add_right_lane": "right lane",
+    "render_queue_3d_add_car": "cars",
+    "render_queue_3d_add_building": "buildings",
+    "render_queue_3d_add_start_light": "start lights",
+}
 
 
 def fail(message: str) -> int:
@@ -20,34 +39,49 @@ def fail(message: str) -> int:
     return 1
 
 
+def direct_priority_write_pattern(priority: int) -> re.Pattern[str]:
+    return re.compile(rf"\.nRenderPriority\s*=\s*{priority}\b|->nRenderPriority\s*=\s*{priority}\b")
+
+
+def compatibility_call_pattern(function_name: str, priority: int) -> re.Pattern[str]:
+    return re.compile(rf"{function_name}\s*\([^;]*\b{priority}\b", re.DOTALL)
+
+
 def main() -> int:
     drawtrk3 = DRAWTRK3.read_text(encoding="utf-8")
 
-    if re.search(r"\.nRenderPriority\s*=\s*11\b|->nRenderPriority\s*=\s*11\b", drawtrk3):
-        return fail("drawtrk3.c writes car legacy priority 11 directly")
+    for priority, name in MIGRATED_PRIORITIES.items():
+        if direct_priority_write_pattern(priority).search(drawtrk3):
+            return fail(f"drawtrk3.c writes {name} legacy priority {priority} directly")
 
-    if re.search(r"\.nRenderPriority\s*=\s*13\b|->nRenderPriority\s*=\s*13\b", drawtrk3):
-        return fail("drawtrk3.c writes building legacy priority 13 directly")
+    for api_name, label in REQUIRED_DRAWTRK3_APIS.items():
+        if api_name not in drawtrk3:
+            return fail(f"drawtrk3.c does not submit {label} through {api_name}")
 
-    if re.search(r"\.nRenderPriority\s*=\s*14\b|->nRenderPriority\s*=\s*14\b", drawtrk3):
-        return fail("drawtrk3.c writes start-light legacy priority 14 directly")
+    if "render_queue_3d_set_legacy_count" in drawtrk3:
+        return fail("drawtrk3.c still syncs raw TrackView writes with render_queue_3d_set_legacy_count")
 
-    if "render_queue_3d_add_building" not in drawtrk3:
-        return fail("drawtrk3.c does not submit buildings through render_queue_3d_add_building")
+    if re.search(r"\bnum_bits\b", drawtrk3):
+        return fail("drawtrk3.c still maintains num_bits instead of querying render_queue_3d_count")
 
-    if "render_queue_3d_add_start_light" not in drawtrk3:
-        return fail("drawtrk3.c does not submit start lights through render_queue_3d_add_start_light")
+    if "render_queue_3d_add_legacy_priority" in drawtrk3:
+        return fail("drawtrk3.c still uses old legacy-priority compatibility API name")
 
-    if "render_queue_3d_add_car" not in drawtrk3:
-        return fail("drawtrk3.c does not submit cars through render_queue_3d_add_car")
-
-    legacy_named_priority = re.compile(r"render_queue_3d_add_legacy_priority\s*\([^;]*\b(?:11|13|14)\b", re.DOTALL)
-    for path in (ROOT / "PROJECTS" / "ROLLER").glob("*.c"):
+    for path in ROLLER_SRC.glob("*.c"):
         if path.name == "render_queue_3d.c":
             continue
         text = path.read_text(encoding="utf-8")
-        if legacy_named_priority.search(text):
-            return fail(f"{path.relative_to(ROOT)} submits priority 11, 13, or 14 through legacy compatibility API")
+        for priority, name in MIGRATED_PRIORITIES.items():
+            if compatibility_call_pattern("render_queue_3d_add_unmigrated_legacy_priority", priority).search(text):
+                return fail(
+                    f"{path.relative_to(ROOT)} submits migrated {name} priority {priority} "
+                    "through unmigrated compatibility API"
+                )
+            if compatibility_call_pattern("render_queue_3d_add_legacy_priority", priority).search(text):
+                return fail(
+                    f"{path.relative_to(ROOT)} submits migrated {name} priority {priority} "
+                    "through old compatibility API"
+                )
 
     return 0
 


### PR DESCRIPTION
## Summary
- Route road-center, left-lane, and right-lane gameplay 3D surfaces through named `render_queue_3d` APIs with typed road-surface payloads.
- Make `RenderQueue3D.count` authoritative in `DrawTrack3` by replacing phase-2 raw `TrackView[num_bits]` writes with queue append APIs.
- Remove `num_bits` / `render_queue_3d_set_legacy_count`, hard-fail invalid queue appends, and extend seam/unit coverage.

## Test Plan
- [x] `git diff --check`
- [x] `zig build test`
- [x] `zig build`

Closes #157
