### PR TITLE
Route ground and roof surfaces through render_queue_3d

### DIFF
--- a/PROJECTS/ROLLER/drawtrk3.c
+++ b/PROJECTS/ROLLER/drawtrk3.c
@@ -1766,7 +1766,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
         fProjectionZ = fGroundDepthSelected;
       }
       fGroundRenderDepth = fProjectionZ;
-      render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 2, iCurrentSect, fGroundRenderDepth); // ground, migrate in #159
+      render_queue_3d_add_ground(render_queue_3d_global(), iCurrentSect, fGroundRenderDepth);
     }
     if (pScreenCoord_1->iClipCount != 99 && pScreenCoord->iClipCount != 99 && Road_On) {
       if (pScreenCoord_1->screenPtAy[2].projected.fZ <= (double)pScreenCoord_1->screenPtAy[1].projected.fZ)
@@ -1884,7 +1884,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
             }
             fRoof1DepthSelected = fRoof1SelectedDepth;
             fRoof1CmdDepth = fRoof1DepthSelected;
-            render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 10, iCurrentSect, fRoof1CmdDepth); // roof, migrate in #159
+            render_queue_3d_add_next_section_roof(render_queue_3d_global(), iCurrentSect, fRoof1CmdDepth);
             goto LABEL_238;
           }
           iRoofType = TrakColour[iNextSectionIndex][TRAK_COLOUR_ROOF];
@@ -1954,7 +1954,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
             }
             fRoof2CmdDepth = fRoof2DepthSelected;
           }
-          render_queue_3d_add_unmigrated_legacy_priority(render_queue_3d_global(), 10, iCurrentSect, fRoof2CmdDepth); // roof, migrate in #159
+          render_queue_3d_add_current_section_roof(render_queue_3d_global(), iCurrentSect, fRoof2CmdDepth);
         }
       }
     }
@@ -2348,7 +2348,7 @@ LABEL_393:
           if (++iRenderObjectIndex >= iRenderQueueCount)
             return;
           break;
