### PR TITLE
Pin render_queue_3d seam checks

### DIFF
--- a/PROJECTS/ROLLER/drawtrk3.c
+++ b/PROJECTS/ROLLER/drawtrk3.c
@@ -10,7 +10,6 @@
 #include "tower.h"
 #include "roller.h"
 #include "render_queue_3d.h"
-#define TrackView(pQueue) (render_queue_3d_entries(pQueue))
 #include <math.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -1262,6 +1261,7 @@ void DrawTrack3(uint8 *pScrPtr, int iChaseCamIdx, int iCarIdx,
   float fLeftWallCameraX; // [esp+344h] [ebp-1B0h]
   int iRenderObjectIndex; // [esp+348h] [ebp-1ACh]
   int iRenderQueueCount;
+  tTrackZOrderEntry *pRenderQueueEntries;
   float fObjectDepthA1; // [esp+34Ch] [ebp-1A8h]
   float fObjectDepthA2; // [esp+350h] [ebp-1A4h]
   float fObjectDepthA3; // [esp+354h] [ebp-1A0h]
@@ -2276,10 +2276,11 @@ LABEL_393:
   render_queue_3d_sort(pRenderQueue3D);
   iRenderObjectIndex = 0;
   iRenderQueueCount = render_queue_3d_count(pRenderQueue3D);
