### PR TITLE
Name gameplay frame phases and lock snapshot records

### DIFF
--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -641,7 +641,7 @@ void doexit()
     }
   }
   close_network();
-  SaveRecords();
+  if (!g_bSnapshotMode) SaveRecords();
   fre((void**)&mirbuf);
   for (int i = 0; i < 16; ++i) {
     fre((void**)&rev_vga[i]);
@@ -1072,6 +1072,7 @@ void draw_road(uint8 *pScrPtr, int iCarIdx, unsigned int uiViewMode, int iCopyIm
       dTextureSubscaleMultiplier = (double)scr_size * 1.2;// VGA texture-less: 1.2x multiplier (slightly higher detail)
     subscale = (float)dTextureSubscaleMultiplier;
   }
+  // Gameplay frame phase: camera/projection setup.
   screen_pointer = pScrPtr;                     // Set global screen buffer pointer for rendering functions
   game_render_set_target(g_pGameRenderer, pScrPtr, winw, winw, winh);
   calculateview(uiViewMode, iCarIdx, iChaseCamIdx); // Calculate camera view matrix and projection parameters
@@ -1098,11 +1099,19 @@ void draw_road(uint8 *pScrPtr, int iCarIdx, unsigned int uiViewMode, int iCopyIm
       .texHalfRes = gfx_size,
   };
   game_render_set_projection(g_pGameRenderer, &proj);
+
+  // Gameplay frame phase: atmosphere. Sky/horizon stays outside the depth-sorted 3D queue.
   game_render_draw_sky(g_pGameRenderer, &cam, &proj); // Draw sky/horizon background
+
+  // Gameplay frame phase: visibility/entity production.
   CalcVisibleTrack(iCarIdx, uiViewMode);        // Calculate which track segments are visible from current viewpoint
-  DrawCars(iCarIdx, uiViewMode);                // Render all visible cars (excluding current player if in chase cam)
+  DrawCars(iCarIdx, uiViewMode);                // Prepare visible cars (excluding current player if in chase cam)
   CalcVisibleBuildings();                       // Calculate visibility and prepare building rendering data
+
+  // Gameplay frame phase: 3D queue production and sorted dispatch.
   DrawTrack3(pScrPtr, iChaseCamIdx, iCarIdx, &cam, &proj); // Render track surface, buildings, and track-side objects
+
+  // Gameplay frame phase: capture/present.
   if (iCopyImmediately)                       // Check if immediate screen copy is requested
   {                                             // Copy rendered frame to display if screen is ready
     if (screenready)
@@ -1406,6 +1415,7 @@ int main(int argc, const char **argv, const char **envp)
   }
   InitCarStructs();                             // Initialize car data structures
   init();
+  SnapshotApplyFixedRecords();
   if (g_bSnapshotMode && g_SnapshotConfig.eKind == SNAPSHOT_KIND_SCENE) {
     SnapshotEnsureMenuRenderer();
     int iSceneRc = SnapshotRunScene();
@@ -1994,7 +2004,7 @@ void play_game_uninit()
       //} while ((int)iOffset < iMaxOffset);
     }
   } else {
-    SaveRecords();
+    if (!g_bSnapshotMode) SaveRecords();
     save_fatal_config();
   }
   if (no_mem) {

--- a/PROJECTS/ROLLER/drawtrk3.c
+++ b/PROJECTS/ROLLER/drawtrk3.c
@@ -10,7 +10,7 @@
 #include "tower.h"
 #include "roller.h"
 #include "render_queue_3d.h"
-#define TrackView (render_queue_3d_entries(render_queue_3d_global()))
+#define TrackView(pQueue) (render_queue_3d_entries(pQueue))
 #include <math.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -1358,12 +1358,15 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
   float fWorldY; // [esp+4CCh] [ebp-28h]
   float fWorldX; // [esp+4D0h] [ebp-24h]
   int iRenderingTemp; // [esp+4E0h] [ebp-14h]
+  RenderQueue3D *pRenderQueue3D = render_queue_3d_global();
 
   pScrPtr_1 = pScrPtr;                          // Store function parameters
   iChaseCamIdx_1 = iChaseCamIdx;
   iCarIdx_1 = iCarIdx;
   cars_drawn = 0;                               // Initialize global counters for rendering
   num_pols = 0;
+
+  // Gameplay 3D queue phase: project visible track geometry into screen-space caches.
   for (iTrackSectionIndex = 0; TrackSize + 1 >= iTrackSectionIndex; ++iTrackSectionIndex) {
     if (first_size + 1 >= iTrackSectionIndex || iTrackSectionIndex >= gap_size) {
       iCurrentTrackIndex = start_sect + iTrackSectionIndex;// Calculate current track section index with wraparound
@@ -1675,8 +1678,10 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
       }
     }
   }
