### PR TITLE
Route wall surfaces through render_queue_3d

### DIFF
--- a/PROJECTS/ROLLER/drawtrk3.c
+++ b/PROJECTS/ROLLER/drawtrk3.c
@@ -1985,7 +1985,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
       }
       fLeftLowerWallDepthSelected = fLeftLowerWallSelected;
       fLeftLowerWallCmdDepth = fLeftLowerWallDepthSelected;
-      render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 3, iCurrentSect, fLeftLowerWallCmdDepth); // lower wall, migrate in #158
+      render_queue_3d_add_left_lower_wall(render_queue_3d_global(), iCurrentSect, fLeftLowerWallCmdDepth);
     }
     if (GroundColour[iCurrentSect][GROUND_COLOUR_RLOWALL] != -1 && bGroundVisible) {
       if (pNextGroundScreen->screenPtAy[3].projected.fZ <= (double)pNextGroundScreen->screenPtAy[4].projected.fZ)
@@ -2013,7 +2013,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
       }
       fRightLowerWallDepthSelected = fRightLowerWallSelected;
       fRightLowerWallCmdDepth = fRightLowerWallDepthSelected;
-      render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 4, iCurrentSect, fRightLowerWallCmdDepth); // lower wall, migrate in #158
+      render_queue_3d_add_right_lower_wall(render_queue_3d_global(), iCurrentSect, fRightLowerWallCmdDepth);
     }
     if (pScreenCoord_1->iClipCount != 99 && pScreenCoord->iClipCount != 99) {
       if (Walls_On) {
@@ -2054,7 +2054,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
                 * 0.25f;
             }
             fRightWallCmdDepth = fLeftWallRoofDepth;
-            render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 8, iCurrentSect, fRightWallCmdDepth); // wall, migrate in #158
+            render_queue_3d_add_left_high_wall(render_queue_3d_global(), iCurrentSect, fRightWallCmdDepth);
           } else {
             if (pScreenCoord_1->screenPtAy[0].projected.fZ <= (double)pScreenCoord_1->screenPtAy[1].projected.fZ)
               fLeftWallDepthMax1 = pScreenCoord_1->screenPtAy[1].projected.fZ;
@@ -2080,7 +2080,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
               fLeftWallDepthTmp1 = fLeftWallDepthSelected;
             }
             fLeftWallFinalDepth = fLeftWallDepthSelected;
-            render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 0, iCurrentSect, fLeftWallFinalDepth); // wall, migrate in #158
+            render_queue_3d_add_left_wall(render_queue_3d_global(), iCurrentSect, fLeftWallFinalDepth);
           }
         }
       }
@@ -2123,7 +2123,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
                                    + pScreenCoord->screenPtAy[5].projected.fZ)
                 * 0.25f;
             }
-            render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 9, iCurrentSect, fRightWallRoofDepth); // wall, migrate in #158
+            render_queue_3d_add_right_high_wall(render_queue_3d_global(), iCurrentSect, fRightWallRoofDepth);
           } else {
             if (pScreenCoord_1->screenPtAy[2].projected.fZ <= (double)pScreenCoord_1->screenPtAy[3].projected.fZ)
               fRightWallBasicDepth1 = pScreenCoord_1->screenPtAy[3].projected.fZ;
@@ -2150,7 +2150,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
             }
             fRightWallFinalDepth = fRightWallBasicSelected;
             fRightWallBasicCmdDepth = fRightWallFinalDepth;
-            render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 1, iCurrentSect, fRightWallBasicCmdDepth); // wall, migrate in #158
+            render_queue_3d_add_right_wall(render_queue_3d_global(), iCurrentSect, fRightWallBasicCmdDepth);
           }
         }
       }
@@ -2292,8 +2292,8 @@ LABEL_393:
         pNextGroundScreen = &GroundScreenXYZ[iNextSectionIndex];
       }
       switch (pRenderCommand->nRenderPriority) {
-        case 0:
-        case 8:
+        case RENDER_QUEUE_3D_LEFT_WALL_LEGACY_PRIORITY:
+        case RENDER_QUEUE_3D_LEFT_HIGH_WALL_LEGACY_PRIORITY:
           {
             int sf = TrakColour[iSectionNum][TRAK_COLOUR_LEFT_WALL];
             int highWall = (sf < 0);
@@ -2318,8 +2318,8 @@ LABEL_393:
             }
           }
           goto LABEL_1271;