+  pRenderQueueEntries = render_queue_3d_entries(pRenderQueue3D);
   if (iRenderQueueCount > 0) {
     iIndexTmp1 = 144 * iChaseCamIdx_1;
     while (1) {
-      pRenderCommand = &TrackView(pRenderQueue3D)[iRenderQueueCount - 1 - iRenderObjectIndex];
+      pRenderCommand = &pRenderQueueEntries[iRenderQueueCount - 1 - iRenderObjectIndex];
       pTypedRenderCommand = render_queue_3d_command_at(pRenderQueue3D, iRenderQueueCount - 1 - iRenderObjectIndex);
       fRenderDepth = pRenderCommand->fZDepth;
       iSectionNum = pRenderCommand->nChunkIdx;
@@ -2720,9 +2721,9 @@ int facing_ok(float fX0, float fY0, float fZ0,
 
 //-------------------------------------------------------------------------------------------------
 //00027A10
-int Zcmp(const void *pTrackView1, const void *pTrackView2)
+int Zcmp(const void *pCommand1, const void *pCommand2)
 {
-  return render_queue_3d_compare_legacy_z_order(pTrackView1, pTrackView2);
+  return render_queue_3d_compare_legacy_z_order(pCommand1, pCommand2);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/render_queue_3d.c
+++ b/PROJECTS/ROLLER/render_queue_3d.c
@@ -24,30 +24,6 @@ static void render_queue_3d_require(int iCondition)
 
 //-------------------------------------------------------------------------------------------------
 
-static int render_queue_3d_is_named_priority(int iLegacyPriority)
-{
-  switch (iLegacyPriority) {
-  case RENDER_QUEUE_3D_LEFT_WALL_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_RIGHT_WALL_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_GROUND_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_LEFT_LOWER_WALL_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_RIGHT_LOWER_WALL_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_ROAD_CENTER_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_LEFT_LANE_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_RIGHT_LANE_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_LEFT_HIGH_WALL_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_RIGHT_HIGH_WALL_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_ROOF_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_CAR_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY:
-  case RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY:
-    return 1;
-  }
-  return 0;
-}
-
-//-------------------------------------------------------------------------------------------------
-
 RenderQueue3D *render_queue_3d_global(void)
 {
   return &g_RenderQueue3D;
@@ -104,17 +80,6 @@ static tTrackZOrderEntry *render_queue_3d_add_required(RenderQueue3D *pQueue,
   ++pQueue->count;
 
   return pEntry;
-}
-
-//-------------------------------------------------------------------------------------------------
-
-void render_queue_3d_add_unmigrated_legacy_priority(RenderQueue3D *pQueue,
-                                                     int iLegacyPriority,
-                                                     int iChunkIdx,
-                                                     float fZDepth)
-{
-  render_queue_3d_require(!render_queue_3d_is_named_priority(iLegacyPriority));
-  render_queue_3d_add_required(pQueue, iLegacyPriority, iChunkIdx, fZDepth);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/render_queue_3d.h
+++ b/PROJECTS/ROLLER/render_queue_3d.h
@@ -20,8 +20,8 @@
 #define RENDER_QUEUE_3D_BUILDING_LEGACY_PRIORITY 13
 #define RENDER_QUEUE_3D_START_LIGHT_LEGACY_PRIORITY 14
 
-// Only implemented gameplay-3D command kinds are named here. Legacy priorities stay on the
-// temporary compatibility path until their renderers migrate to typed queue submission APIs.
+// Only implemented gameplay-3D command kinds are named here. Gameplay 3D submissions use
+// typed queue APIs so raw legacy priority writes cannot leak back into drawtrk3.c.
 typedef enum
 {
   RENDER_COMMAND_3D_KIND_BUILDING = 0,
@@ -146,13 +146,6 @@ void render_queue_3d_clear(RenderQueue3D *pQueue);
 tTrackZOrderEntry *render_queue_3d_entries(RenderQueue3D *pQueue);
 const RenderCommand3D *render_queue_3d_command_at(const RenderQueue3D *pQueue, int iIndex);
 int render_queue_3d_count(const RenderQueue3D *pQueue);
-
-// Temporary compatibility API for unmigrated legacy render priorities. Priorities with named
-// command APIs must use those APIs instead.
-void render_queue_3d_add_unmigrated_legacy_priority(RenderQueue3D *pQueue,
-                                                     int iLegacyPriority,
-                                                     int iChunkIdx,
-                                                     float fZDepth);
 
 void render_queue_3d_add_ground(RenderQueue3D *pQueue,
                                  int iSectionIdx,

--- a/tools/check_render_queue_3d_seams.py
+++ b/tools/check_render_queue_3d_seams.py
@@ -15,6 +15,8 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 DRAWTRK3 = ROOT / "PROJECTS" / "ROLLER" / "drawtrk3.c"
 FRAME_SRC = ROOT / "PROJECTS" / "ROLLER" / "3d.c"
+RENDER_QUEUE_SRC = ROOT / "PROJECTS" / "ROLLER" / "render_queue_3d.c"
+RENDER_QUEUE_HDR = ROOT / "PROJECTS" / "ROLLER" / "render_queue_3d.h"
 SNAPSHOT_SRC = ROOT / "PROJECTS" / "ROLLER" / "snapshot.c"
 SNAPSHOT_HDR = ROOT / "PROJECTS" / "ROLLER" / "snapshot.h"
 ROLLER_SRC = ROOT / "PROJECTS" / "ROLLER"
@@ -69,6 +71,12 @@ REQUIRED_DRAWTRACK_PHASE_MARKERS = {
     "Gameplay 3D queue phase: sorted dispatch": "sorted dispatch phase",
 }
 
+GAMEPLAY_3D_RENDER_QUEUE_FILES = {
+    "drawtrk3.c",
+    "render_queue_3d.c",
+    "render_queue_3d.h",
+}
+
 REQUIRED_SNAPSHOT_RECORD_MARKERS = {
     "SnapshotApplyFixedRecords();": "snapshot-mode record fixture application",
     "if (!g_bSnapshotMode) SaveRecords();": "snapshot-mode SaveRecords guard",
@@ -84,8 +92,8 @@ def fail(message: str) -> int:
     return 1
 
 
-def direct_priority_write_pattern(priority: int) -> re.Pattern[str]:
-    return re.compile(rf"\.nRenderPriority\s*=\s*{priority}\b|->nRenderPriority\s*=\s*{priority}\b")
+def direct_priority_write_pattern() -> re.Pattern[str]:
+    return re.compile(r"\.nRenderPriority\s*=|->nRenderPriority\s*=")
 
 
 def compatibility_call_pattern(function_name: str, priority: int) -> re.Pattern[str]:
@@ -97,10 +105,11 @@ def main() -> int:
     frame_src = FRAME_SRC.read_text(encoding="utf-8")
     snapshot_src = SNAPSHOT_SRC.read_text(encoding="utf-8")
     snapshot_hdr = SNAPSHOT_HDR.read_text(encoding="utf-8")
+    render_queue_src = RENDER_QUEUE_SRC.read_text(encoding="utf-8")
+    render_queue_hdr = RENDER_QUEUE_HDR.read_text(encoding="utf-8")
 
-    for priority, name in MIGRATED_PRIORITIES.items():
-        if direct_priority_write_pattern(priority).search(drawtrk3):
-            return fail(f"drawtrk3.c writes {name} legacy priority {priority} directly")
+    if direct_priority_write_pattern().search(drawtrk3):
+        return fail("drawtrk3.c writes legacy render priorities directly")
 
     for api_name, label in REQUIRED_DRAWTRK3_APIS.items():
         if api_name not in drawtrk3:
@@ -112,8 +121,14 @@ def main() -> int:
     if re.search(r"\bnum_bits\b", drawtrk3):
         return fail("drawtrk3.c still maintains num_bits instead of querying render_queue_3d_count")
 
+    if "TrackView" in drawtrk3:
+        return fail("drawtrk3.c must not use the legacy TrackView queue alias")
+
     if "render_queue_3d_add_legacy_priority" in drawtrk3:
         return fail("drawtrk3.c still uses old legacy-priority compatibility API name")
+
+    if "render_queue_3d_add_unmigrated_legacy_priority" in render_queue_src + render_queue_hdr:
+        return fail("temporary unmigrated legacy-priority compatibility API must be removed")
 
     for marker, label in REQUIRED_FRAME_PHASE_MARKERS.items():
         if marker not in frame_src:
@@ -130,6 +145,13 @@ def main() -> int:
     for marker, label in REQUIRED_SNAPSHOT_RECORD_MARKERS.items():
         if marker not in snapshot_text:
             return fail(f"snapshot harness does not pin {label}")
+
+    for path in ROLLER_SRC.glob("*.[ch]"):
+        if path.name in GAMEPLAY_3D_RENDER_QUEUE_FILES:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "render_queue_3d.h" in text or re.search(r"\brender_queue_3d_", text):
+            return fail(f"{path.relative_to(ROOT)} reaches into gameplay render_queue_3d")
 
     save_records_callers = "\n".join(path.read_text(encoding="utf-8") for path in ROLLER_SRC.glob("*.c"))
     if save_records_callers.count("SaveRecords();") != save_records_callers.count("if (!g_bSnapshotMode) SaveRecords();"):


### PR DESCRIPTION
## Summary
- Remove the completed unmigrated legacy-priority compatibility API from render_queue_3d.
- Remove the legacy TrackView alias from drawtrk3.c and read queue entries through the render_queue_3d accessor.
- Strengthen seam checks to reject direct drawtrk3 legacy priority writes, removed compatibility API use, and non-gameplay render_queue_3d reach-ins.

Closes #161

## Test Plan
- [x] python3 tools/check_render_queue_3d_seams.py
- [x] zig build test-render-queue-3d
- [x] zig build
- [x] zig build test-snapshots