### PR TITLE
Add race result snapshot scene

### DIFF
--- a/PROJECTS/ROLLER/3d.h
+++ b/PROJECTS/ROLLER/3d.h
@@ -426,6 +426,7 @@ void winner_race();
 void snapshot_render_winner_race(void);
 void snapshot_render_winner_championship(void);
 void snapshot_render_championship_over(void);
+void snapshot_render_race_result(void);
 void champion_race();
 void play_game(int iTrack);
 void game_keys();

--- a/PROJECTS/ROLLER/func3.c
+++ b/PROJECTS/ROLLER/func3.c
@@ -635,6 +635,11 @@ void snapshot_render_race_result(void)
   static const int iLaps[8] = { 4, 4, 4, 4, 4, 2, 3, 1 };
   static const int iPoints[8] = { 10, 8, 6, 5, 4, 3, 2, 1 };
 
+  char szSnapshotIngameEng[11] = "ingame.eng";
+  char szSnapshotConfigEng[11] = "config.eng";
+  load_language_file(szSnapshotIngameEng, 0);
+  load_language_file(szSnapshotConfigEng, 1);
+
   numcars = 8;
   racers = 8;
   competitors = 8;

--- a/PROJECTS/ROLLER/func3.c
+++ b/PROJECTS/ROLLER/func3.c
@@ -588,9 +588,14 @@ void RaceResult()
   // Display completed result screen and wait for input
   copypic(scrbuf, screen);
   fade_palette(32);
+  if (g_bSnapshotMode && g_SnapshotConfig.eKind == SNAPSHOT_KIND_SCENE)
+    UpdateSDLWindow();
   ticks = 0;
-  while (!fatkbhit() && ticks < 2160)
+  while (!fatkbhit() && ticks < 2160) {
+    if (SnapshotShouldStop())
+      break;
     UpdateSDL();
+  }
 
   // cleanup
   fre((void **)&front_vga[0]);
@@ -600,6 +605,88 @@ void RaceResult()
   scr_size = iSavedScreenSize;
   holdmusic = -1;
   fade_palette(0);
+}
+
+void snapshot_render_race_result(void)
+{
+  static char szNames[8][9] = {
+    "HUMAN",
+    "VIPER",
+    "RHINO",
+    "MANTA",
+    "BANSHEE",
+    "WRAITH",
+    "FALCON",
+    "TEMPEST",
+  };
+  static const int iOrder[8] = { 0, 3, 1, 5, 2, 6, 4, 7 };
+  static const float fTimes[8] = {
+    187.34f,
+    190.82f,
+    193.15f,
+    199.47f,
+    205.90f,
+    0.0f,
+    0.0f,
+    0.0f,
+  };
+  static const int iKills[8] = { 2, 0, 4, 1, 3, 2, 0, 1 };
+  static const int iLives[8] = { 3, 2, 1, 2, 1, 0, 2, 0 };
+  static const int iLaps[8] = { 4, 4, 4, 4, 4, 2, 3, 1 };
+  static const int iPoints[8] = { 10, 8, 6, 5, 4, 3, 2, 1 };
+
+  numcars = 8;
+  racers = 8;
+  competitors = 8;
+  players = 1;
+  player_type = 1;
+  NoOfLaps = 3;
+  FastestLap = 1;
+  result_p1 = 0;
+  result_p2 = 1;
+  result_p1_pos = 0;
+  result_p2_pos = 2;
+  textures_off &= ~TEX_OFF_ADVANCED_CARS;
+
+  memset(result_order, 0, sizeof(result_order));
+  memset(result_control, 0, sizeof(result_control));
+  memset(result_competing, 0, sizeof(result_competing));
+  memset(result_design, 0, sizeof(result_design));
+  memset(result_time, 0, sizeof(result_time));
+  memset(result_best, 0, sizeof(result_best));
+  memset(result_lap, 0, sizeof(result_lap));
+  memset(result_lives, 0, sizeof(result_lives));
+  memset(result_kills, 0, sizeof(result_kills));
+  memset(carorder, 0, sizeof(carorder));
+  memset(human_control, 0, sizeof(human_control));
+  memset(non_competitors, 0, sizeof(non_competitors));
+
+  for (int i = 0; i < racers; ++i) {
+    int iDriver = iOrder[i];
+    carorder[i] = iDriver;
+    result_order[i] = iDriver;
+    result_control[iDriver] = (iDriver == result_p1 || iDriver == result_p2) ? -1 : 0;
+    human_control[iDriver] = result_control[iDriver];
+    result_competing[iDriver] = 0;
+    result_design[iDriver] = iDriver & 7;
+    result_time[iDriver] = fTimes[iDriver];
+    result_best[iDriver] = iDriver == FastestLap ? 61.24f : 64.0f + (float)iDriver;
+    result_lap[iDriver] = iLaps[iDriver];
+    result_lives[iDriver] = iLives[iDriver];
+    result_kills[iDriver] = iKills[iDriver];
+    points[i] = iPoints[i];
+    Car[iDriver].byCarDesignIdx = (uint8)result_design[iDriver];
+    Car[iDriver].fBestLapTime = result_best[iDriver];
+    Car[iDriver].fTotalRaceTime = result_time[iDriver];
+    Car[iDriver].byKills = (uint8)result_kills[iDriver];
+    Car[iDriver].byLap = (char)result_lap[iDriver];
+    Car[iDriver].byLives = (uint8)result_lives[iDriver];
+    name_copy(driver_names[iDriver], szNames[iDriver]);
+  }
+
+  // RaceResult() is the real post-race screen. It presents once after its
+  // snapshot-mode fade skip, then exits through the snapshot stop check.
+  RaceResult();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/snapshot_scenes.c
+++ b/PROJECTS/ROLLER/snapshot_scenes.c
@@ -53,6 +53,10 @@ int SnapshotRunScene(void)
     snapshot_render_championship_over();
     return SnapshotSceneCapturedAll();
   }
