### PR TITLE
Add championship-over snapshot scene

### DIFF
--- a/PROJECTS/ROLLER/3d.h
+++ b/PROJECTS/ROLLER/3d.h
@@ -425,6 +425,7 @@ void play_game_uninit();
 void winner_race();
 void snapshot_render_winner_race(void);
 void snapshot_render_winner_championship(void);
+void snapshot_render_championship_over(void);
 void champion_race();
 void play_game(int iTrack);
 void game_keys();

--- a/PROJECTS/ROLLER/func3.c
+++ b/PROJECTS/ROLLER/func3.c
@@ -2961,8 +2961,10 @@ void snapshot_render_championship_over(void)
     2, 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
   };
 
-  load_language_file(szSelectEng, 0);
-  load_language_file(szConfigEng, 1);
+  char szSnapshotIngameEng[11] = "ingame.eng";
+  char szSnapshotConfigEng[11] = "config.eng";
+  load_language_file(szSnapshotIngameEng, 0);
+  load_language_file(szSnapshotConfigEng, 1);
 
   network_on = 0;
   network_champ_on = 0;

--- a/PROJECTS/ROLLER/func3.c
+++ b/PROJECTS/ROLLER/func3.c
@@ -2951,6 +2951,90 @@ void snapshot_render_winner_championship(void)
   championship_winner();
 }
 
+void snapshot_render_championship_over(void)
+{
+  static char szSnapshotNames[16][9] = {
+    "HUMAN", "PLAYER 2", "VIRTUE", "MAX", "JANE", "ZERO", "MACE", "DUKE",
+    "NOVA", "ROOK", "JET", "BOLT", "ACE", "VOID", "KANE", "RAY"
+  };
+  static const int iSnapshotChampOrder[16] = {
+    2, 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+  };
+
+  load_language_file(szSelectEng, 0);
+  load_language_file(szConfigEng, 1);
+
+  network_on = 0;
+  network_champ_on = 0;
+  players = 1;
+  player_type = 0;
+  player1_car = 0;
+  player2_car = 1;
+  result_p1 = player1_car;
+  result_p2 = player2_car;
+  result_p1_pos = 1;
+  result_p2_pos = 2;
+  my_car = player1_car;
+  my_number = player1_car;
+  my_control = 0;
+  my_invul = 0;
+
+  game_type = 1;
+  competitors = 16;
+  racers = 16;
+  numcars = 16;
+  Race = 8;
+  TrackLoad = 8;
+  level = 1;
+  damage_level = 0;
+  death_race = 0;
+  cup_won = 0;
+  front_fade = 0;
+  frontend_on = 0;
+  tick_on = 0;
+  holdmusic = 0;
+  quit_game = 0;
+  StartPressed = 0;
+  I_Quit = 0;
+
+  for (int i = 0; i < 16; ++i) {
+    int iDriver = iSnapshotChampOrder[i];
+    champorder[i] = iDriver;
+    carorder[i] = iDriver;
+    result_order[i] = iDriver;
+    championship_points[iDriver] = 160 - (i * 7);
+    team_points[i >> 1] = 0;
+    team_wins[i] = 0;
+    team_kills[i] = 0;
+    team_fasts[i] = 0;
+    total_wins[i] = 0;
+    total_kills[i] = 0;
+    total_fasts[i] = 0;
+    result_time[iDriver] = 180.0f + (float)(i * 3);
+    result_best[iDriver] = 22.0f + (float)i;
+    result_lap[iDriver] = 8;
+    result_lives[iDriver] = 3;
+    result_kills[iDriver] = i & 3;
+    result_competing[iDriver] = 0;
+    result_control[iDriver] = iDriver == player1_car ? 0 : 3;
+    human_control[iDriver] = iDriver == player1_car ? 0 : 3;
+    non_competitors[iDriver] = 0;
+    player_started[iDriver] = iDriver == player1_car ? -1 : 0;
+    player_invul[iDriver] = 0;
+    Players_Cars[iDriver] = iDriver % 14;
+    result_design[iDriver] = Players_Cars[iDriver];
+    Car[iDriver].byCarDesignIdx = (uint8)Players_Cars[iDriver];
+    Car[iDriver].iDriverIdx = iDriver;
+    name_copy(driver_names[iDriver], szSnapshotNames[iDriver]);
+  }
+  team_points[0] = championship_points[0] + championship_points[1];
+  team_points[1] = championship_points[2] + championship_points[3];
+  FastestLap = champorder[0];
+  BestTime = result_best[FastestLap];
+
+  ChampionshipOver();
+}
+
 //-------------------------------------------------------------------------------------------------
 //0005B660
 void print_mem_used(const char *szMsg)
@@ -4137,14 +4221,29 @@ LABEL_30:
 LABEL_36:
   copypic(scrbuf, screen);                      // Display results screen and wait for user input
   fade_palette(32);
+  if (g_bSnapshotMode) {
+    while (!SnapshotShouldStop() && g_SnapshotConfig.iPresentFrame < g_SnapshotConfig.iMaxFrame) {
+      UpdateSDLWindow();
+      if (!SnapshotShouldStop())
+        SnapshotAdvanceTick();
+    }
+  }
   ticks = 0;
-  while (!fatkbhit() && ticks < 2160)
+  while (!fatkbhit() && ticks < 2160) {
     UpdateSDL();
+    if (SnapshotShouldStop())
+      break;
+    SnapshotAdvanceTick();
+  }
   fre(&title_vga);                              // Clean up resources and show end sequence
   fre(&font_vga);
   fre((void **)front_vga);
   scr_size = id;
+  if (SnapshotShouldStop())
+    return;
   fade_palette(0);