-  iTrackLoopCounter = TrackSize;                // Second phase: Build render list by traversing track backwards
-  render_queue_3d_clear(render_queue_3d_global());
+  iTrackLoopCounter = TrackSize;
+
+  // Gameplay 3D queue phase: produce world commands by traversing visible track sections backwards.
+  render_queue_3d_clear(pRenderQueue3D);
   if (TrackSize >= 0) {
     while (iTrackLoopCounter > first_size && iTrackLoopCounter < gap_size) {
     LABEL_356:
@@ -1766,7 +1771,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
         fProjectionZ = fGroundDepthSelected;
       }
       fGroundRenderDepth = fProjectionZ;
-      render_queue_3d_add_ground(render_queue_3d_global(), iCurrentSect, fGroundRenderDepth);
+      render_queue_3d_add_ground(pRenderQueue3D, iCurrentSect, fGroundRenderDepth);
     }
     if (pScreenCoord_1->iClipCount != 99 && pScreenCoord->iClipCount != 99 && Road_On) {
       if (pScreenCoord_1->screenPtAy[2].projected.fZ <= (double)pScreenCoord_1->screenPtAy[1].projected.fZ)
@@ -1794,7 +1799,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
       }
       fRoadCenterFinalDepth = fRoadCenterDepthSelected;
       fRoadCenterCmdDepth = fRoadCenterFinalDepth;
-      render_queue_3d_add_road_center(render_queue_3d_global(), iCurrentSect, fRoadCenterCmdDepth);
+      render_queue_3d_add_road_center(pRenderQueue3D, iCurrentSect, fRoadCenterCmdDepth);
     }
     if (pScreenCoord_1->iClipCount != 99 && pScreenCoord->iClipCount != 99 && Road_On) {
       if (pScreenCoord_1->screenPtAy[0].projected.fZ <= (double)pScreenCoord_1->screenPtAy[1].projected.fZ)
@@ -1822,7 +1827,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
       }
       fLeftRoadFinalDepth = fLeftRoadDepthSelected;
       fLeftRoadCmdDepth = fLeftRoadFinalDepth;
-      render_queue_3d_add_left_lane(render_queue_3d_global(), iCurrentSect, fLeftRoadCmdDepth);
+      render_queue_3d_add_left_lane(pRenderQueue3D, iCurrentSect, fLeftRoadCmdDepth);
     }
     if (pScreenCoord_1->iClipCount != 99 && pScreenCoord->iClipCount != 99 && Road_On) {
       if (pScreenCoord_1->screenPtAy[2].projected.fZ <= (double)pScreenCoord_1->screenPtAy[3].projected.fZ)
@@ -1850,7 +1855,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
       }
       fRightRoadFinalDepth = fRightRoadDepthSelected;
       fRightRoadCmdDepth = fRightRoadFinalDepth;