+  if (strcmp(g_SnapshotConfig.szSceneName, "race-result") == 0) {
+    snapshot_render_race_result();
+    return SnapshotSceneCapturedAll();
+  }
 
   fprintf(stderr, "ERROR: unknown snapshot scene '%s'\n", g_SnapshotConfig.szSceneName);
   return 1;

--- a/build.zig
+++ b/build.zig
@@ -263,6 +263,7 @@ const snapshot_scenes = [_]SnapshotScene{
     .{ .name = "winner-race", .frames = "30" },
     .{ .name = "winner-championship", .frames = "30" },
     .{ .name = "championship-over", .frames = "30" },
+    .{ .name = "race-result", .frames = "1" },
 };
 
 fn configureSnapshotTests(

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -44,7 +44,7 @@ On the canonical host (Apple Silicon macOS at the time of writing) this:
 1. Builds the `roller` binary if needed.
 2. Runs `roller --snapshot introN.gss --frames ... --out
    tests/snapshots/baselines/` once per intro replay, serially, then
-   runs `roller --snapshot-scene NAME --frames 30 --out
+   runs `roller --snapshot-scene NAME --frames ... --out
    tests/snapshots/baselines/` once per named scene.
 3. Runs `git diff --exit-code --stat -- tests/snapshots/baselines/`.
 
@@ -108,37 +108,25 @@ tracked separately in a future ADR.
 The list of replays and which frames are captured per replay live in
 `build.zig`'s `snapshot_replays` table.
 
-Named scene snapshots live in `build.zig`'s `snapshot_scenes` table. Most
-scenes capture frame `30`, meaning the thirtieth `SnapshotPresent()` call made
-by that scene's render driver. This gives frontend and winner screens a settle
-period before capture. Single-present static screens can capture their first
-settled present; for example the real post-race `RaceResult()` scene writes
-`race-result_1.png`. Scene PNG names use `<scene-name>_<present-index>.png`,
-for example `menu-main_30.png`, `winner-race_30.png`, and
+Named scene snapshots live in `build.zig`'s `snapshot_scenes` table. Each
+entry declares the scene name and capture frame(s). Animated frontend and
+winner scenes usually capture a later settled present such as frame `30`, while
+single-present static result screens can capture frame `1`. Scene PNG names use
+`<scene-name>_<present-index>.png`, for example `menu-main_30.png` or
 `race-result_1.png`.
 
 ## File layout
 
 ```
 tests/snapshots/
-├── README.md                  ← this file
-└── baselines/                 ← indexed PNGs, LFS-tracked
-    ├── intro1_60.png          ← <replay-stem>_<frame-index>.png
-    ├── intro1_240.png
-    ├── intro1_480.png
-    ├── intro1_720.png
-    ├── intro2_60.png
-    ├── ...
-    ├── intro7_600.png
-    ├── menu-main_30.png       ← <scene-name>_<present-index>.png
-    ├── menu-select-car_30.png
-    ├── menu-select-track_30.png
-    ├── menu-select-type_30.png
-    ├── menu-select-disk_30.png
-    ├── winner-race_30.png
-    ├── winner-championship_30.png
-    └── race-result_1.png
+├── README.md
+└── baselines/    ← indexed PNG baselines, LFS-tracked
 ```
+
+Replay baseline filenames use `<replay-stem>_<frame-index>.png`; named scene
+baseline filenames use `<scene-name>_<present-index>.png`. Treat `build.zig`'s
+`snapshot_replays` and `snapshot_scenes` tables as the source of truth for the
+current generated file set.
 
 Each PNG is a 640x400 8-bit indexed image with the active 256-entry
 palette in the PLTE chunk. Any image viewer can open them.

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -108,12 +108,14 @@ tracked separately in a future ADR.
 The list of replays and which frames are captured per replay live in
 `build.zig`'s `snapshot_replays` table.
 
-Named scene snapshots live in `build.zig`'s `snapshot_scenes` table. Each
-scene currently captures frame `30`, meaning the thirtieth `SnapshotPresent()`
-call made by that scene's render driver. This gives frontend and winner
-screens a settle period before capture. Scene PNG names use
-`<scene-name>_<present-index>.png`, for example `menu-main_30.png` and
-`winner-race_30.png`.
+Named scene snapshots live in `build.zig`'s `snapshot_scenes` table. Most
+scenes capture frame `30`, meaning the thirtieth `SnapshotPresent()` call made
+by that scene's render driver. This gives frontend and winner screens a settle
+period before capture. Single-present static screens can capture their first
+settled present; for example the real post-race `RaceResult()` scene writes
+`race-result_1.png`. Scene PNG names use `<scene-name>_<present-index>.png`,
+for example `menu-main_30.png`, `winner-race_30.png`, and
+`race-result_1.png`.
 
 ## File layout
 
@@ -134,7 +136,8 @@ tests/snapshots/
     ├── menu-select-type_30.png
     ├── menu-select-disk_30.png
     ├── winner-race_30.png
-    └── winner-championship_30.png
+    ├── winner-championship_30.png
+    └── race-result_1.png
 ```
 
 Each PNG is a 640x400 8-bit indexed image with the active 256-entry

--- a/tests/snapshots/baselines/race-result_1.png
+++ b/tests/snapshots/baselines/race-result_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa06f54941633468bcf5f978a74d6ba885a94967e21e397c34b0c1dbd4802b59
+size 76682

--- a/tests/snapshots/baselines/race-result_1.png
+++ b/tests/snapshots/baselines/race-result_1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa06f54941633468bcf5f978a74d6ba885a94967e21e397c34b0c1dbd4802b59
-size 76682
+oid sha256:ad47c61824aa6446ea53ce7a4f182cfaaa07854cd56b33cf40a3ab62af1c6678
+size 77468


### PR DESCRIPTION
## Summary
- Add deterministic named snapshot scene `race-result` using the real `RaceResult()` rendering path.
- Generate and track `tests/snapshots/baselines/race-result_1.png`.
- Document the single-present RaceResult scene in the snapshot README.

Closes #166

## Test Plan
- `zig build -Dassets-path=/Users/sh/Projects/ROLLER/fatdata run -- --no-crash-handler --whiplash-root /Users/sh/Projects/ROLLER/fatdata --snapshot-scene race-result --frames 1 --out /Users/sh/Projects/ROLLER/.worktrees/issue-166-race-result-snapshot/tests/snapshots/baselines`
- Captured `race-result` twice to `/tmp` and compared both outputs plus the checked-in baseline with `cmp`.
- `zig build -Dassets-path=/Users/sh/Projects/ROLLER/fatdata test-snapshots` (captures completed; final diff gate failed on known unrelated `menu-select-track_30.png` drift, reverted that file)
- `zig build -Dassets-path=/Users/sh/Projects/ROLLER/fatdata test-snapshots -Dscratch`