-        case 1:
-        case 9:
+        case RENDER_QUEUE_3D_RIGHT_WALL_LEGACY_PRIORITY:
+        case RENDER_QUEUE_3D_RIGHT_HIGH_WALL_LEGACY_PRIORITY:
           {
             int sf = TrakColour[iSectionNum][TRAK_COLOUR_RIGHT_WALL];
             int highWall = (sf < 0);
@@ -2378,7 +2378,7 @@ LABEL_393:
             }
           }
           goto LABEL_1271;
-        case 3:
+        case RENDER_QUEUE_3D_LEFT_LOWER_WALL_LEGACY_PRIORITY:
           {
             int sf = GroundColour[iSectionNum][GROUND_COLOUR_LUOWALL];
             if (sf == -1 || GroundColour[iSectionNum][GROUND_COLOUR_OFLOOR] == -1)
@@ -2446,7 +2446,7 @@ LABEL_393:
             }
           }
           goto LABEL_1271;
-        case 4:
+        case RENDER_QUEUE_3D_RIGHT_LOWER_WALL_LEGACY_PRIORITY:
           {
             int sf = GroundColour[iSectionNum][GROUND_COLOUR_RUOWALL];
             if (sf == -1 || GroundColour[iSectionNum][GROUND_COLOUR_OFLOOR] == -1)

--- a/PROJECTS/ROLLER/render_queue_3d.c
+++ b/PROJECTS/ROLLER/render_queue_3d.c
@@ -27,9 +27,15 @@ static void render_queue_3d_require(int iCondition)
 static int render_queue_3d_is_named_priority(int iLegacyPriority)
 {
   switch (iLegacyPriority) {
+  case RENDER_QUEUE_3D_LEFT_WALL_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_RIGHT_WALL_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_LEFT_LOWER_WALL_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_RIGHT_LOWER_WALL_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_ROAD_CENTER_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_LEFT_LANE_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_RIGHT_LANE_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_LEFT_HIGH_WALL_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_RIGHT_HIGH_WALL_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY:
@@ -160,6 +166,111 @@ void render_queue_3d_add_right_lane(RenderQueue3D *pQueue,
 }
 
 //-------------------------------------------------------------------------------------------------
+
+static void render_queue_3d_add_wall_surface(RenderQueue3D *pQueue,
+                                             int iLegacyPriority,
+                                             int iSectionIdx,
+                                             float fZDepth,
+                                             RenderCommand3DWallSurfaceSide side,
+                                             RenderCommand3DWallSurfaceVariant variant)
+{
+  render_queue_3d_add_required(pQueue, iLegacyPriority, iSectionIdx, fZDepth);
+  RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
+  pCommand->kind = RENDER_COMMAND_3D_KIND_WALL_SURFACE;
+  pCommand->payload.wall_surface.section_idx = iSectionIdx;
+  pCommand->payload.wall_surface.depth = fZDepth;
+  pCommand->payload.wall_surface.side = side;
+  pCommand->payload.wall_surface.variant = variant;
+  pQueue->has_typed_command[pQueue->count - 1] = 1;
+}
+
+void render_queue_3d_add_left_wall(RenderQueue3D *pQueue,
+                                    int iSectionIdx,
+                                    float fZDepth)
+{
+  render_queue_3d_add_wall_surface(pQueue,
+                                   RENDER_QUEUE_3D_LEFT_WALL_LEGACY_PRIORITY,
+                                   iSectionIdx,
+                                   fZDepth,
+                                   RENDER_COMMAND_3D_WALL_SURFACE_LEFT,
+                                   RENDER_COMMAND_3D_WALL_SURFACE_BASIC);
+}
+
+void render_queue_3d_add_right_wall(RenderQueue3D *pQueue,
+                                     int iSectionIdx,
+                                     float fZDepth)
+{
+  render_queue_3d_add_wall_surface(pQueue,
+                                   RENDER_QUEUE_3D_RIGHT_WALL_LEGACY_PRIORITY,
+                                   iSectionIdx,
+                                   fZDepth,
+                                   RENDER_COMMAND_3D_WALL_SURFACE_RIGHT,
+                                   RENDER_COMMAND_3D_WALL_SURFACE_BASIC);
+}
+
+void render_queue_3d_add_left_high_wall(RenderQueue3D *pQueue,
+                                         int iSectionIdx,
+                                         float fZDepth)
+{
+  render_queue_3d_add_wall_surface(pQueue,
+                                   RENDER_QUEUE_3D_LEFT_HIGH_WALL_LEGACY_PRIORITY,
+                                   iSectionIdx,
+                                   fZDepth,
+                                   RENDER_COMMAND_3D_WALL_SURFACE_LEFT,
+                                   RENDER_COMMAND_3D_WALL_SURFACE_HIGH);
+}
+
+void render_queue_3d_add_right_high_wall(RenderQueue3D *pQueue,
+                                          int iSectionIdx,
+                                          float fZDepth)
+{
+  render_queue_3d_add_wall_surface(pQueue,
+                                   RENDER_QUEUE_3D_RIGHT_HIGH_WALL_LEGACY_PRIORITY,
+                                   iSectionIdx,
+                                   fZDepth,
+                                   RENDER_COMMAND_3D_WALL_SURFACE_RIGHT,
+                                   RENDER_COMMAND_3D_WALL_SURFACE_HIGH);
+}
+
+static void render_queue_3d_add_lower_wall_surface(RenderQueue3D *pQueue,
+                                                   int iLegacyPriority,
+                                                   int iSectionIdx,
+                                                   float fZDepth,
+                                                   RenderCommand3DWallSurfaceSide side)
+{
+  render_queue_3d_add_required(pQueue, iLegacyPriority, iSectionIdx, fZDepth);
+  RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
+  pCommand->kind = RENDER_COMMAND_3D_KIND_LOWER_WALL_SURFACE;
+  pCommand->payload.lower_wall_surface.section_idx = iSectionIdx;
+  pCommand->payload.lower_wall_surface.depth = fZDepth;
+  pCommand->payload.lower_wall_surface.side = side;
+  pQueue->has_typed_command[pQueue->count - 1] = 1;
+}
+
+void render_queue_3d_add_left_lower_wall(RenderQueue3D *pQueue,
+                                          int iSectionIdx,
+                                          float fZDepth)
+{
+  render_queue_3d_add_lower_wall_surface(pQueue,
+                                         RENDER_QUEUE_3D_LEFT_LOWER_WALL_LEGACY_PRIORITY,
+                                         iSectionIdx,
+                                         fZDepth,
+                                         RENDER_COMMAND_3D_WALL_SURFACE_LEFT);
+}
+
+void render_queue_3d_add_right_lower_wall(RenderQueue3D *pQueue,
+                                           int iSectionIdx,
+                                           float fZDepth)
+{
+  render_queue_3d_add_lower_wall_surface(pQueue,
+                                         RENDER_QUEUE_3D_RIGHT_LOWER_WALL_LEGACY_PRIORITY,
+                                         iSectionIdx,
+                                         fZDepth,
+                                         RENDER_COMMAND_3D_WALL_SURFACE_RIGHT);
+}
+
+//-------------------------------------------------------------------------------------------------
+
 
 void render_queue_3d_add_building(RenderQueue3D *pQueue,
                                    int iBuildingIdx,

--- a/PROJECTS/ROLLER/render_queue_3d.h
+++ b/PROJECTS/ROLLER/render_queue_3d.h
@@ -5,9 +5,15 @@
 //-------------------------------------------------------------------------------------------------
 
 #define RENDER_QUEUE_3D_CAPACITY 6500
+#define RENDER_QUEUE_3D_LEFT_WALL_LEGACY_PRIORITY 0
+#define RENDER_QUEUE_3D_RIGHT_WALL_LEGACY_PRIORITY 1
+#define RENDER_QUEUE_3D_LEFT_LOWER_WALL_LEGACY_PRIORITY 3
+#define RENDER_QUEUE_3D_RIGHT_LOWER_WALL_LEGACY_PRIORITY 4
 #define RENDER_QUEUE_3D_ROAD_CENTER_LEGACY_PRIORITY 5
 #define RENDER_QUEUE_3D_LEFT_LANE_LEGACY_PRIORITY 6
 #define RENDER_QUEUE_3D_RIGHT_LANE_LEGACY_PRIORITY 7
+#define RENDER_QUEUE_3D_LEFT_HIGH_WALL_LEGACY_PRIORITY 8
+#define RENDER_QUEUE_3D_RIGHT_HIGH_WALL_LEGACY_PRIORITY 9
 #define RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY 11
 #define RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY 13
 #define RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY 14
@@ -18,8 +24,10 @@ typedef enum
 {
   RENDER_COMMAND_3D_KIND_BUILDING = 0,
   RENDER_COMMAND_3D_KIND_CAR,
+  RENDER_COMMAND_3D_KIND_LOWER_WALL_SURFACE,
   RENDER_COMMAND_3D_KIND_ROAD_SURFACE,
-  RENDER_COMMAND_3D_KIND_START_LIGHT
+  RENDER_COMMAND_3D_KIND_START_LIGHT,
+  RENDER_COMMAND_3D_KIND_WALL_SURFACE
 } RenderCommand3DKind;
 
 typedef struct
@@ -35,6 +43,33 @@ typedef struct
   GameRenderCarPose pose;
   GameRenderCarOptions options;
 } RenderCommand3DCar;
+
+typedef enum
+{
+  RENDER_COMMAND_3D_WALL_SURFACE_LEFT = 0,
+  RENDER_COMMAND_3D_WALL_SURFACE_RIGHT
+} RenderCommand3DWallSurfaceSide;
+
+typedef enum
+{
+  RENDER_COMMAND_3D_WALL_SURFACE_BASIC = 0,
+  RENDER_COMMAND_3D_WALL_SURFACE_HIGH
+} RenderCommand3DWallSurfaceVariant;
+
+typedef struct
+{
+  int section_idx;
+  float depth;
+  RenderCommand3DWallSurfaceSide side;
+  RenderCommand3DWallSurfaceVariant variant;
+} RenderCommand3DWallSurface;
+
+typedef struct
+{
+  int section_idx;
+  float depth;
+  RenderCommand3DWallSurfaceSide side;
+} RenderCommand3DLowerWallSurface;
 
 typedef enum
 {
@@ -63,8 +98,10 @@ typedef struct
   {
     RenderCommand3DBuilding building;
     RenderCommand3DCar car;
+    RenderCommand3DLowerWallSurface lower_wall_surface;
     RenderCommand3DRoadSurface road_surface;
     RenderCommand3DStartLight start_light;
+    RenderCommand3DWallSurface wall_surface;
   } payload;
 } RenderCommand3D;
 
@@ -91,6 +128,30 @@ void render_queue_3d_add_unmigrated_legacy_priority(RenderQueue3D *pQueue,
                                                      int iLegacyPriority,
                                                      int iChunkIdx,
                                                      float fZDepth);
+
+void render_queue_3d_add_left_wall(RenderQueue3D *pQueue,
+                                    int iSectionIdx,
+                                    float fZDepth);
+
+void render_queue_3d_add_right_wall(RenderQueue3D *pQueue,
+                                     int iSectionIdx,
+                                     float fZDepth);
+
+void render_queue_3d_add_left_high_wall(RenderQueue3D *pQueue,
+                                         int iSectionIdx,
+                                         float fZDepth);
+
+void render_queue_3d_add_right_high_wall(RenderQueue3D *pQueue,
+                                          int iSectionIdx,
+                                          float fZDepth);
+
+void render_queue_3d_add_left_lower_wall(RenderQueue3D *pQueue,
+                                          int iSectionIdx,
+                                          float fZDepth);
+
+void render_queue_3d_add_right_lower_wall(RenderQueue3D *pQueue,
+                                           int iSectionIdx,
+                                           float fZDepth);
 
 void render_queue_3d_add_road_center(RenderQueue3D *pQueue,
                                       int iSectionIdx,

--- a/tests/render_queue_3d_test.c
+++ b/tests/render_queue_3d_test.c
@@ -64,6 +64,97 @@ static void test_road_lane_priority_mapping_payloads(void)
   assert(command->payload.road_surface.depth == 125.0f);
 }
 
+
+static void test_wall_priority_mapping_payloads(void)
+{
+  RenderQueue3D queue;
+  const RenderCommand3D *command;
+  render_queue_3d_clear(&queue);
+
+  render_queue_3d_add_left_wall(&queue, 20, 200.0f);
+  render_queue_3d_add_right_wall(&queue, 21, 201.0f);
+  render_queue_3d_add_left_high_wall(&queue, 22, 202.0f);
+  render_queue_3d_add_right_high_wall(&queue, 23, 203.0f);
+
+  assert(render_queue_3d_count(&queue) == 4);
+
+  assert(queue.entries[0].nRenderPriority == RENDER_QUEUE_3D_LEFT_WALL_LEGACY_PRIORITY);
+  assert(queue.entries[0].nChunkIdx == 20);
+  assert(queue.entries[0].fZDepth == 200.0f);
+  command = render_queue_3d_command_at(&queue, 0);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_WALL_SURFACE);
+  assert(command->payload.wall_surface.section_idx == 20);
+  assert(command->payload.wall_surface.depth == 200.0f);
+  assert(command->payload.wall_surface.side == RENDER_COMMAND_3D_WALL_SURFACE_LEFT);
+  assert(command->payload.wall_surface.variant == RENDER_COMMAND_3D_WALL_SURFACE_BASIC);
+
+  assert(queue.entries[1].nRenderPriority == RENDER_QUEUE_3D_RIGHT_WALL_LEGACY_PRIORITY);
+  assert(queue.entries[1].nChunkIdx == 21);
+  assert(queue.entries[1].fZDepth == 201.0f);
+  command = render_queue_3d_command_at(&queue, 1);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_WALL_SURFACE);
+  assert(command->payload.wall_surface.section_idx == 21);
+  assert(command->payload.wall_surface.depth == 201.0f);
+  assert(command->payload.wall_surface.side == RENDER_COMMAND_3D_WALL_SURFACE_RIGHT);
+  assert(command->payload.wall_surface.variant == RENDER_COMMAND_3D_WALL_SURFACE_BASIC);
+
+  assert(queue.entries[2].nRenderPriority == RENDER_QUEUE_3D_LEFT_HIGH_WALL_LEGACY_PRIORITY);
+  assert(queue.entries[2].nChunkIdx == 22);
+  assert(queue.entries[2].fZDepth == 202.0f);
+  command = render_queue_3d_command_at(&queue, 2);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_WALL_SURFACE);
+  assert(command->payload.wall_surface.section_idx == 22);
+  assert(command->payload.wall_surface.depth == 202.0f);
+  assert(command->payload.wall_surface.side == RENDER_COMMAND_3D_WALL_SURFACE_LEFT);
+  assert(command->payload.wall_surface.variant == RENDER_COMMAND_3D_WALL_SURFACE_HIGH);
+
+  assert(queue.entries[3].nRenderPriority == RENDER_QUEUE_3D_RIGHT_HIGH_WALL_LEGACY_PRIORITY);
+  assert(queue.entries[3].nChunkIdx == 23);
+  assert(queue.entries[3].fZDepth == 203.0f);
+  command = render_queue_3d_command_at(&queue, 3);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_WALL_SURFACE);
+  assert(command->payload.wall_surface.section_idx == 23);
+  assert(command->payload.wall_surface.depth == 203.0f);
+  assert(command->payload.wall_surface.side == RENDER_COMMAND_3D_WALL_SURFACE_RIGHT);
+  assert(command->payload.wall_surface.variant == RENDER_COMMAND_3D_WALL_SURFACE_HIGH);
+}
+
+static void test_lower_wall_priority_mapping_payloads(void)
+{
+  RenderQueue3D queue;
+  const RenderCommand3D *command;
+  render_queue_3d_clear(&queue);
+
+  render_queue_3d_add_left_lower_wall(&queue, 30, 300.0f);
+  render_queue_3d_add_right_lower_wall(&queue, 31, 301.0f);
+
+  assert(render_queue_3d_count(&queue) == 2);
+
+  assert(queue.entries[0].nRenderPriority == RENDER_QUEUE_3D_LEFT_LOWER_WALL_LEGACY_PRIORITY);
+  assert(queue.entries[0].nChunkIdx == 30);
+  assert(queue.entries[0].fZDepth == 300.0f);
+  command = render_queue_3d_command_at(&queue, 0);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_LOWER_WALL_SURFACE);
+  assert(command->payload.lower_wall_surface.section_idx == 30);
+  assert(command->payload.lower_wall_surface.depth == 300.0f);
+  assert(command->payload.lower_wall_surface.side == RENDER_COMMAND_3D_WALL_SURFACE_LEFT);
+
+  assert(queue.entries[1].nRenderPriority == RENDER_QUEUE_3D_RIGHT_LOWER_WALL_LEGACY_PRIORITY);
+  assert(queue.entries[1].nChunkIdx == 31);
+  assert(queue.entries[1].fZDepth == 301.0f);
+  command = render_queue_3d_command_at(&queue, 1);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_LOWER_WALL_SURFACE);
+  assert(command->payload.lower_wall_surface.section_idx == 31);
+  assert(command->payload.lower_wall_surface.depth == 301.0f);
+  assert(command->payload.lower_wall_surface.side == RENDER_COMMAND_3D_WALL_SURFACE_RIGHT);
+}
+
 static void test_building_priority_mapping(void)
 {
   RenderQueue3D queue;
@@ -180,6 +271,8 @@ int main(int argc, const char **argv, const char **envp)
   (void)envp;
   test_sort_matches_legacy_zcmp();
   test_road_lane_priority_mapping_payloads();
+  test_wall_priority_mapping_payloads();
+  test_lower_wall_priority_mapping_payloads();
   test_building_priority_mapping();
   test_start_light_priority_mapping();
   test_car_priority_mapping_payload();

--- a/tools/check_render_queue_3d_seams.py
+++ b/tools/check_render_queue_3d_seams.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Pin migrated render_queue_3d command seams.
 
-Cars, buildings, start lights, and road/lane surfaces have migrated away from raw legacy
-priority submission. Keep priorities 5, 6, 7, 11, 13, and 14 out of drawtrk3's direct
-writes and out of the temporary unmigrated-priority compatibility path.
+Cars, buildings, start lights, road/lane surfaces, and wall/lower-wall surfaces have migrated
+away from raw legacy priority submission. Keep priorities 0, 1, 3, 4, 5, 6, 7, 8, 9,
+11, 13, and 14 out of drawtrk3's direct writes and out of the temporary unmigrated-priority
+compatibility path.
 """
 from __future__ import annotations
 
@@ -16,15 +17,27 @@ DRAWTRK3 = ROOT / "PROJECTS" / "ROLLER" / "drawtrk3.c"
 ROLLER_SRC = ROOT / "PROJECTS" / "ROLLER"
 
 MIGRATED_PRIORITIES = {
+    0: "left-wall",
+    1: "right-wall",
+    3: "left-lower-wall",
+    4: "right-lower-wall",
     5: "road-center",
     6: "left-lane",
     7: "right-lane",
+    8: "left-high-wall",
+    9: "right-high-wall",
     11: "car",
     13: "building",
     14: "start-light",
 }
 
 REQUIRED_DRAWTRK3_APIS = {
+    "render_queue_3d_add_left_wall": "left wall",
+    "render_queue_3d_add_right_wall": "right wall",
+    "render_queue_3d_add_left_lower_wall": "left lower wall",
+    "render_queue_3d_add_right_lower_wall": "right lower wall",
+    "render_queue_3d_add_left_high_wall": "left high wall",
+    "render_queue_3d_add_right_high_wall": "right high wall",
     "render_queue_3d_add_road_center": "road center",
     "render_queue_3d_add_left_lane": "left lane",
     "render_queue_3d_add_right_lane": "right lane",


### PR DESCRIPTION
## Summary
- Route wall and lower-wall gameplay 3D surfaces through named `render_queue_3d` APIs for priorities `0/1/3/4/8/9`.
- Add typed wall/lower-wall queue payloads while preserving legacy-priority dispatch behavior.
- Extend render queue unit coverage and seam checks to keep migrated wall priorities off the unmigrated compatibility path.

## Test Plan
- [x] `git diff --check`
- [x] `zig build test-render-queue-3d`
- [x] `zig build test`
- [x] `zig build test-snapshots`
- [x] `zig build`

Closes #158