-      render_queue_3d_add_right_lane(render_queue_3d_global(), iCurrentSect, fRightRoadCmdDepth);
+      render_queue_3d_add_right_lane(pRenderQueue3D, iCurrentSect, fRightRoadCmdDepth);
     }
     if (pScreenCoord_1->iClipCount != 99 && pScreenCoord->iClipCount != 99) {
       if (Walls_On) {
@@ -1884,7 +1889,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
             }
             fRoof1DepthSelected = fRoof1SelectedDepth;
             fRoof1CmdDepth = fRoof1DepthSelected;
-            render_queue_3d_add_next_section_roof(render_queue_3d_global(), iCurrentSect, fRoof1CmdDepth);
+            render_queue_3d_add_next_section_roof(pRenderQueue3D, iCurrentSect, fRoof1CmdDepth);
             goto LABEL_238;
           }
           iRoofType = TrakColour[iNextSectionIndex][TRAK_COLOUR_ROOF];
@@ -1954,7 +1959,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
             }
             fRoof2CmdDepth = fRoof2DepthSelected;
           }
-          render_queue_3d_add_current_section_roof(render_queue_3d_global(), iCurrentSect, fRoof2CmdDepth);
+          render_queue_3d_add_current_section_roof(pRenderQueue3D, iCurrentSect, fRoof2CmdDepth);
         }
       }
     }
@@ -1985,7 +1990,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
       }
       fLeftLowerWallDepthSelected = fLeftLowerWallSelected;
       fLeftLowerWallCmdDepth = fLeftLowerWallDepthSelected;
-      render_queue_3d_add_left_lower_wall(render_queue_3d_global(), iCurrentSect, fLeftLowerWallCmdDepth);
+      render_queue_3d_add_left_lower_wall(pRenderQueue3D, iCurrentSect, fLeftLowerWallCmdDepth);
     }
     if (GroundColour[iCurrentSect][GROUND_COLOUR_RLOWALL] != -1 && bGroundVisible) {
       if (pNextGroundScreen->screenPtAy[3].projected.fZ <= (double)pNextGroundScreen->screenPtAy[4].projected.fZ)
@@ -2013,7 +2018,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
       }
       fRightLowerWallDepthSelected = fRightLowerWallSelected;
       fRightLowerWallCmdDepth = fRightLowerWallDepthSelected;
-      render_queue_3d_add_right_lower_wall(render_queue_3d_global(), iCurrentSect, fRightLowerWallCmdDepth);
+      render_queue_3d_add_right_lower_wall(pRenderQueue3D, iCurrentSect, fRightLowerWallCmdDepth);
     }
     if (pScreenCoord_1->iClipCount != 99 && pScreenCoord->iClipCount != 99) {
       if (Walls_On) {
@@ -2054,7 +2059,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
                 * 0.25f;
             }
             fRightWallCmdDepth = fLeftWallRoofDepth;
-            render_queue_3d_add_left_high_wall(render_queue_3d_global(), iCurrentSect, fRightWallCmdDepth);
+            render_queue_3d_add_left_high_wall(pRenderQueue3D, iCurrentSect, fRightWallCmdDepth);
           } else {
             if (pScreenCoord_1->screenPtAy[0].projected.fZ <= (double)pScreenCoord_1->screenPtAy[1].projected.fZ)
               fLeftWallDepthMax1 = pScreenCoord_1->screenPtAy[1].projected.fZ;
@@ -2080,7 +2085,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
               fLeftWallDepthTmp1 = fLeftWallDepthSelected;
             }
             fLeftWallFinalDepth = fLeftWallDepthSelected;
-            render_queue_3d_add_left_wall(render_queue_3d_global(), iCurrentSect, fLeftWallFinalDepth);
+            render_queue_3d_add_left_wall(pRenderQueue3D, iCurrentSect, fLeftWallFinalDepth);
           }
         }
       }
@@ -2123,7 +2128,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
                                    + pScreenCoord->screenPtAy[5].projected.fZ)
                 * 0.25f;
             }