+  if (SnapshotShouldStop())
+    return;
   EndChampSequence();                           // Run championship end sequence and credits
   RollCredits();
   if (TrackLoad >= 17)                        // Reset track selection if at maximum

--- a/PROJECTS/ROLLER/snapshot_scenes.c
+++ b/PROJECTS/ROLLER/snapshot_scenes.c
@@ -41,6 +41,10 @@ int SnapshotRunScene(void)
     snapshot_render_winner_championship();
     return SnapshotSceneCapturedAll();
   }
+  if (strcmp(g_SnapshotConfig.szSceneName, "championship-over") == 0) {
+    snapshot_render_championship_over();
+    return SnapshotSceneCapturedAll();
+  }
 
   fprintf(stderr, "ERROR: unknown snapshot scene '%s'\n", g_SnapshotConfig.szSceneName);
   return 1;

--- a/build.zig
+++ b/build.zig
@@ -260,6 +260,7 @@ const snapshot_scenes = [_]SnapshotScene{
     .{ .name = "menu-select-disk", .frames = "30" },
     .{ .name = "winner-race", .frames = "30" },
     .{ .name = "winner-championship", .frames = "30" },
+    .{ .name = "championship-over", .frames = "30" },
 };
 
 fn configureSnapshotTests(

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -110,10 +110,10 @@ The list of replays and which frames are captured per replay live in
 
 Named scene snapshots live in `build.zig`'s `snapshot_scenes` table. Each
 scene currently captures frame `30`, meaning the thirtieth `SnapshotPresent()`
-call made by that scene's render driver. This gives frontend and winner
-screens a settle period before capture. Scene PNG names use
-`<scene-name>_<present-index>.png`, for example `menu-main_30.png` and
-`winner-race_30.png`.
+call made by that scene's render driver. This gives frontend, winner, and
+end-of-championship screens a settle period before capture. Scene PNG names use
+`<scene-name>_<present-index>.png`, for example `menu-main_30.png`,
+`winner-race_30.png`, and `championship-over_30.png`.
 
 ## File layout
 
@@ -134,7 +134,8 @@ tests/snapshots/
     ├── menu-select-type_30.png
     ├── menu-select-disk_30.png
     ├── winner-race_30.png
-    └── winner-championship_30.png
+    ├── winner-championship_30.png
+    └── championship-over_30.png
 ```
 
 Each PNG is a 640x400 8-bit indexed image with the active 256-entry

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -110,10 +110,10 @@ The list of replays and which frames are captured per replay live in
 
 Named scene snapshots live in `build.zig`'s `snapshot_scenes` table. Each
 scene currently captures frame `30`, meaning the thirtieth `SnapshotPresent()`
-call made by that scene's render driver. This gives frontend, winner, and
-end-of-championship screens a settle period before capture. Scene PNG names use
-`<scene-name>_<present-index>.png`, for example `menu-main_30.png`,
-`winner-race_30.png`, and `championship-over_30.png`.
+call made by that scene's render driver. This gives frontend and winner
+screens a settle period before capture. Scene PNG names use
+`<scene-name>_<present-index>.png`, for example `menu-main_30.png` and
+`winner-race_30.png`.
 
 ## File layout
 
@@ -134,8 +134,7 @@ tests/snapshots/
     ├── menu-select-type_30.png
     ├── menu-select-disk_30.png
     ├── winner-race_30.png
-    ├── winner-championship_30.png
-    └── championship-over_30.png
+    └── winner-championship_30.png
 ```
 
 Each PNG is a 640x400 8-bit indexed image with the active 256-entry

--- a/tests/snapshots/baselines/championship-over_30.png
+++ b/tests/snapshots/baselines/championship-over_30.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11eed75e6c44248df03cf2b9956aa6c7b25afd834c54d02f55e3f7490aee7f39
+size 69939

--- a/tests/snapshots/baselines/championship-over_30.png
+++ b/tests/snapshots/baselines/championship-over_30.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:11eed75e6c44248df03cf2b9956aa6c7b25afd834c54d02f55e3f7490aee7f39
-size 69939
+oid sha256:6468d59ee45d9c3cd844913412a3f4826006499e5d3808ad1de2c897543619f6
+size 70543


### PR DESCRIPTION
Fixes #170.

## Summary
- Adds deterministic named snapshot scene `championship-over` and registers it in `build.zig`.
- Drives the real `ChampionshipOver()` path with deterministic completed-championship state.
- Adds the generated `championship-over_30.png` baseline and updates snapshot docs.

## Test Plan
- `zig build -Dassets-path=/Users/sh/Projects/ROLLER/fatdata run -- --no-crash-handler --whiplash-root /Users/sh/Projects/ROLLER/fatdata --snapshot-scene championship-over --frames 30 --out /Users/sh/Projects/ROLLER/.worktrees/issue-170-championship-over-snapshot/tests/snapshots/baselines`
- `zig build -Dassets-path=/Users/sh/Projects/ROLLER/fatdata run -- --no-crash-handler --whiplash-root /Users/sh/Projects/ROLLER/fatdata --snapshot-scene championship-over --frames 30 --out /Users/sh/Projects/ROLLER/.worktrees/issue-170-championship-over-snapshot/zig-out/snapshot-scratch/championship-over-det`
- `cmp tests/snapshots/baselines/championship-over_30.png zig-out/snapshot-scratch/championship-over-det/championship-over_30.png`
- `zig build -Dassets-path=/Users/sh/Projects/ROLLER/fatdata test-snapshots` (captures completed, final git diff gate failed on known unrelated `menu-select-track_30.png` drift; reverted that drift)