-        case 2:
+        case RENDER_QUEUE_3D_GROUND_LEGACY_PRIORITY:
           {
             int sf = GroundColour[iSectionNum][GROUND_COLOUR_OFLOOR];
             if (!facing_ok(
@@ -2566,7 +2566,7 @@ LABEL_393:
             }
           }
           goto LABEL_1271;
-        case 0xA:
+        case RENDER_QUEUE_3D_ROOF_LEGACY_PRIORITY:
           {
             int sf = TrakColour[iSectionNum][TRAK_COLOUR_ROOF];
             /* Single-section roof from NEXT section (negative surface type) */

--- a/PROJECTS/ROLLER/render_queue_3d.c
+++ b/PROJECTS/ROLLER/render_queue_3d.c
@@ -29,6 +29,7 @@ static int render_queue_3d_is_named_priority(int iLegacyPriority)
   switch (iLegacyPriority) {
   case RENDER_QUEUE_3D_LEFT_WALL_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_RIGHT_WALL_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_GROUND_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_LEFT_LOWER_WALL_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_RIGHT_LOWER_WALL_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_ROAD_CENTER_LEGACY_PRIORITY:
@@ -36,6 +37,7 @@ static int render_queue_3d_is_named_priority(int iLegacyPriority)
   case RENDER_QUEUE_3D_RIGHT_LANE_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_LEFT_HIGH_WALL_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_RIGHT_HIGH_WALL_LEGACY_PRIORITY:
+  case RENDER_QUEUE_3D_ROOF_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY:
   case RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY:
@@ -113,6 +115,54 @@ void render_queue_3d_add_unmigrated_legacy_priority(RenderQueue3D *pQueue,
 {
   render_queue_3d_require(!render_queue_3d_is_named_priority(iLegacyPriority));
   render_queue_3d_add_required(pQueue, iLegacyPriority, iChunkIdx, fZDepth);
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void render_queue_3d_add_ground(RenderQueue3D *pQueue,
+                                 int iSectionIdx,
+                                 float fZDepth)
+{
+  render_queue_3d_add_required(pQueue, RENDER_QUEUE_3D_GROUND_LEGACY_PRIORITY, iSectionIdx, fZDepth);
+  RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
+  pCommand->kind = RENDER_COMMAND_3D_KIND_GROUND_SURFACE;
+  pCommand->payload.ground_surface.section_idx = iSectionIdx;
+  pCommand->payload.ground_surface.depth = fZDepth;
+  pQueue->has_typed_command[pQueue->count - 1] = 1;
+}
+
+static void render_queue_3d_add_roof_surface(RenderQueue3D *pQueue,
+                                             int iSectionIdx,
+                                             float fZDepth,
+                                             RenderCommand3DRoofSurfaceVariant variant)
+{
+  render_queue_3d_add_required(pQueue, RENDER_QUEUE_3D_ROOF_LEGACY_PRIORITY, iSectionIdx, fZDepth);
+  RenderCommand3D *pCommand = &pQueue->commands[pQueue->count - 1];
+  pCommand->kind = RENDER_COMMAND_3D_KIND_ROOF_SURFACE;
+  pCommand->payload.roof_surface.section_idx = iSectionIdx;
+  pCommand->payload.roof_surface.depth = fZDepth;
+  pCommand->payload.roof_surface.variant = variant;
+  pQueue->has_typed_command[pQueue->count - 1] = 1;
+}
+
+void render_queue_3d_add_next_section_roof(RenderQueue3D *pQueue,
+                                            int iSectionIdx,
+                                            float fZDepth)
+{
+  render_queue_3d_add_roof_surface(pQueue,
+                                   iSectionIdx,
+                                   fZDepth,
+                                   RENDER_COMMAND_3D_ROOF_SURFACE_NEXT_SECTION);
+}
+
+void render_queue_3d_add_current_section_roof(RenderQueue3D *pQueue,
+                                               int iSectionIdx,
+                                               float fZDepth)
+{
+  render_queue_3d_add_roof_surface(pQueue,
+                                   iSectionIdx,
+                                   fZDepth,
+                                   RENDER_COMMAND_3D_ROOF_SURFACE_CURRENT_SECTION);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/render_queue_3d.h
+++ b/PROJECTS/ROLLER/render_queue_3d.h
@@ -7,6 +7,7 @@
 #define RENDER_QUEUE_3D_CAPACITY 6500
 #define RENDER_QUEUE_3D_LEFT_WALL_LEGACY_PRIORITY 0
 #define RENDER_QUEUE_3D_RIGHT_WALL_LEGACY_PRIORITY 1
+#define RENDER_QUEUE_3D_GROUND_LEGACY_PRIORITY 2
 #define RENDER_QUEUE_3D_LEFT_LOWER_WALL_LEGACY_PRIORITY 3
 #define RENDER_QUEUE_3D_RIGHT_LOWER_WALL_LEGACY_PRIORITY 4
 #define RENDER_QUEUE_3D_ROAD_CENTER_LEGACY_PRIORITY 5
@@ -14,6 +15,7 @@
 #define RENDER_QUEUE_3D_RIGHT_LANE_LEGACY_PRIORITY 7
 #define RENDER_QUEUE_3D_LEFT_HIGH_WALL_LEGACY_PRIORITY 8
 #define RENDER_QUEUE_3D_RIGHT_HIGH_WALL_LEGACY_PRIORITY 9
+#define RENDER_QUEUE_3D_ROOF_LEGACY_PRIORITY 10
 #define RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY 11
 #define RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY 13
 #define RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY 14
@@ -24,8 +26,10 @@ typedef enum
 {
   RENDER_COMMAND_3D_KIND_BUILDING = 0,
   RENDER_COMMAND_3D_KIND_CAR,
+  RENDER_COMMAND_3D_KIND_GROUND_SURFACE,
   RENDER_COMMAND_3D_KIND_LOWER_WALL_SURFACE,
   RENDER_COMMAND_3D_KIND_ROAD_SURFACE,
+  RENDER_COMMAND_3D_KIND_ROOF_SURFACE,
   RENDER_COMMAND_3D_KIND_START_LIGHT,
   RENDER_COMMAND_3D_KIND_WALL_SURFACE
 } RenderCommand3DKind;
@@ -43,6 +47,12 @@ typedef struct
   GameRenderCarPose pose;
   GameRenderCarOptions options;
 } RenderCommand3DCar;
+
+typedef struct
+{
+  int section_idx;
+  float depth;
+} RenderCommand3DGroundSurface;
 
 typedef enum
 {
@@ -85,6 +95,19 @@ typedef struct
   RenderCommand3DRoadSurfaceKind surface_kind;
 } RenderCommand3DRoadSurface;
 
+typedef enum
+{
+  RENDER_COMMAND_3D_ROOF_SURFACE_NEXT_SECTION = 0,
+  RENDER_COMMAND_3D_ROOF_SURFACE_CURRENT_SECTION
+} RenderCommand3DRoofSurfaceVariant;
+
+typedef struct
+{
+  int section_idx;
+  float depth;
+  RenderCommand3DRoofSurfaceVariant variant;
+} RenderCommand3DRoofSurface;
+
 typedef struct
 {
   int light_idx;
@@ -98,8 +121,10 @@ typedef struct
   {
     RenderCommand3DBuilding building;
     RenderCommand3DCar car;
+    RenderCommand3DGroundSurface ground_surface;
     RenderCommand3DLowerWallSurface lower_wall_surface;
     RenderCommand3DRoadSurface road_surface;
+    RenderCommand3DRoofSurface roof_surface;
     RenderCommand3DStartLight start_light;
     RenderCommand3DWallSurface wall_surface;
   } payload;
@@ -128,6 +153,18 @@ void render_queue_3d_add_unmigrated_legacy_priority(RenderQueue3D *pQueue,
                                                      int iLegacyPriority,
                                                      int iChunkIdx,
                                                      float fZDepth);
+
+void render_queue_3d_add_ground(RenderQueue3D *pQueue,
+                                 int iSectionIdx,
+                                 float fZDepth);
+
+void render_queue_3d_add_next_section_roof(RenderQueue3D *pQueue,
+                                            int iSectionIdx,
+                                            float fZDepth);
+
+void render_queue_3d_add_current_section_roof(RenderQueue3D *pQueue,
+                                               int iSectionIdx,
+                                               float fZDepth);
 
 void render_queue_3d_add_left_wall(RenderQueue3D *pQueue,
                                     int iSectionIdx,

--- a/tests/render_queue_3d_test.c
+++ b/tests/render_queue_3d_test.c
@@ -8,7 +8,7 @@ static void test_sort_matches_legacy_zcmp(void)
   render_queue_3d_clear(&queue);
 
   render_queue_3d_add_road_center(&queue, 100, 10.0f);
-  render_queue_3d_add_unmigrated_legacy_priority(&queue, 2, 101, 4.0f);
+  render_queue_3d_add_ground(&queue, 101, 4.0f);
   render_queue_3d_add_building(&queue, 102, 10.0f);
   render_queue_3d_add_left_lane(&queue, 103, 10.0f);
 
@@ -155,6 +155,48 @@ static void test_lower_wall_priority_mapping_payloads(void)
   assert(command->payload.lower_wall_surface.side == RENDER_COMMAND_3D_WALL_SURFACE_RIGHT);
 }
 
+static void test_ground_roof_priority_mapping_payloads(void)
+{
+  RenderQueue3D queue;
+  const RenderCommand3D *command;
+  render_queue_3d_clear(&queue);
+
+  render_queue_3d_add_ground(&queue, 40, 400.0f);
+  render_queue_3d_add_next_section_roof(&queue, 41, 401.0f);
+  render_queue_3d_add_current_section_roof(&queue, 42, 402.0f);
+
+  assert(render_queue_3d_count(&queue) == 3);
+
+  assert(queue.entries[0].nRenderPriority == RENDER_QUEUE_3D_GROUND_LEGACY_PRIORITY);
+  assert(queue.entries[0].nChunkIdx == 40);
+  assert(queue.entries[0].fZDepth == 400.0f);
+  command = render_queue_3d_command_at(&queue, 0);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_GROUND_SURFACE);
+  assert(command->payload.ground_surface.section_idx == 40);
+  assert(command->payload.ground_surface.depth == 400.0f);
+
+  assert(queue.entries[1].nRenderPriority == RENDER_QUEUE_3D_ROOF_LEGACY_PRIORITY);
+  assert(queue.entries[1].nChunkIdx == 41);
+  assert(queue.entries[1].fZDepth == 401.0f);
+  command = render_queue_3d_command_at(&queue, 1);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_ROOF_SURFACE);
+  assert(command->payload.roof_surface.section_idx == 41);
+  assert(command->payload.roof_surface.depth == 401.0f);
+  assert(command->payload.roof_surface.variant == RENDER_COMMAND_3D_ROOF_SURFACE_NEXT_SECTION);
+
+  assert(queue.entries[2].nRenderPriority == RENDER_QUEUE_3D_ROOF_LEGACY_PRIORITY);
+  assert(queue.entries[2].nChunkIdx == 42);
+  assert(queue.entries[2].fZDepth == 402.0f);
+  command = render_queue_3d_command_at(&queue, 2);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_ROOF_SURFACE);
+  assert(command->payload.roof_surface.section_idx == 42);
+  assert(command->payload.roof_surface.depth == 402.0f);
+  assert(command->payload.roof_surface.variant == RENDER_COMMAND_3D_ROOF_SURFACE_CURRENT_SECTION);
+}
+
 static void test_building_priority_mapping(void)
 {
   RenderQueue3D queue;
@@ -237,14 +279,18 @@ static void test_sort_keeps_typed_payloads_with_sorted_entries(void)
   render_queue_3d_clear(&queue);
 
   render_queue_3d_add_car(&queue, 4, 20.0f, &pose, &options);
-  render_queue_3d_add_unmigrated_legacy_priority(&queue, 2, 101, 10.0f);
+  render_queue_3d_add_ground(&queue, 101, 10.0f);
   render_queue_3d_add_right_lane(&queue, 77, 30.0f);
 
   render_queue_3d_sort(&queue);
 
   assert(render_queue_3d_count(&queue) == 3);
   assert(queue.entries[0].nChunkIdx == 101);
-  assert(render_queue_3d_command_at(&queue, 0) == NULL);
+  command = render_queue_3d_command_at(&queue, 0);
+  assert(command != NULL);
+  assert(command->kind == RENDER_COMMAND_3D_KIND_GROUND_SURFACE);
+  assert(command->payload.ground_surface.section_idx == 101);
+  assert(command->payload.ground_surface.depth == 10.0f);
   assert(queue.entries[1].nRenderPriority == RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY);
   assert(queue.entries[1].nChunkIdx == 4);
   command = render_queue_3d_command_at(&queue, 1);
@@ -273,6 +319,7 @@ int main(int argc, const char **argv, const char **envp)
   test_road_lane_priority_mapping_payloads();
   test_wall_priority_mapping_payloads();
   test_lower_wall_priority_mapping_payloads();
+  test_ground_roof_priority_mapping_payloads();
   test_building_priority_mapping();
   test_start_light_priority_mapping();
   test_car_priority_mapping_payload();

--- a/tools/check_render_queue_3d_seams.py
+++ b/tools/check_render_queue_3d_seams.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Pin migrated render_queue_3d command seams.
 
-Cars, buildings, start lights, road/lane surfaces, and wall/lower-wall surfaces have migrated
-away from raw legacy priority submission. Keep priorities 0, 1, 3, 4, 5, 6, 7, 8, 9,
-11, 13, and 14 out of drawtrk3's direct writes and out of the temporary unmigrated-priority
-compatibility path.
+Cars, buildings, start lights, road/lane surfaces, wall/lower-wall surfaces, and ground/roof
+surfaces have migrated away from raw legacy priority submission. Keep priorities 0, 1, 2,
+3, 4, 5, 6, 7, 8, 9, 10, 11, 13, and 14 out of drawtrk3's direct writes and out of the
+temporary unmigrated-priority compatibility path.
 """
 from __future__ import annotations
 
@@ -19,6 +19,7 @@ ROLLER_SRC = ROOT / "PROJECTS" / "ROLLER"
 MIGRATED_PRIORITIES = {
     0: "left-wall",
     1: "right-wall",
+    2: "ground",
     3: "left-lower-wall",
     4: "right-lower-wall",
     5: "road-center",
@@ -26,6 +27,7 @@ MIGRATED_PRIORITIES = {
     7: "right-lane",
     8: "left-high-wall",
     9: "right-high-wall",
+    10: "roof",
     11: "car",
     13: "building",
     14: "start-light",
@@ -38,6 +40,9 @@ REQUIRED_DRAWTRK3_APIS = {
     "render_queue_3d_add_right_lower_wall": "right lower wall",
     "render_queue_3d_add_left_high_wall": "left high wall",
     "render_queue_3d_add_right_high_wall": "right high wall",
+    "render_queue_3d_add_ground": "ground",
+    "render_queue_3d_add_next_section_roof": "next-section roof",
+    "render_queue_3d_add_current_section_roof": "current-section roof",
     "render_queue_3d_add_road_center": "road center",
     "render_queue_3d_add_left_lane": "left lane",
     "render_queue_3d_add_right_lane": "right lane",


### PR DESCRIPTION
## Summary
- Route ground and roof gameplay 3D surfaces through named `render_queue_3d` APIs for priorities `2` and `10`.
- Add typed ground/roof queue payloads, including roof-source variants, while preserving legacy-priority dispatch behavior.
- Extend render queue tests and seam checks to keep migrated ground/roof priorities off the unmigrated compatibility path.

## Test Plan
- [x] `git diff --check`
- [x] `python3 tools/check_render_queue_3d_seams.py`
- [x] `zig build test-render-queue-3d`
- [x] `zig build test`
- [x] `zig build test-snapshots`
- [x] `zig build`

Closes #159