-            render_queue_3d_add_right_high_wall(render_queue_3d_global(), iCurrentSect, fRightWallRoofDepth);
+            render_queue_3d_add_right_high_wall(pRenderQueue3D, iCurrentSect, fRightWallRoofDepth);
           } else {
             if (pScreenCoord_1->screenPtAy[2].projected.fZ <= (double)pScreenCoord_1->screenPtAy[3].projected.fZ)
               fRightWallBasicDepth1 = pScreenCoord_1->screenPtAy[3].projected.fZ;
@@ -2150,7 +2155,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
             }
             fRightWallFinalDepth = fRightWallBasicSelected;
             fRightWallBasicCmdDepth = fRightWallFinalDepth;
-            render_queue_3d_add_right_wall(render_queue_3d_global(), iCurrentSect, fRightWallBasicCmdDepth);
+            render_queue_3d_add_right_wall(pRenderQueue3D, iCurrentSect, fRightWallBasicCmdDepth);
           }
         }
       }
@@ -2179,7 +2184,7 @@ LABEL_357:
             .anim_frame = Car[iCarCommandIdx].byWheelAnimationFrame,
             .color_remap = NULL,
           };
-          render_queue_3d_add_car(render_queue_3d_global(), iCarCommandIdx, fOffsetTmp1, &pose, &options);
+          render_queue_3d_add_car(pRenderQueue3D, iCarCommandIdx, fOffsetTmp1, &pose, &options);
         }
         cars_drawn = iCarProcessingFlag + 1;
       }
