### PR TITLE
Add player setup menu snapshot

### DIFF
--- a/PROJECTS/ROLLER/frontend.h
+++ b/PROJECTS/ROLLER/frontend.h
@@ -131,6 +131,7 @@ void select_configure();
 void front_displaycalibrationbar(int iY, int iX, int iValue);
 void front_volumebar(int iY, int iVolumeLevel, int iFillColor);
 void select_players();
+void snapshot_render_menu_select_players(void);
 void select_type();
 void snapshot_render_menu_select_type(void);
 void select_track();

--- a/PROJECTS/ROLLER/frontend_select_players.c
+++ b/PROJECTS/ROLLER/frontend_select_players.c
@@ -16,6 +16,7 @@
 #include "colision.h"
 #include "rollercomms.h"
 #include "menu_render.h"
+#include "snapshot.h"
 #include <fcntl.h>
 #include <string.h>
 #ifdef IS_WINDOWS
@@ -27,6 +28,14 @@
 #include <unistd.h>
 #define O_BINARY 0 //linux does not differentiate between text and binary
 #endif
+
+void snapshot_render_menu_select_players(void)
+{
+  snapshot_setup_frontend_menu_state(0);
+  player_type = 2;
+  players = 2;
+  select_players();
+}
 
 //-------------------------------------------------------------------------------------------------
 //00047000
@@ -222,6 +231,8 @@ void select_players()
     }
     show_received_mesage();
     menu_render_end_frame(mr);
+    if (SnapshotShouldStop())
+      return;
     }                                         // end RENDER FRAME (GPU)
     while (fatkbhit())                        // KEYBOARD INPUT PROCESSING: Handle navigation and selection
     {

--- a/PROJECTS/ROLLER/snapshot_scenes.c
+++ b/PROJECTS/ROLLER/snapshot_scenes.c
@@ -29,6 +29,10 @@ int SnapshotRunScene(void)
     snapshot_render_menu_select_type();
     return SnapshotSceneCapturedAll();
   }
+  if (strcmp(g_SnapshotConfig.szSceneName, "menu-select-players") == 0) {
+    snapshot_render_menu_select_players();
+    return SnapshotSceneCapturedAll();
+  }
   if (strcmp(g_SnapshotConfig.szSceneName, "menu-select-disk") == 0) {
     snapshot_render_menu_select_disk();
     return SnapshotSceneCapturedAll();

--- a/build.zig
+++ b/build.zig
@@ -257,6 +257,7 @@ const snapshot_scenes = [_]SnapshotScene{
     .{ .name = "menu-select-car", .frames = "30" },
     .{ .name = "menu-select-track", .frames = "30" },
     .{ .name = "menu-select-type", .frames = "30" },
+    .{ .name = "menu-select-players", .frames = "30" },
     .{ .name = "menu-select-disk", .frames = "30" },
     .{ .name = "winner-race", .frames = "30" },
     .{ .name = "winner-championship", .frames = "30" },

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -112,8 +112,8 @@ Named scene snapshots live in `build.zig`'s `snapshot_scenes` table. Each
 scene currently captures frame `30`, meaning the thirtieth `SnapshotPresent()`
 call made by that scene's render driver. This gives frontend and winner
 screens a settle period before capture. Scene PNG names use
-`<scene-name>_<present-index>.png`, for example `menu-main_30.png`,
-`menu-select-players_30.png`, and `winner-race_30.png`.
+`<scene-name>_<present-index>.png`, for example `menu-main_30.png` and
+`winner-race_30.png`.
 
 ## File layout
 
@@ -132,7 +132,6 @@ tests/snapshots/
     ├── menu-select-car_30.png
     ├── menu-select-track_30.png
     ├── menu-select-type_30.png
-    ├── menu-select-players_30.png
     ├── menu-select-disk_30.png
     ├── winner-race_30.png
     └── winner-championship_30.png

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -112,8 +112,8 @@ Named scene snapshots live in `build.zig`'s `snapshot_scenes` table. Each
 scene currently captures frame `30`, meaning the thirtieth `SnapshotPresent()`
 call made by that scene's render driver. This gives frontend and winner
 screens a settle period before capture. Scene PNG names use
-`<scene-name>_<present-index>.png`, for example `menu-main_30.png` and
-`winner-race_30.png`.
+`<scene-name>_<present-index>.png`, for example `menu-main_30.png`,
+`menu-select-players_30.png`, and `winner-race_30.png`.
 
 ## File layout
 
@@ -132,6 +132,7 @@ tests/snapshots/
     ├── menu-select-car_30.png
     ├── menu-select-track_30.png
     ├── menu-select-type_30.png
+    ├── menu-select-players_30.png
     ├── menu-select-disk_30.png
     ├── winner-race_30.png
     └── winner-championship_30.png

--- a/tests/snapshots/baselines/menu-select-players_30.png
+++ b/tests/snapshots/baselines/menu-select-players_30.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6fef48992c5971dea5390481f93ed299fe28fb43e0c7aa1f0fb9dd399b5568a
+size 73778


### PR DESCRIPTION
Summary:
- Add the deterministic named snapshot scene `menu-select-players` for issue #171.
- Drive the scene through the real `select_players()` menu path with deterministic frontend setup and snapshot stop handling.
- Add the generated `menu-select-players_30.png` baseline and document it in the snapshot README.

Test Plan:
- `zig build -Dassets-path=/Users/sh/Projects/ROLLER/fatdata -Dscratch test-snapshots`
- `zig build -Dassets-path=/Users/sh/Projects/ROLLER/fatdata run -- --no-crash-handler --whiplash-root /Users/sh/Projects/ROLLER/fatdata --snapshot-scene menu-select-players --frames 30 --out /tmp/roller-171-a`
- `zig build -Dassets-path=/Users/sh/Projects/ROLLER/fatdata run -- --no-crash-handler --whiplash-root /Users/sh/Projects/ROLLER/fatdata --snapshot-scene menu-select-players --frames 30 --out /tmp/roller-171-b`
- `cmp /tmp/roller-171-a/menu-select-players_30.png /tmp/roller-171-b/menu-select-players_30.png`
- `cmp /tmp/roller-171-a/menu-select-players_30.png tests/snapshots/baselines/menu-select-players_30.png`

Note: full `zig build -Dassets-path=/Users/sh/Projects/ROLLER/fatdata test-snapshots` was attempted, but the existing `menu-select-track_30.png` baseline is rewritten differently on this host, so the final git-diff check failed on that unrelated file. That file was reverted and is not included in this PR.

Closes #171