@@ -2245,7 +2250,7 @@ LABEL_393:
   pVisibleBuildingsPtr = &VisibleBuildings[0];     // Process building objects for rendering
   if (VisibleBuildings[0].iBuildingIdx != -1) {
     do {
-      render_queue_3d_add_building(render_queue_3d_global(),
+      render_queue_3d_add_building(pRenderQueue3D,
                                    pVisibleBuildingsPtr->iBuildingIdx,
                                    pVisibleBuildingsPtr->fDepth);
       ++pVisibleBuildingsPtr;
@@ -2261,20 +2266,21 @@ LABEL_393:
         + (SLight[0][iLightArrayOffset].currentPos.fZ - viewz) * vk9;
       if (fLightZ > 0.0) {
         fLightDepth = fLightZ;
-        render_queue_3d_add_start_light(render_queue_3d_global(), iLightIndex, fLightDepth);
+        render_queue_3d_add_start_light(pRenderQueue3D, iLightIndex, fLightDepth);
       }
       ++iLightIndex;
       ++iLightArrayOffset;
     } while (iLightIndex < 3);
   }
-  render_queue_3d_sort(render_queue_3d_global());// Fifth phase: Sort render list by Z-depth and render objects
+  // Gameplay 3D queue phase: sorted dispatch of world commands by Z-depth.
+  render_queue_3d_sort(pRenderQueue3D);
   iRenderObjectIndex = 0;
-  iRenderQueueCount = render_queue_3d_count(render_queue_3d_global());
+  iRenderQueueCount = render_queue_3d_count(pRenderQueue3D);
   if (iRenderQueueCount > 0) {
     iIndexTmp1 = 144 * iChaseCamIdx_1;
     while (1) {
-      pRenderCommand = &TrackView[iRenderQueueCount - 1 - iRenderObjectIndex];
-      pTypedRenderCommand = render_queue_3d_command_at(render_queue_3d_global(), iRenderQueueCount - 1 - iRenderObjectIndex);
+      pRenderCommand = &TrackView(pRenderQueue3D)[iRenderQueueCount - 1 - iRenderObjectIndex];
+      pTypedRenderCommand = render_queue_3d_command_at(pRenderQueue3D, iRenderQueueCount - 1 - iRenderObjectIndex);
       fRenderDepth = pRenderCommand->fZDepth;
       iSectionNum = pRenderCommand->nChunkIdx;
       pScreenCoord_1 = NULL;

--- a/PROJECTS/ROLLER/snapshot.c
+++ b/PROJECTS/ROLLER/snapshot.c
@@ -20,6 +20,19 @@
 int g_bSnapshotMode = 0;
 tSnapshotConfig g_SnapshotConfig = { 0 };
 
+typedef struct SnapshotRecordFixture
+{
+  int iTrackIdx;
+  int iLapCentiseconds;
+  int iCarIdx;
+  int iKills;
+  char szName[9];
+} SnapshotRecordFixture;
+
+static const SnapshotRecordFixture g_SnapshotRecordFixtures[] = {
+  { 1, 6127, 0, 0, "HUMAN" },
+};
+
 //-------------------------------------------------------------------------------------------------
 
 void SnapshotSetReplay(const char *szReplay)
@@ -231,4 +244,30 @@ void SnapshotApplyFixedSettings(void)
   level = 0;
   damage_level = 0;
   infinite_laps = 0;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void SnapshotApplyFixedRecords(void)
+{
+  if (!g_bSnapshotMode) return;
+
+  for (int i = 0; i < 25; ++i) {
+    memset(RecordNames[i], 0, sizeof(RecordNames[i]));
+    strcpy(RecordNames[i], "-----");
+    RecordLaps[i] = 128.0f;
+    RecordCars[i] = -1;
+    RecordKills[i] = 0;
+  }
+
+  for (int i = 0; i < (int)(sizeof(g_SnapshotRecordFixtures) / sizeof(g_SnapshotRecordFixtures[0])); ++i) {
+    const SnapshotRecordFixture *pFixture = &g_SnapshotRecordFixtures[i];
+    if (pFixture->iTrackIdx < 0 || pFixture->iTrackIdx >= 25) continue;
+
+    RecordLaps[pFixture->iTrackIdx] = (float)pFixture->iLapCentiseconds * 0.01f;
+    RecordCars[pFixture->iTrackIdx] = pFixture->iCarIdx;
+    RecordKills[pFixture->iTrackIdx] = pFixture->iKills;
+    memset(RecordNames[pFixture->iTrackIdx], 0, sizeof(RecordNames[pFixture->iTrackIdx]));
+    strncpy(RecordNames[pFixture->iTrackIdx], pFixture->szName, sizeof(RecordNames[pFixture->iTrackIdx]) - 1);
+  }
 }

--- a/PROJECTS/ROLLER/snapshot.h
+++ b/PROJECTS/ROLLER/snapshot.h
@@ -70,5 +70,9 @@ void SnapshotAdvanceTick(void);
 // are independent of the developer's local fatal.ini.
 void SnapshotApplyFixedSettings(void);
 
+// Pins record-table data after LoadRecords() so menu snapshots do not drift
+// with the developer's mutable dgkfc.rec file.
+void SnapshotApplyFixedRecords(void);
+
 //-------------------------------------------------------------------------------------------------
 #endif

--- a/tools/check_render_queue_3d_seams.py
+++ b/tools/check_render_queue_3d_seams.py
@@ -14,6 +14,9 @@ import sys
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 DRAWTRK3 = ROOT / "PROJECTS" / "ROLLER" / "drawtrk3.c"
+FRAME_SRC = ROOT / "PROJECTS" / "ROLLER" / "3d.c"
+SNAPSHOT_SRC = ROOT / "PROJECTS" / "ROLLER" / "snapshot.c"
+SNAPSHOT_HDR = ROOT / "PROJECTS" / "ROLLER" / "snapshot.h"
 ROLLER_SRC = ROOT / "PROJECTS" / "ROLLER"
 
 MIGRATED_PRIORITIES = {
@@ -51,6 +54,30 @@ REQUIRED_DRAWTRK3_APIS = {
     "render_queue_3d_add_start_light": "start lights",
 }
 
+REQUIRED_FRAME_PHASE_MARKERS = {
+    "Gameplay frame phase: camera/projection setup": "camera/projection setup phase",
+    "Gameplay frame phase: atmosphere": "atmosphere phase",
+    "Gameplay frame phase: visibility/entity production": "visibility/entity production phase",
+    "Gameplay frame phase: 3D queue production and sorted dispatch": "3D queue production/dispatch phase",
+    "Gameplay frame phase: capture/present": "capture/present phase",
+}
+
+REQUIRED_DRAWTRACK_PHASE_MARKERS = {
+    "RenderQueue3D *pRenderQueue3D = render_queue_3d_global();": "local render queue pointer",
+    "Gameplay 3D queue phase: project visible track geometry": "track projection phase",
+    "Gameplay 3D queue phase: produce world commands": "queue production phase",
+    "Gameplay 3D queue phase: sorted dispatch": "sorted dispatch phase",
+}
+
+REQUIRED_SNAPSHOT_RECORD_MARKERS = {
+    "SnapshotApplyFixedRecords();": "snapshot-mode record fixture application",
+    "if (!g_bSnapshotMode) SaveRecords();": "snapshot-mode SaveRecords guard",
+    "void SnapshotApplyFixedRecords(void)": "fixed snapshot record implementation",
+    "SnapshotRecordFixture": "fixed snapshot record fixture data",
+    "HUMAN": "baseline menu-select-track record holder",
+    "6127": "baseline menu-select-track record lap centiseconds",
+}
+
 
 def fail(message: str) -> int:
     print(f"render_queue_3d seam check failed: {message}", file=sys.stderr)
@@ -67,6 +94,9 @@ def compatibility_call_pattern(function_name: str, priority: int) -> re.Pattern[
 
 def main() -> int:
     drawtrk3 = DRAWTRK3.read_text(encoding="utf-8")
+    frame_src = FRAME_SRC.read_text(encoding="utf-8")
+    snapshot_src = SNAPSHOT_SRC.read_text(encoding="utf-8")
+    snapshot_hdr = SNAPSHOT_HDR.read_text(encoding="utf-8")
 
     for priority, name in MIGRATED_PRIORITIES.items():
         if direct_priority_write_pattern(priority).search(drawtrk3):
@@ -85,6 +115,25 @@ def main() -> int:
     if "render_queue_3d_add_legacy_priority" in drawtrk3:
         return fail("drawtrk3.c still uses old legacy-priority compatibility API name")
 
+    for marker, label in REQUIRED_FRAME_PHASE_MARKERS.items():
+        if marker not in frame_src:
+            return fail(f"3d.c does not name the gameplay {label}")
+
+    for marker, label in REQUIRED_DRAWTRACK_PHASE_MARKERS.items():
+        if marker not in drawtrk3:
+            return fail(f"drawtrk3.c does not name the gameplay {label}")
+
+    if drawtrk3.count("render_queue_3d_global()") != 1:
+        return fail("DrawTrack3 should use one local render queue pointer instead of repeated render_queue_3d_global() calls")
+
+    snapshot_text = "\n".join([frame_src, snapshot_src, snapshot_hdr])
+    for marker, label in REQUIRED_SNAPSHOT_RECORD_MARKERS.items():
+        if marker not in snapshot_text:
+            return fail(f"snapshot harness does not pin {label}")
+
+    save_records_callers = "\n".join(path.read_text(encoding="utf-8") for path in ROLLER_SRC.glob("*.c"))
+    if save_records_callers.count("SaveRecords();") != save_records_callers.count("if (!g_bSnapshotMode) SaveRecords();"):
+        return fail("snapshot mode must guard every SaveRecords() call")
     for path in ROLLER_SRC.glob("*.c"):
         if path.name == "render_queue_3d.c":
             continue


### PR DESCRIPTION
## Summary
- name the gameplay render-frame phases in `updatescreen()` and the 3D queue phases in `DrawTrack3()`
- use one local `RenderQueue3D *pRenderQueue3D` pointer in `DrawTrack3()` instead of repeated singleton lookups
- lock snapshot record data to deterministic fixtures and skip `SaveRecords()` while snapshot mode is active
- extend the render-queue seam checker to pin the phase markers and snapshot record/SaveRecords invariants

## Verification
- `git diff --check`
- `python3 tools/check_render_queue_3d_seams.py`
- `zig build test-render-queue-3d`
- `zig build test`
- `zig build test-snapshots`
- `zig build`

Closes #160
