### PR TITLE
fix car shadows, particles through walls, mirror selection; add debug options

### DIFF
--- a/PROJECTS/ROLLER/car.c
+++ b/PROJECTS/ROLLER/car.c
@@ -14,6 +14,7 @@
 #include "polyf.h"
 #include "polytex.h"
 #include "roller.h"
+#include "scene_render_gpu.h"
 #include <math.h>
 #include <assert.h>
 #include <string.h>
@@ -1519,7 +1520,7 @@ LABEL_105:
 LABEL_117:
   pCoords = CarDesigns[carDesignIndex].pCoords;
   pPols = CarDesigns[carDesignIndex].pPols;
-  if ((Car[iCarIndexCopy].byStatusFlags & 2) != 0) {
+  if ((Car[iCarIndexCopy].byStatusFlags & 2) != 0 && !g_bShowCarOnExplosion) {
     pCarDesign = NULL;
     iNumCoords = 0;
   }
@@ -2204,7 +2205,7 @@ void DisplayCarSmoke(int carIdx, const CarRenderPose *pose)
         float vx = (float)(dx * vk1 + dy * vk4 + dz * vk7);
         float vy = (float)(dx * vk2 + dy * vk5 + dz * vk8);
         float camZ = (float)(dx * vk3 + dy * vk6 + dz * vk9);
-        if (camZ <= 80.0f) continue;
+        if (camZ <= SCENE_GPU_NEAR) continue;
 
         float invZ = 1.0f / camZ;
         int sx = d2i((double)VIEWDIST * vx * invZ + xbase) * scr_size >> 6;
@@ -2213,12 +2214,11 @@ void DisplayCarSmoke(int carIdx, const CarRenderPose *pose)
         SmokePt[0][i].screen.y = sy;
         SmokePt[0][i].view.fZ  = camZ;
 
-        /* Provide GPU depth so particles are occluded by solid geometry.
-         * Bias forward slightly so smoke passes depth test against road/ground
-         * at the same distance (floating-point precision tie at z≈1).  The bias
-         * is proportional to z² so it stays small at close range. */
-        float gndcZ = (camZ - 80.0f) * (20000000.0f / (20000000.0f - 80.0f)) / camZ;
-        gndcZ -= 0.0002f;
+        /* GPU depth for this particle, matching the perspective formula in build_mvp.
+         * Tiny forward bias covers CPU vs GPU float rounding (a few ULPs).
+         * Keep it minimal so crash-smoke at wall depth doesn't bleed through. */
+        float gndcZ = (camZ - SCENE_GPU_NEAR) * (SCENE_GPU_FAR / (SCENE_GPU_FAR - SCENE_GPU_NEAR)) / camZ;
+        gndcZ -= 0.000002f;
         if (gndcZ < 0.0f) gndcZ = 0.0f;
         game_render_set_particle_depth(g_pGameRenderer, gndcZ);
 
@@ -2237,7 +2237,7 @@ void DisplayCarSmoke(int carIdx, const CarRenderPose *pose)
             float svx = (float)(dx2 * vk1 + dy2 * vk4 + dz2 * vk7);
             float svy = (float)(dx2 * vk2 + dy2 * vk5 + dz2 * vk8);
             float camZ2 = (float)(dx2 * vk3 + dy2 * vk6 + dz2 * vk9);
-            float clamp2 = camZ2 < 80.0f ? 80.0f : camZ2;
+            float clamp2 = camZ2 < SCENE_GPU_NEAR ? SCENE_GPU_NEAR : camZ2;
             float invZ2 = 1.0f / clamp2;
             int sx2 = d2i((double)VIEWDIST * svx * invZ2 + xbase) * scr_size >> 6;
             int sy2 = (scr_size * (199 - d2i((double)VIEWDIST * svy * invZ2 + ybase))) >> 6;
@@ -2252,6 +2252,17 @@ void DisplayCarSmoke(int carIdx, const CarRenderPose *pose)
             CarPol.vertices[1].x = sx2 - iTemp; CarPol.vertices[1].y = sy2;
             CarPol.vertices[2].x = sx  - iTemp; CarPol.vertices[2].y = sy;
             CarPol.vertices[3].x = sx  + iTemp; CarPol.vertices[3].y = sy;
+            /* v0,v1 are at the tail (camZ2); v2,v3 are at the head (camZ).
+             * Supply per-vertex depth so the GPU interpolates Z across the quad
+             * instead of using the head's flat depth for the whole trail. */
+            if (camZ2 > SCENE_GPU_NEAR) {
+                float tailNdcZ = (camZ2 - SCENE_GPU_NEAR) *
+                                 (SCENE_GPU_FAR / (SCENE_GPU_FAR - SCENE_GPU_NEAR)) / camZ2;
+                tailNdcZ -= 0.000002f;
+                if (tailNdcZ < 0.0f) tailNdcZ = 0.0f;
+                const float ndcZv[4] = {tailNdcZ, tailNdcZ, gndcZ, gndcZ};
+                game_render_set_particle_depth_pervertex(g_pGameRenderer, ndcZv);
+            }
             if ((surf & SURFACE_FLAG_APPLY_TEXTURE) == 0)
                 game_render_quad_screen(g_pGameRenderer, &CarPol, TEXTURE_HANDLE_INVALID, NULL);
             else

--- a/PROJECTS/ROLLER/debug_overlay.c
+++ b/PROJECTS/ROLLER/debug_overlay.c
@@ -866,6 +866,13 @@ static void DrawDebugPanel(DebugOverlay *pOverlay) {
       noclip_camera_set_input_enabled(!pOverlay->bVisible);
     }
 
+    int bShowCarOnExplosion = (int)g_bShowCarOnExplosion;
+    nk_layout_row_dynamic(pCtx, DEBUG_ROW_H, 1);
+    if (nk_checkbox_label(pCtx, "Show car on explosion", &bShowCarOnExplosion)) {
+      g_bShowCarOnExplosion = (bool)bShowCarOnExplosion;
+      InputSaveConfig();
+    }
+
 #if defined(_WIN32)
     {
       static const char *apszInputBackends[] = { "WinMM", "SDL DirectInput" };
@@ -979,6 +986,9 @@ static void DrawDebugPanel(DebugOverlay *pOverlay) {
         InputSaveConfig();
       }
 
+      if (!bGPU) nk_widget_disable_end(pCtx);
+
+      if (!bGPU || g_bDisableMipmaps) nk_widget_disable_begin(pCtx);
       nk_layout_row_dynamic(pCtx, DEBUG_ROW_H, 1);
       int bTrilinear = (int)g_bTrilinear;
       if (nk_checkbox_label(pCtx, "Trilinear filtering", &bTrilinear)) {
@@ -986,11 +996,19 @@ static void DrawDebugPanel(DebugOverlay *pOverlay) {
         game_render_set_trilinear(g_pGameRenderer, g_bTrilinear);
         InputSaveConfig();
       }
+      if (!bGPU || g_bDisableMipmaps) nk_widget_disable_end(pCtx);
 
+      if (!bGPU) nk_widget_disable_begin(pCtx);
+      
+      nk_layout_row_dynamic(pCtx, DEBUG_ROW_H, 1);
+      int bDisableMipmaps = (int)g_bDisableMipmaps;
+      if (nk_checkbox_label(pCtx, "Disable mipmaps (debug)", &bDisableMipmaps)) {
+        g_bDisableMipmaps = (bool)bDisableMipmaps;
+        game_render_set_disable_mipmaps(g_pGameRenderer, g_bDisableMipmaps);
+      }
       if (!bGPU) nk_widget_disable_end(pCtx);
 
-
-      if (!bGPU || !g_bTrilinear) nk_widget_disable_begin(pCtx);
+      if (!bGPU || !g_bTrilinear || g_bDisableMipmaps) nk_widget_disable_begin(pCtx);
       { char buf[20]; snprintf(buf, sizeof(buf), "LOD bias %.1f", g_fLodBias);
         nk_layout_row_dynamic(pCtx, DEBUG_ROW_H, 2);
         nk_label(pCtx, buf, NK_TEXT_LEFT);
@@ -1001,7 +1019,7 @@ static void DrawDebugPanel(DebugOverlay *pOverlay) {
           InputSaveConfig();
         }
       }
-      if (!bGPU || !g_bTrilinear) nk_widget_disable_end(pCtx);
+      if (!bGPU || !g_bTrilinear || g_bDisableMipmaps) nk_widget_disable_end(pCtx);
 
 
       if (!bGPU) nk_widget_disable_begin(pCtx);

--- a/PROJECTS/ROLLER/frontend_select_car.c
+++ b/PROJECTS/ROLLER/frontend_select_car.c
@@ -672,8 +672,8 @@ void frontend_car_select_update(void)
         frontend_car_select_request_exit();
       }
     } else if (byInputKey <= 0x20u) {
-      // Space: switch active player in two-player mode
       if (player_type == 2) {
+        // Space: switch active player in two-player mode
         if (iFrontendCarActivePlayer) {
           iFrontendCarActivePlayer = 0;
           frontend_car_select_begin_car_out(Players_Cars[player1_car]);
@@ -683,6 +683,10 @@ void frontend_car_select_update(void)
           frontend_car_select_begin_car_out(Players_Cars[player2_car]);
           iFrontendCarSpeechPending = 0;
         }
+      } else {
+        // Space: toggle basic/advanced car set
+        textures_off ^= TEX_OFF_ADVANCED_CARS;
+        switch_sets = -1;
       }
     } else if (byInputKey < 0x2Du) {
       if (byInputKey == 43)  // '+'

--- a/PROJECTS/ROLLER/game_render.c
+++ b/PROJECTS/ROLLER/game_render.c
@@ -366,6 +366,12 @@ void game_render_set_particle_depth(GameRenderer *renderer, float ndcZ)
         scene_render_gpu_set_particle_ndcz(renderer->gpu, ndcZ);
 }
 
+void game_render_set_particle_depth_pervertex(GameRenderer *renderer, const float ndcZ[4])
+{
+    if (renderer && renderer->gpu)
+        scene_render_gpu_set_particle_ndcz_pervertex(renderer->gpu, ndcZ);
+}
+
 void game_render_draw_car(GameRenderer *renderer, int carIdx,
                           const GameRenderCarPose *pose,
                           const GameRenderCarOptions *options) {
@@ -552,6 +558,10 @@ void game_render_set_texture_filter(GameRenderer *renderer, int filter) {
 
 void game_render_set_trilinear(GameRenderer *renderer, bool enabled) {
     if (renderer) scene_render_gpu_set_trilinear(renderer->gpu, enabled);
+}
+
+void game_render_set_disable_mipmaps(GameRenderer *renderer, bool disabled) {
+    if (renderer) scene_render_gpu_set_disable_mipmaps(renderer->gpu, disabled);
 }
 
 void game_render_set_anisotropy_level(GameRenderer *renderer, int level) {

--- a/PROJECTS/ROLLER/game_render.h
+++ b/PROJECTS/ROLLER/game_render.h
@@ -52,6 +52,7 @@ void game_render_set_mode(GameRenderer *renderer, GameRenderMode mode);
 GameRenderMode game_render_get_mode(const GameRenderer *renderer);
 void game_render_set_force_gpu_load(GameRenderer *renderer, bool force);
 void game_render_set_particle_depth(GameRenderer *renderer, float ndcZ);
+void game_render_set_particle_depth_pervertex(GameRenderer *renderer, const float ndcZ[4]);
 void game_render_set_split_screen(GameRenderer *renderer, bool split);
 bool game_render_is_split_screen(const GameRenderer *renderer);
 void game_render_set_debug_overlay(GameRenderer *renderer, DebugOverlay *overlay);
@@ -113,6 +114,9 @@ void game_render_quad_screen(GameRenderer *renderer,
 // call so GPU particles are depth-tested against scene geometry.
 // Must be called before each particle quad.  Ignored in SW mode.
 void game_render_set_particle_depth(GameRenderer *renderer, float ndcZ);
+// Per-vertex variant: ndcZ[4] maps to quad vertices v0..v3.  Consumed after one call.
+// Use for elongated trails (type 1) where head and tail are at different depths.
+void game_render_set_particle_depth_pervertex(GameRenderer *renderer, const float ndcZ[4]);
 
 // Draw — world-space quad (GPU-ready interface)
 // verts must point to exactly 4 GameRenderVertex entries.

--- a/PROJECTS/ROLLER/game_render_hardware.c
+++ b/PROJECTS/ROLLER/game_render_hardware.c
@@ -52,6 +52,7 @@ typedef struct {
     int             indexCount;
     int             bodyIndexCount;
     bool            built;
+    bool            advancedCars; /* TEX_OFF_ADVANCED_CARS state when built */
 } GRHWCarMesh;
 
 struct GameRendererHardware {
@@ -264,7 +265,8 @@ static bool build_car_mesh(SDL_GPUDevice *dev, int carIdx,
             cr = cg = cb = ca = 1.0f;
         } else {
             uint8 colorIdx = (uint8)tex;
-            if (!(tex & SURFACE_FLAG_APPLY_TEXTURE) &&
+            if ((textures_off & TEX_OFF_ADVANCED_CARS) != 0 &&
+                !(tex & SURFACE_FLAG_APPLY_TEXTURE) &&
                 remap->uiColorFrom != 0xFFFFFFFF &&
                 colorIdx == (uint8)remap->uiColorFrom)
                 colorIdx = (uint8)remap->uiColorTo;
@@ -344,7 +346,8 @@ static bool build_car_mesh(SDL_GPUDevice *dev, int carIdx,
             crb = cgb = cbb = cab = 1.0f;
         } else {
             uint8 colorIdx = (uint8)tex;
-            if (!(tex & SURFACE_FLAG_APPLY_TEXTURE) &&
+            if ((textures_off & TEX_OFF_ADVANCED_CARS) != 0 &&
+                !(tex & SURFACE_FLAG_APPLY_TEXTURE) &&
                 remap->uiColorFrom != 0xFFFFFFFF &&
                 colorIdx == (uint8)remap->uiColorFrom)
                 colorIdx = (uint8)remap->uiColorTo;
@@ -528,11 +531,21 @@ void game_render_hw_draw_car(GameRendererHardware       *r,
     if (carIdx < 0 || carIdx >= GAME_RENDER_HW_NUM_CARS) return;
 
     GRHWCarMesh *mesh = &r->meshes[carIdx];
+    bool wantAdvanced = (textures_off & TEX_OFF_ADVANCED_CARS) != 0;
+    if (mesh->built && mesh->advancedCars != wantAdvanced) {
+        for (int f = 0; f < GRHW_ANIM_FRAMES; f++) {
+            if (mesh->vertexBufs[f]) { SDL_ReleaseGPUBuffer(r->device, mesh->vertexBufs[f]); mesh->vertexBufs[f] = NULL; }
+        }
+        if (mesh->indexBuf)  { SDL_ReleaseGPUBuffer(r->device, mesh->indexBuf);  mesh->indexBuf  = NULL; }
+        if (mesh->atlas)     { SDL_ReleaseGPUTexture(r->device, mesh->atlas);    mesh->atlas      = NULL; }
+        mesh->built = false;
+    }
     if (!mesh->built) {
         if (build_car_mesh(r->device, carIdx, palette, mesh))
             mesh->built = true;
         else
             return;
+        mesh->advancedCars = wantAdvanced;
     }
     if (mesh->indexCount <= 0) return;
 

--- a/PROJECTS/ROLLER/game_render_hardware.c
+++ b/PROJECTS/ROLLER/game_render_hardware.c
@@ -584,34 +584,20 @@ void game_render_hw_draw_car(GameRendererHardware       *r,
         chunk_model_matrix(Mc, &localdata[chunk]);
         mat4_mul(Mcar_chunk, Mc, M);
         mat4_mul(mvp, vp, Mcar_chunk);
-        /* Body only — shadow drawn separately with flat matrix below. */
         scene_render_gpu_queue_car_draw(scene,
             vertBuf, mesh->indexBuf, mesh->atlas,
             0, mesh->bodyIndexCount, mvp);
 
-        /* Shadow: world XY from chunk transform, groundZ from current chunk.
-         * Direction from Mcar_chunk col-0 XY (world-space car forward, projected
-         * flat) so the shadow tracks the car on curved/tilted track sections. */
-        float wx = Mcar_chunk[12], wy = Mcar_chunk[13];
-        const tData *gsd = &localdata[chunk];
-        float gp3x = gsd->pointAy[3].fX, gp3y = gsd->pointAy[3].fY;
-        float glx = gsd->pointAy[0].fX*(wx+gp3x) + gsd->pointAy[1].fX*(wy+gp3y);
-        float gly = gsd->pointAy[0].fY*(wx+gp3x) + gsd->pointAy[1].fY*(wy+gp3y);
-        float groundZ = gsd->pointAy[2].fX*glx + gsd->pointAy[2].fY*gly - gsd->pointAy[3].fZ;
-
-        float fx = Mcar_chunk[0], fy = Mcar_chunk[1];
-        float flen = sqrtf(fx*fx + fy*fy);
-        if (flen > 1e-6f) { fx /= flen; fy /= flen; }
-        float Mshadow[16];
-        Mshadow[ 0]= fx;   Mshadow[ 1]= fy;   Mshadow[ 2]=0.0f; Mshadow[ 3]=0.0f;
-        Mshadow[ 4]=-fy;   Mshadow[ 5]= fx;   Mshadow[ 6]=0.0f; Mshadow[ 7]=0.0f;
-        Mshadow[ 8]=0.0f;  Mshadow[ 9]=0.0f;  Mshadow[10]=1.0f; Mshadow[11]=0.0f;
-        Mshadow[12]=wx;    Mshadow[13]=wy;
-        Mshadow[14]=groundZ - fZLow + 3.0f;  /* +3 clears coplanarity with road */
-        Mshadow[15]=1.0f;
-        float shadowMvp[16];
-        mat4_mul(shadowMvp, vp, Mshadow);
-        scene_render_gpu_queue_car_draw(scene,
+        /* Shadow: use physical pose (no camera lean offsets) so shadow corners
+         * stay exactly on the road surface (chunk-local Z=0).  adjPose tilts the
+         * quad slightly off-road, letting it pass depth-test through barriers. */
+        float M_phys[16];
+        car_model_matrix(M_phys, pose);
+        M_phys[14] -= fZLow;
+        float Mcar_chunk_phys[16], shadowMvp[16];
+        mat4_mul(Mcar_chunk_phys, Mc, M_phys);
+        mat4_mul(shadowMvp, vp, Mcar_chunk_phys);
+        scene_render_gpu_queue_car_shadow_draw(scene,
             vertBuf, mesh->indexBuf, mesh->atlas,
             mesh->bodyIndexCount, 6, shadowMvp);
 
@@ -633,19 +619,25 @@ void game_render_hw_draw_car(GameRendererHardware       *r,
             float ly = sd->pointAy[0].fY*(wx+p3x) + sd->pointAy[1].fY*(wy+p3y);
             float groundZ = sd->pointAy[2].fX*lx + sd->pointAy[2].fY*ly - sd->pointAy[3].fZ;
 
+            float sxA = sd->pointAy[2].fX * sd->pointAy[0].fX
+                      + sd->pointAy[2].fY * sd->pointAy[0].fY;
+            float syA = sd->pointAy[2].fX * sd->pointAy[1].fX
+                      + sd->pointAy[2].fY * sd->pointAy[1].fY;
             float fx = M[0], fy = M[1];
             float flen = sqrtf(fx*fx + fy*fy);
             if (flen > 1e-6f) { fx /= flen; fy /= flen; }
-            float Mshadow[16];
-            Mshadow[ 0]= fx;   Mshadow[ 1]= fy;   Mshadow[ 2]=0.0f; Mshadow[ 3]=0.0f;
-            Mshadow[ 4]=-fy;   Mshadow[ 5]= fx;   Mshadow[ 6]=0.0f; Mshadow[ 7]=0.0f;
-            Mshadow[ 8]=0.0f;  Mshadow[ 9]=0.0f;  Mshadow[10]=1.0f; Mshadow[11]=0.0f;
-            Mshadow[12]=wx;    Mshadow[13]=wy;
-            Mshadow[14]=groundZ - fZLow + 3.0f;  /* +3 clears coplanarity with road */
+            float Mshadow[16] = {0};
+            Mshadow[ 0]= fx;            Mshadow[ 1]= fy;
+            Mshadow[ 2]= sxA*fx + syA*fy;
+            Mshadow[ 4]=-fy;            Mshadow[ 5]= fx;
+            Mshadow[ 6]= sxA*(-fy) + syA*fx;
+            Mshadow[10]=1.0f;
+            Mshadow[12]=wx;             Mshadow[13]=wy;
+            Mshadow[14]=groundZ - fZLow;
             Mshadow[15]=1.0f;
             float shadowMvp[16];
             mat4_mul(shadowMvp, vp, Mshadow);
-            scene_render_gpu_queue_car_draw(scene,
+            scene_render_gpu_queue_car_shadow_draw(scene,
                 vertBuf, mesh->indexBuf, mesh->atlas,
                 mesh->bodyIndexCount, 6, shadowMvp);
         }

--- a/PROJECTS/ROLLER/game_render_hw.h
+++ b/PROJECTS/ROLLER/game_render_hw.h
@@ -13,6 +13,8 @@ typedef struct GameRenderer GameRenderer;
 void game_render_set_texture_filter(GameRenderer *renderer, int filter);
 /* Trilinear mip blending */
 void game_render_set_trilinear(GameRenderer *renderer, bool enabled);
+/* Debug: clamp sampler to mip 0 only (isolates Adreno mipmap layout bug) */
+void game_render_set_disable_mipmaps(GameRenderer *renderer, bool disabled);
 /* Anisotropy level: 0=2x, 1=4x, 2=8x, 3=16x */
 void game_render_set_anisotropy_level(GameRenderer *renderer, int level);
 /* Mip LOD bias: negative=sharper, positive=blurrier */

--- a/PROJECTS/ROLLER/menu_render_gpu.c
+++ b/PROJECTS/ROLLER/menu_render_gpu.c
@@ -114,7 +114,8 @@ struct MenuRendererGPU {
 
     // 3D mesh state
     MeshPreview carMesh;
-    int loadedCarIdx;   // -1 = no car loaded (avoids per-frame reload)
+    int loadedCarIdx;       // -1 = no car loaded (avoids per-frame reload)
+    bool loadedAdvancedCars; // TEX_OFF_ADVANCED_CARS state when car mesh was built
     bool trackMeshLoaded;
     MeshPreview trackMesh;
 
@@ -1194,7 +1195,8 @@ static SDL_GPUTexture *BuildCarTextureAtlas(MenuRendererGPU *r, int carIdx,
 
 void menu_render_gpu_load_car_mesh(MenuRendererGPU *r, int carIdx, const tColor *pal)
 {
-    if (r->loadedCarIdx == carIdx && r->carMesh.loaded) return;
+    bool wantAdvanced = (textures_off & TEX_OFF_ADVANCED_CARS) != 0;
+    if (r->loadedCarIdx == carIdx && r->carMesh.loaded && r->loadedAdvancedCars == wantAdvanced) return;
     menu_render_gpu_free_car_mesh(r);
 
     if (carIdx < 0 || carIdx > CAR_DESIGN_DEATH) return;
@@ -1218,9 +1220,9 @@ void menu_render_gpu_load_car_mesh(MenuRendererGPU *r, int carIdx, const tColor 
     float whiteU = hasAtlas ? 0.5f / 256.0f : 0.0f;
     float whiteV = hasAtlas ? (atlasH - 0.5f) / fAtlasH : 0.0f;
 
-    // Each quad becomes 4 verts + 6 indices (2 triangles), plus 4+6 for shadow quad
-    MeshVertex *vertices = calloc(numPols * 4 + 4, sizeof(MeshVertex));
-    uint32 *indices = calloc(numPols * 6 + 6, sizeof(uint32));
+    // Each quad: up to 2×(4 verts + 6 indices) when back face is present, plus shadow
+    MeshVertex *vertices = calloc(numPols * 8 + 4, sizeof(MeshVertex));
+    uint32 *indices = calloc(numPols * 12 + 6, sizeof(uint32));
     int vertCount = 0, idxCount = 0;
 
     tCarColorRemap *remap = &car_flat_remap[carIdx];
@@ -1262,7 +1264,8 @@ void menu_render_gpu_load_car_mesh(MenuRendererGPU *r, int carIdx, const tColor 
         } else {
             // Flat-colored polygon — palette color via vertex color
             uint8 colorIdx = (uint8)tex;
-            if (!(tex & SURFACE_FLAG_APPLY_TEXTURE) &&
+            if (wantAdvanced &&
+                !(tex & SURFACE_FLAG_APPLY_TEXTURE) &&
                 remap->uiColorFrom != 0xFFFFFFFF &&
                 colorIdx == (uint8)remap->uiColorFrom)
                 colorIdx = (uint8)remap->uiColorTo;
@@ -1312,6 +1315,70 @@ void menu_render_gpu_load_car_mesh(MenuRendererGPU *r, int carIdx, const tColor 
         indices[idxCount++] = baseVert + 0;
         indices[idxCount++] = baseVert + 2;
         indices[idxCount++] = baseVert + 3;
+
+        // Back face: emit reversed-winding quad with the back texture (pBacks[p]).
+        // Matches SW DrawCar which uses design->pBacks[polIdx] when viewed from behind.
+        if ((tex & SURFACE_FLAG_BACK) && design->pBacks) {
+            uint32 backTex = design->pBacks[p];
+
+            float bu0, bu1, bv0, bv1;
+            float bcr, bcg, bcb;
+            bool backIsTextured = hasAtlas && (backTex & SURFACE_FLAG_APPLY_TEXTURE) &&
+                                  (uint8)backTex < numTiles;
+            if (backIsTextured) {
+                uint8 btile = (uint8)backTex;
+                int bcol = btile % 4, brow = btile / 4;
+                bu0 = (bcol * 64.0f) / 256.0f;
+                bu1 = ((bcol + 1) * 64.0f) / 256.0f;
+                bv0 = (brow * 64.0f) / fAtlasH;
+                bv1 = ((brow + 1) * 64.0f) / fAtlasH;
+                if (backTex & SURFACE_FLAG_FLIP_HORIZ) { float t = bu0; bu0 = bu1; bu1 = t; }
+                if (backTex & SURFACE_FLAG_FLIP_VERT)  { float t = bv0; bv0 = bv1; bv1 = t; }
+                bcr = bcg = bcb = 1.0f;
+            } else {
+                uint8 colorIdx = (uint8)backTex;
+                if (wantAdvanced &&
+                    !(backTex & SURFACE_FLAG_APPLY_TEXTURE) &&
+                    remap->uiColorFrom != 0xFFFFFFFF &&
+                    colorIdx == (uint8)remap->uiColorFrom)
+                    colorIdx = (uint8)remap->uiColorTo;
+                const tColor *bc = &pal[colorIdx];
+                bcr = (bc->byR * 255.0f / 63.0f) / 255.0f;
+                bcg = (bc->byG * 255.0f / 63.0f) / 255.0f;
+                bcb = (bc->byB * 255.0f / 63.0f) / 255.0f;
+                bu0 = bu1 = whiteU;
+                bv0 = bv1 = whiteV;
+            }
+
+            // Same UV layout as front; reversed winding makes it visible from the other side.
+            float back_uvs[4][2] = {
+                { bu1, bv0 }, { bu0, bv0 }, { bu0, bv1 }, { bu1, bv1 }
+            };
+
+            int backBase = vertCount;
+            for (int v = 0; v < 4; v++) {
+                uint8 vi = pols[p].verts[v];
+                if (vi >= numCoords) vi = 0;
+                MeshVertex *mv = &vertices[vertCount++];
+                mv->position[0] = coords[vi].fY;
+                mv->position[1] = coords[vi].fZ;
+                mv->position[2] = coords[vi].fX;
+                mv->uv[0] = back_uvs[v][0];
+                mv->uv[1] = back_uvs[v][1];
+                mv->color[0] = bcr;
+                mv->color[1] = bcg;
+                mv->color[2] = bcb;
+                mv->color[3] = 1.0f;
+            }
+
+            // Reversed winding: (0,2,1) and (0,3,2)
+            indices[idxCount++] = backBase + 0;
+            indices[idxCount++] = backBase + 2;
+            indices[idxCount++] = backBase + 1;
+            indices[idxCount++] = backBase + 0;
+            indices[idxCount++] = backBase + 3;
+            indices[idxCount++] = backBase + 2;
+        }
     }
 
     // Shadow quad: semi-transparent ground plane computed from mesh bounding box
@@ -1367,6 +1434,7 @@ void menu_render_gpu_load_car_mesh(MenuRendererGPU *r, int carIdx, const tColor 
         r->carMesh.indexCount = idxCount;
         r->carMesh.loaded = true;
         r->loadedCarIdx = carIdx;
+        r->loadedAdvancedCars = wantAdvanced;
     } else if (atlas) {
         SDL_ReleaseGPUTexture(r->device, atlas);
     }

--- a/PROJECTS/ROLLER/menu_render_gpu.c
+++ b/PROJECTS/ROLLER/menu_render_gpu.c
@@ -1220,9 +1220,9 @@ void menu_render_gpu_load_car_mesh(MenuRendererGPU *r, int carIdx, const tColor 
     float whiteU = hasAtlas ? 0.5f / 256.0f : 0.0f;
     float whiteV = hasAtlas ? (atlasH - 0.5f) / fAtlasH : 0.0f;
 
-    // Each quad: up to 2×(4 verts + 6 indices) when back face is present, plus shadow
-    MeshVertex *vertices = calloc(numPols * 8 + 4, sizeof(MeshVertex));
-    uint32 *indices = calloc(numPols * 12 + 6, sizeof(uint32));
+    // Each quad: up to 3×(4 verts + 6 indices): front + BACK reversed + FLIP_BACKFACE reversed
+    MeshVertex *vertices = calloc(numPols * 12 + 4, sizeof(MeshVertex));
+    uint32 *indices = calloc(numPols * 18 + 6, sizeof(uint32));
     int vertCount = 0, idxCount = 0;
 
     tCarColorRemap *remap = &car_flat_remap[carIdx];
@@ -1316,9 +1316,9 @@ void menu_render_gpu_load_car_mesh(MenuRendererGPU *r, int carIdx, const tColor 
         indices[idxCount++] = baseVert + 2;
         indices[idxCount++] = baseVert + 3;
 
-        // Back face: emit reversed-winding quad with the back texture (pBacks[p]).
-        // Matches SW DrawCar which uses design->pBacks[polIdx] when viewed from behind.
-        if ((tex & SURFACE_FLAG_BACK) && design->pBacks) {
+        // Back face for BACK-only (no FLIP_BACKFACE) polygons.
+        // FLIP_BACKFACE polygons (with or without BACK) are handled in the loop below.
+        if ((tex & SURFACE_FLAG_BACK) && !(pols[p].uiTex & SURFACE_FLAG_FLIP_BACKFACE) && design->pBacks) {
             uint32 backTex = design->pBacks[p];
 
             float bu0, bu1, bv0, bv1;
@@ -1379,6 +1379,83 @@ void menu_render_gpu_load_car_mesh(MenuRendererGPU *r, int carIdx, const tColor 
             indices[idxCount++] = backBase + 3;
             indices[idxCount++] = backBase + 2;
         }
+    }
+
+    /* FLIP_BACKFACE pass: reversed-winding quad, matching game_render_hardware.c logic.
+       - FLIP_BACKFACE + BACK: reversed polygon uses pBacks[p] (explicit back texture)
+       - FLIP_BACKFACE only:   reversed polygon uses same resolved texture as front face */
+    for (int p = 0; p < numPols; p++) {
+        uint32 rawFront = pols[p].uiTex;
+        if (rawFront & SURFACE_FLAG_SKIP_RENDER) continue;
+        if (!(rawFront & SURFACE_FLAG_FLIP_BACKFACE)) continue;
+
+        uint32 tex;
+        if (rawFront & SURFACE_FLAG_BACK) {
+            if (!design->pBacks) continue;
+            tex = design->pBacks[p];
+        } else {
+            tex = rawFront;
+            if ((tex & CAR_FLAG_ANMS_LOOKUP) && pAnms)
+                tex = pAnms[(uint8)tex].framesAy[0];
+        }
+        if (tex & SURFACE_FLAG_SKIP_RENDER) continue;
+
+        bool isTextured = hasAtlas && (tex & SURFACE_FLAG_APPLY_TEXTURE) &&
+                          (uint8)tex < numTiles;
+
+        float u0, u1, v0, v1;
+        float cr, cg, cb;
+
+        if (isTextured) {
+            uint8 tileIdx = (uint8)tex;
+            int col = tileIdx % 4, row = tileIdx / 4;
+            u0 = (col * 64.0f) / 256.0f;
+            u1 = ((col + 1) * 64.0f) / 256.0f;
+            v0 = (row * 64.0f) / fAtlasH;
+            v1 = ((row + 1) * 64.0f) / fAtlasH;
+            if (tex & SURFACE_FLAG_FLIP_HORIZ) { float t = u0; u0 = u1; u1 = t; }
+            if (tex & SURFACE_FLAG_FLIP_VERT)  { float t = v0; v0 = v1; v1 = t; }
+            cr = cg = cb = 1.0f;
+        } else {
+            uint8 colorIdx = (uint8)tex;
+            if (wantAdvanced &&
+                !(tex & SURFACE_FLAG_APPLY_TEXTURE) &&
+                remap->uiColorFrom != 0xFFFFFFFF &&
+                colorIdx == (uint8)remap->uiColorFrom)
+                colorIdx = (uint8)remap->uiColorTo;
+            const tColor *c = &pal[colorIdx];
+            cr = (c->byR * 255.0f / 63.0f) / 255.0f;
+            cg = (c->byG * 255.0f / 63.0f) / 255.0f;
+            cb = (c->byB * 255.0f / 63.0f) / 255.0f;
+            u0 = u1 = whiteU;
+            v0 = v1 = whiteV;
+        }
+
+        /* Reversed vertex order (3,2,1,0) makes the quad visible from the back side. */
+        float uvs[4][2] = {
+            { u1, v0 }, { u0, v0 }, { u0, v1 }, { u1, v1 }
+        };
+        int baseVert = vertCount;
+        for (int v = 0; v < 4; v++) {
+            uint8 vi = pols[p].verts[3 - v];
+            if (vi >= numCoords) vi = 0;
+            MeshVertex *mv = &vertices[vertCount++];
+            mv->position[0] = coords[vi].fY;
+            mv->position[1] = coords[vi].fZ;
+            mv->position[2] = coords[vi].fX;
+            mv->uv[0] = uvs[v][0];
+            mv->uv[1] = uvs[v][1];
+            mv->color[0] = cr;
+            mv->color[1] = cg;
+            mv->color[2] = cb;
+            mv->color[3] = 1.0f;
+        }
+        indices[idxCount++] = (uint32)(baseVert + 0);
+        indices[idxCount++] = (uint32)(baseVert + 1);
+        indices[idxCount++] = (uint32)(baseVert + 2);
+        indices[idxCount++] = (uint32)(baseVert + 0);
+        indices[idxCount++] = (uint32)(baseVert + 2);
+        indices[idxCount++] = (uint32)(baseVert + 3);
     }
 
     // Shadow quad: semi-transparent ground plane computed from mesh bounding box

--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -112,9 +112,11 @@ bool g_bAINoCheatStart = false;  //  Set true to not give AI cars an advantage d
 bool g_bFixCarMenuBug = true;
 bool g_bImprovedJumpLanding = true;
 bool g_bNoclip = false;
+bool g_bShowCarOnExplosion = false;
 int   g_iTextureFilter   = 0;
 int   g_iAnisotropyLevel = 3;     /* default 16x */
 bool  g_bTrilinear       = false;
+bool  g_bDisableMipmaps  = false;
 float g_fLodBias         = 0.0f;
 float g_fRenderScale     = 1.0f;
 int   g_iAntiAliasing    = 0;     /* 0=off, 1=2x, 2=4x, 3=8x */

--- a/PROJECTS/ROLLER/roller.h
+++ b/PROJECTS/ROLLER/roller.h
@@ -18,9 +18,11 @@ extern bool g_bAINoCheatStart;
 extern bool g_bFixCarMenuBug;
 extern bool g_bImprovedJumpLanding;
 extern bool g_bNoclip;
+extern bool g_bShowCarOnExplosion; /* true = keep car mesh visible during explosion animation */
 extern int   g_iTextureFilter;   /* 0=nearest, 1=bilinear, 2=anisotropic */
 extern int   g_iAnisotropyLevel; /* 0=2x, 1=4x, 2=8x, 3=16x */
 extern bool  g_bTrilinear;       /* true = blend linearly between mip levels */
+extern bool  g_bDisableMipmaps;  /* true = clamp sampler to mip 0 (debug) */
 extern float g_fLodBias;         /* mip LOD bias; 0 = neutral */
 extern float g_fRenderScale;     /* render resolution multiplier; 1.0 = native */
 extern int   g_iAntiAliasing;    /* 0=off, 1=MSAA 2x, 2=MSAA 4x, 3=MSAA 8x */

--- a/PROJECTS/ROLLER/rollerinput.c
+++ b/PROJECTS/ROLLER/rollerinput.c
@@ -3030,6 +3030,13 @@ static int InputParseDebugSetting(const char *szName, const char *szValue)
     return 1;
   }
 
+  if (InputStringEqualsNoCase(szName, "ShowCarOnExplosion")) {
+    g_bShowCarOnExplosion = InputStringEqualsNoCase(szValue, "On") ||
+                            InputStringEqualsNoCase(szValue, "1")  ||
+                            InputStringEqualsNoCase(szValue, "True");
+    return 1;
+  }
+
   if (InputStringEqualsNoCase(szName, "CRTFilter")) {
     g_bCRTFilter = InputStringEqualsNoCase(szValue, "On") ||
                    InputStringEqualsNoCase(szValue, "1")  ||
@@ -3422,6 +3429,7 @@ void InputSaveConfig(void)
           g_iAntiAliasing == 3 ? "8x" : g_iAntiAliasing == 2 ? "4x" :
           g_iAntiAliasing == 1 ? "2x" : "Off");
   fprintf(fp, "Vsync=%s\n", g_bVsync ? "On" : "Off");
+  fprintf(fp, "ShowCarOnExplosion=%s\n", g_bShowCarOnExplosion ? "On" : "Off");
   fprintf(fp, "CRTFilter=%s\n",   g_bCRTFilter   ? "On" : "Off");
   fprintf(fp, "SignsOnTop=%s\n",  g_bSignsOnTop  ? "On" : "Off");
   fprintf(fp, "ShiftFreeze=%s\n", g_bShiftFreezeEnabled ? "On" : "Off");

--- a/PROJECTS/ROLLER/scene_render_gpu.c
+++ b/PROJECTS/ROLLER/scene_render_gpu.c
@@ -152,9 +152,12 @@ struct SceneRendererGPU {
 
     /* ---- Car mesh pipeline (SceneGPUMeshVertex: pos[3]+uv[2]+col[4]) ---- */
     SDL_GPUGraphicsPipeline *carPipeline;
+    SDL_GPUGraphicsPipeline *carShadowPipeline; /* LESS_OR_EQUAL + no depth write + bias */
 
     SceneGPUCarDrawCmd carDraws[SCENE_GPU_MAX_CAR_DRAWS];
     int                carDrawCount;
+    SceneGPUCarDrawCmd carShadowDraws[SCENE_GPU_MAX_CAR_DRAWS];
+    int                carShadowDrawCount;
 
     /* ---- HUD overlay pipeline (SceneGPUHUDVertex: NDC pos[2]+uv[2]) ---- */
     SDL_GPUGraphicsPipeline *hudPipeline;
@@ -979,6 +982,73 @@ static SDL_GPUGraphicsPipeline *make_car_pipeline(SceneRendererGPU *r,
     return SDL_CreateGPUGraphicsPipeline(r->device, &pi);
 }
 
+static SDL_GPUGraphicsPipeline *make_car_shadow_pipeline(SceneRendererGPU *r,
+                                                          SDL_GPUShader *vert,
+                                                          SDL_GPUShader *frag,
+                                                          SDL_GPUSampleCount sc,
+                                                          SDL_GPUFillMode fillMode)
+{
+    SDL_GPUVertexAttribute attrs[3] = {
+        {.location=0, .format=SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3,
+         .offset=(Uint32)offsetof(SceneGPUMeshVertex, position)},
+        {.location=1, .format=SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2,
+         .offset=(Uint32)offsetof(SceneGPUMeshVertex, uv)},
+        {.location=2, .format=SDL_GPU_VERTEXELEMENTFORMAT_FLOAT4,
+         .offset=(Uint32)offsetof(SceneGPUMeshVertex, color)}
+    };
+    SDL_GPUVertexBufferDescription binding = {
+        .pitch = sizeof(SceneGPUMeshVertex),
+        .input_rate = SDL_GPU_VERTEXINPUTRATE_VERTEX
+    };
+    SDL_GPUColorTargetDescription ct = {
+        .format = SDL_GetGPUSwapchainTextureFormat(r->device, r->window),
+        .blend_state = {
+            .enable_blend          = true,
+            .src_color_blendfactor = SDL_GPU_BLENDFACTOR_SRC_ALPHA,
+            .dst_color_blendfactor = SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
+            .color_blend_op        = SDL_GPU_BLENDOP_ADD,
+            .src_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ONE,
+            .dst_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
+            .alpha_blend_op        = SDL_GPU_BLENDOP_ADD
+        }
+    };
+    SDL_GPUGraphicsPipelineCreateInfo pi = {
+        .vertex_shader   = vert,
+        .fragment_shader = frag,
+        .primitive_type  = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
+        .vertex_input_state = {
+            .vertex_attributes          = attrs,
+            .num_vertex_attributes      = 3,
+            .vertex_buffer_descriptions = &binding,
+            .num_vertex_buffers         = 1
+        },
+        /* CULL_NONE: shadow quad may be seen at a grazing angle */
+        .rasterizer_state = {
+            .fill_mode  = fillMode,
+            .front_face = SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE,
+            .cull_mode  = SDL_GPU_CULLMODE_NONE,
+            .enable_depth_bias          = true,
+            .depth_bias_constant_factor = -50.0f,
+            .depth_bias_slope_factor    = -5.0f,
+        },
+        .target_info = {
+            .color_target_descriptions = &ct,
+            .num_color_targets         = 1,
+            .has_depth_stencil_target  = true,
+            .depth_stencil_format      = SDL_GPU_TEXTUREFORMAT_D32_FLOAT
+        },
+        .multisample_state = { .sample_count = sc },
+        /* Drawn after car body: car-written depth blocks shadow on car surface.
+         * No depth write: preserve car body depth for subsequent passes. */
+        .depth_stencil_state = {
+            .enable_depth_test  = true,
+            .enable_depth_write = false,
+            .compare_op         = SDL_GPU_COMPAREOP_LESS_OR_EQUAL
+        }
+    };
+    return SDL_CreateGPUGraphicsPipeline(r->device, &pi);
+}
+
 static SDL_GPUGraphicsPipeline *make_sky_pipeline(SceneRendererGPU *r,
                                                       SDL_GPUShader *vert,
                                                       SDL_GPUShader *frag,
@@ -1248,9 +1318,10 @@ SceneRendererGPU *scene_render_gpu_create(SDL_GPUDevice *device, SDL_Window *win
     if (!cv || !cf) goto fail;
 
     r->carPipeline = make_car_pipeline(r, cv, cf, SDL_GPU_SAMPLECOUNT_1, SDL_GPU_FILLMODE_FILL);
+    r->carShadowPipeline = make_car_shadow_pipeline(r, cv, cf, SDL_GPU_SAMPLECOUNT_1, SDL_GPU_FILLMODE_FILL);
     SDL_ReleaseGPUShader(device, cv);
     SDL_ReleaseGPUShader(device, cf);
-    if (!r->carPipeline) goto fail;
+    if (!r->carPipeline || !r->carShadowPipeline) goto fail;
 
     /* ---- HUD shaders ---- */
     SDL_GPUShader *hv = load_shader(device, SDL_GPU_SHADERSTAGE_VERTEX,
@@ -1405,9 +1476,10 @@ void scene_render_gpu_destroy(SceneRendererGPU *r)
     if (r->treePipeline)         SDL_ReleaseGPUGraphicsPipeline(r->device, r->treePipeline);
     if (r->wallPipeline)     SDL_ReleaseGPUGraphicsPipeline(r->device, r->wallPipeline);
     if (r->bfWallPipeline)   SDL_ReleaseGPUGraphicsPipeline(r->device, r->bfWallPipeline);
-    if (r->shadowPipeline)   SDL_ReleaseGPUGraphicsPipeline(r->device, r->shadowPipeline);
-    if (r->carPipeline)      SDL_ReleaseGPUGraphicsPipeline(r->device, r->carPipeline);
-    if (r->skyPipeline)      SDL_ReleaseGPUGraphicsPipeline(r->device, r->skyPipeline);
+    if (r->shadowPipeline)      SDL_ReleaseGPUGraphicsPipeline(r->device, r->shadowPipeline);
+    if (r->carPipeline)         SDL_ReleaseGPUGraphicsPipeline(r->device, r->carPipeline);
+    if (r->carShadowPipeline)   SDL_ReleaseGPUGraphicsPipeline(r->device, r->carShadowPipeline);
+    if (r->skyPipeline)         SDL_ReleaseGPUGraphicsPipeline(r->device, r->skyPipeline);
     if (r->hudPipeline)      SDL_ReleaseGPUGraphicsPipeline(r->device, r->hudPipeline);
     if (r->particlePipeline)    SDL_ReleaseGPUGraphicsPipeline(r->device, r->particlePipeline);
     if (r->particleVertBuf)     SDL_ReleaseGPUBuffer(r->device, r->particleVertBuf);
@@ -1588,6 +1660,7 @@ void scene_render_gpu_begin_frame(SceneRendererGPU *r)
     r->vertexCount       = 0;
     r->drawCmdCount      = 0;
     r->carDrawCount      = 0;
+    r->carShadowDrawCount = 0;
     r->particleVertCount    = 0;
     r->particleNdcZ         = 0.0f;
     r->useParticleNdcZv     = false;
@@ -2013,7 +2086,27 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
         }
     }
 
-    /* Shadow pass: drawn after car mesh so the car's written depth masks the
+    /* Car shadow pass: drawn after car body so car-written depth blocks shadow
+     * on the car surface (LESS_OR_EQUAL fails where car body wrote smaller depth). */
+    if (r->carShadowDrawCount > 0 && r->carShadowPipeline) {
+        SDL_BindGPUGraphicsPipeline(rp, r->carShadowPipeline);
+        SDL_PushGPUFragmentUniformData(r->cmdBuf, 0, &pfu, sizeof(pfu));
+        for (int i = 0; i < r->carShadowDrawCount; i++) {
+            SceneGPUCarDrawCmd *cmd = &r->carShadowDraws[i];
+            if (!cmd->texture) continue;
+            SDL_PushGPUVertexUniformData(r->cmdBuf, 0, cmd->mvp, sizeof(cmd->mvp));
+            SDL_GPUBufferBinding cvbb = {.buffer = cmd->vertBuf};
+            SDL_BindGPUVertexBuffers(rp, 0, &cvbb, 1);
+            SDL_GPUBufferBinding cibb = {.buffer = cmd->idxBuf};
+            SDL_BindGPUIndexBuffer(rp, &cibb, SDL_GPU_INDEXELEMENTSIZE_32BIT);
+            tsb.texture = cmd->texture;
+            tsb.sampler = r->sampler;
+            SDL_BindGPUFragmentSamplers(rp, 0, &tsb, 1);
+            SDL_DrawGPUIndexedPrimitives(rp, (Uint32)cmd->idxCount, 1, (Uint32)cmd->firstIndex, 0, 0);
+        }
+    }
+
+    /* Road shadow pass: drawn after car mesh so the car's written depth masks the
      * shadow from appearing on the car body (fails LESS_OR_EQUAL where car is). */
     if (r->shadowPipeline && r->drawCmdCount > 0) {
         SDL_BindGPUVertexBuffers(rp, 0, &vbb, 1);  /* restore scene vertex buffer */
@@ -2146,6 +2239,7 @@ void scene_render_gpu_discard_queued(SceneRendererGPU *r)
     r->vertexCount  = 0;
     r->drawCmdCount = 0;
     r->carDrawCount = 0;
+    r->carShadowDrawCount = 0;
 }
 
 /* --------------------------------------------------------------------------
@@ -2384,6 +2478,7 @@ void scene_render_gpu_set_wireframe(SceneRendererGPU *r, bool enabled)
     if (r->bfWallPipeline)       { SDL_ReleaseGPUGraphicsPipeline(r->device, r->bfWallPipeline);       r->bfWallPipeline       = NULL; }
     if (r->shadowPipeline)       { SDL_ReleaseGPUGraphicsPipeline(r->device, r->shadowPipeline);       r->shadowPipeline       = NULL; }
     if (r->carPipeline)          { SDL_ReleaseGPUGraphicsPipeline(r->device, r->carPipeline);          r->carPipeline          = NULL; }
+    if (r->carShadowPipeline)    { SDL_ReleaseGPUGraphicsPipeline(r->device, r->carShadowPipeline);    r->carShadowPipeline    = NULL; }
     if (r->skyPipeline)          { SDL_ReleaseGPUGraphicsPipeline(r->device, r->skyPipeline);          r->skyPipeline          = NULL; }
 
     SDL_GPUFillMode fm = enabled ? SDL_GPU_FILLMODE_LINE : SDL_GPU_FILLMODE_FILL;
@@ -2397,8 +2492,10 @@ void scene_render_gpu_set_wireframe(SceneRendererGPU *r, bool enabled)
     SDL_GPUShader *cf = load_shader(r->device, SDL_GPU_SHADERSTAGE_FRAGMENT,
         game_car_pixel_spirv,  game_car_pixel_spirv_size,
         game_car_pixel_msl,    game_car_pixel_msl_size,  1, 1);
-    if (cv && cf)
-        r->carPipeline = make_car_pipeline(r, cv, cf, sc, fm);
+    if (cv && cf) {
+        r->carPipeline       = make_car_pipeline(r, cv, cf, sc, fm);
+        r->carShadowPipeline = make_car_shadow_pipeline(r, cv, cf, sc, fm);
+    }
     if (cv) SDL_ReleaseGPUShader(r->device, cv);
     if (cf) SDL_ReleaseGPUShader(r->device, cf);
 }
@@ -2451,6 +2548,7 @@ void scene_render_gpu_set_msaa(SceneRendererGPU *r, int level)
     if (r->bfWallPipeline)       { SDL_ReleaseGPUGraphicsPipeline(r->device, r->bfWallPipeline);       r->bfWallPipeline       = NULL; }
     if (r->shadowPipeline)       { SDL_ReleaseGPUGraphicsPipeline(r->device, r->shadowPipeline);       r->shadowPipeline       = NULL; }
     if (r->carPipeline)          { SDL_ReleaseGPUGraphicsPipeline(r->device, r->carPipeline);          r->carPipeline          = NULL; }
+    if (r->carShadowPipeline)    { SDL_ReleaseGPUGraphicsPipeline(r->device, r->carShadowPipeline);    r->carShadowPipeline    = NULL; }
     if (r->skyPipeline)          { SDL_ReleaseGPUGraphicsPipeline(r->device, r->skyPipeline);          r->skyPipeline          = NULL; }
     if (r->particlePipeline)     { SDL_ReleaseGPUGraphicsPipeline(r->device, r->particlePipeline);     r->particlePipeline     = NULL; }
     if (r->texParticlePipeline)  { SDL_ReleaseGPUGraphicsPipeline(r->device, r->texParticlePipeline);  r->texParticlePipeline  = NULL; }
@@ -2501,8 +2599,10 @@ void scene_render_gpu_set_msaa(SceneRendererGPU *r, int level)
     SDL_GPUShader *cf = load_shader(r->device, SDL_GPU_SHADERSTAGE_FRAGMENT,
         game_car_pixel_spirv,  game_car_pixel_spirv_size,
         game_car_pixel_msl,    game_car_pixel_msl_size,  1, 1);
-    if (cv && cf)
-        r->carPipeline = make_car_pipeline(r, cv, cf, sc, fm);
+    if (cv && cf) {
+        r->carPipeline       = make_car_pipeline(r, cv, cf, sc, fm);
+        r->carShadowPipeline = make_car_shadow_pipeline(r, cv, cf, sc, fm);
+    }
     if (cv) SDL_ReleaseGPUShader(r->device, cv);
     if (cf) SDL_ReleaseGPUShader(r->device, cf);
 
@@ -3639,6 +3739,24 @@ void scene_render_gpu_queue_car_draw(SceneRendererGPU *r,
 {
     if (!r || r->carDrawCount >= SCENE_GPU_MAX_CAR_DRAWS) return;
     SceneGPUCarDrawCmd *cmd = &r->carDraws[r->carDrawCount++];
+    cmd->vertBuf    = vertBuf;
+    cmd->idxBuf     = idxBuf;
+    cmd->texture    = texture;
+    cmd->firstIndex = firstIndex;
+    cmd->idxCount   = idxCount;
+    memcpy(cmd->mvp, mvp, 16 * sizeof(float));
+}
+
+void scene_render_gpu_queue_car_shadow_draw(SceneRendererGPU *r,
+                                            SDL_GPUBuffer *vertBuf,
+                                            SDL_GPUBuffer *idxBuf,
+                                            SDL_GPUTexture *texture,
+                                            int firstIndex,
+                                            int idxCount,
+                                            const float mvp[16])
+{
+    if (!r || r->carShadowDrawCount >= SCENE_GPU_MAX_CAR_DRAWS) return;
+    SceneGPUCarDrawCmd *cmd = &r->carShadowDraws[r->carShadowDrawCount++];
     cmd->vertBuf    = vertBuf;
     cmd->idxBuf     = idxBuf;
     cmd->texture    = texture;

--- a/PROJECTS/ROLLER/scene_render_gpu.c
+++ b/PROJECTS/ROLLER/scene_render_gpu.c
@@ -31,8 +31,7 @@ extern int backwards;          /* drawtrk3.c: -1 = camera looks backward along t
 #define SCENE_GPU_MAX_CAR_DRAWS      32   /* 16 cars × up to 2 draws each (body + shadow) */
 #define SCENE_GPU_MAX_PARTICLE_VERTS (576 * 6) /* 18 cars × 32 particles × 6 verts per quad */
 #define SCENE_GPU_MAX_TEX_RANGES     (SCENE_GPU_MAX_PARTICLE_VERTS / 6) /* one range per quad worst case */
-#define SCENE_GPU_NEAR               10.0f
-#define SCENE_GPU_FAR                20000000.0f
+/* SCENE_GPU_NEAR / SCENE_GPU_FAR defined in scene_render_gpu.h */
 
 /* --------------------------------------------------------------------------
  * Vertex layouts
@@ -218,6 +217,7 @@ struct SceneRendererGPU {
 
     int   textureFilter;   /* 0=nearest, 1=bilinear, 2=anisotropic */
     bool  trilinear;       /* true = LINEAR mipmap mode; textures always have full mip chain */
+    bool  disableMipmaps;  /* true = clamp sampler to mip 0 only (debug: isolates Adreno layout bug) */
     int   anisotropyLevel; /* 0=2x, 1=4x, 2=8x, 3=16x */
     float lodBias;         /* mip LOD bias applied to all texture samples */
     float renderScale;     /* internal render resolution multiplier; 1.0 = native */
@@ -253,6 +253,8 @@ struct SceneRendererGPU {
     SceneGPUParticleVertex  *particleVerts;  /* CPU-side accumulation buffer */
     int                      particleVertCount;
     float                    particleNdcZ;   /* depth for next screen_quad_flat call */
+    float                    particleNdcZv[4]; /* per-vertex depth override (v0..v3) */
+    bool                     useParticleNdcZv; /* true = use particleNdcZv instead of particleNdcZ */
 
     /* ---- Screen-space textured particle pass ---- */
     SDL_GPUGraphicsPipeline   *texParticlePipeline;
@@ -1444,16 +1446,29 @@ void scene_render_gpu_screen_quad_flat(SceneRendererGPU *r,
     SceneGPUParticleVertex *v = r->particleVerts + r->particleVertCount;
     /* Two triangles (v0,v1,v2) and (v0,v2,v3) covering the quad. */
     static const int idx[6] = {0, 1, 2, 0, 2, 3};
+    bool perZ = r->useParticleNdcZv;
     for (int i = 0; i < 6; i++) {
         int k = idx[i];
-        v[i] = (SceneGPUParticleVertex){ndcX[k], ndcY[k], r->particleNdcZ, cr, cg, cb, ca};
+        float z = perZ ? r->particleNdcZv[k] : r->particleNdcZ;
+        v[i] = (SceneGPUParticleVertex){ndcX[k], ndcY[k], z, cr, cg, cb, ca};
     }
     r->particleVertCount += 6;
+    r->useParticleNdcZv = false;
 }
 
 void scene_render_gpu_set_particle_ndcz(SceneRendererGPU *r, float ndcZ)
 {
     if (r) r->particleNdcZ = ndcZ;
+}
+
+void scene_render_gpu_set_particle_ndcz_pervertex(SceneRendererGPU *r, const float ndcZ[4])
+{
+    if (!r) return;
+    r->particleNdcZv[0] = ndcZ[0];
+    r->particleNdcZv[1] = ndcZ[1];
+    r->particleNdcZv[2] = ndcZ[2];
+    r->particleNdcZv[3] = ndcZ[3];
+    r->useParticleNdcZv = true;
 }
 
 /* Returns the GPU texture for tile tile_idx within game tex_idx's slot, or NULL. */
@@ -1508,15 +1523,18 @@ bool scene_render_gpu_screen_quad_textured(SceneRendererGPU *r,
     static const float uvU[4] = {1.0f, 0.0f, 0.0f, 1.0f};
     static const float uvV[4] = {0.0f, 0.0f, 1.0f, 1.0f};
     static const int idx[6] = {0, 1, 2, 0, 2, 3};
+    bool perZ = r->useParticleNdcZv;
     SceneGPUTexParticleVertex *v = r->texParticleVerts + r->texParticleVertCount;
     for (int i = 0; i < 6; i++) {
         int k = idx[i];
-        v[i] = (SceneGPUTexParticleVertex){ndcX[k], ndcY[k], r->particleNdcZ,
+        float z = perZ ? r->particleNdcZv[k] : r->particleNdcZ;
+        v[i] = (SceneGPUTexParticleVertex){ndcX[k], ndcY[k], z,
                                            uvU[k], uvV[k],
                                            cr, cg, cb, ca};
     }
     r->texParticleVertCount              += 6;
     r->texParticleRanges[ri].count       += 6;
+    r->useParticleNdcZv = false;
     return true;
 }
 
@@ -1572,6 +1590,7 @@ void scene_render_gpu_begin_frame(SceneRendererGPU *r)
     r->carDrawCount      = 0;
     r->particleVertCount    = 0;
     r->particleNdcZ         = 0.0f;
+    r->useParticleNdcZv     = false;
     r->texParticleVertCount  = 0;
     r->texParticleRangeCount = 0;
     r->hudSrcBuf         = NULL;
@@ -2199,7 +2218,7 @@ static void rebuild_sampler(SceneRendererGPU *r)
         .mipmap_mode       = r->trilinear ? SDL_GPU_SAMPLERMIPMAPMODE_LINEAR
                                           : SDL_GPU_SAMPLERMIPMAPMODE_NEAREST,
         .mip_lod_bias      = r->lodBias,
-        .max_lod           = 1000.0f,
+        .max_lod           = r->disableMipmaps ? 0.0f : 1000.0f,
     };
     r->sampler = SDL_CreateGPUSampler(r->device, &si);
 }
@@ -2215,6 +2234,13 @@ void scene_render_gpu_set_trilinear(SceneRendererGPU *r, bool enabled)
 {
     if (!r) return;
     r->trilinear = enabled;
+    rebuild_sampler(r);
+}
+
+void scene_render_gpu_set_disable_mipmaps(SceneRendererGPU *r, bool disabled)
+{
+    if (!r) return;
+    r->disableMipmaps = disabled;
     rebuild_sampler(r);
 }
 

--- a/PROJECTS/ROLLER/scene_render_gpu.h
+++ b/PROJECTS/ROLLER/scene_render_gpu.h
@@ -5,6 +5,10 @@
 #include "debug_overlay.h"
 #include "sound.h"    /* tColor, pal_addr */
 
+/* GPU projection near/far planes — must match the perspective matrix in scene_render_gpu.c */
+#define SCENE_GPU_NEAR 10.0f
+#define SCENE_GPU_FAR  20000000.0f
+
 typedef struct SceneRendererGPU SceneRendererGPU;
 struct SceneRenderer;
 struct CRTFilter;
@@ -59,6 +63,9 @@ void scene_render_gpu_set_texture_filter(SceneRendererGPU *r, int filter);
 
 /* enabled: true = trilinear (LINEAR between mip levels); textures always carry a full mip chain */
 void scene_render_gpu_set_trilinear(SceneRendererGPU *r, bool enabled);
+
+/* disabled: clamp sampler max_lod to 0 — debug flag to isolate mipmap-related GPU bugs */
+void scene_render_gpu_set_disable_mipmaps(SceneRendererGPU *r, bool disabled);
 
 /* vsync: deferred to next begin_frame to avoid mid-frame swapchain conflict */
 void scene_render_gpu_set_vsync(SceneRendererGPU *r, bool enabled);
@@ -133,6 +140,11 @@ void scene_render_gpu_screen_quad_flat(SceneRendererGPU *r,
 /* Set the per-particle NDC depth used by subsequent screen_quad_* calls.
  * 0.0 = near plane (always passes depth test). Reset to 0 each begin_frame. */
 void scene_render_gpu_set_particle_ndcz(SceneRendererGPU *r, float ndcZ);
+
+/* Set per-vertex NDC depth for the NEXT screen_quad_* call only (v0..v3 order).
+ * Consumed and cleared after a single call. Use for elongated trails where head
+ * and tail are at different camera depths to avoid Z-fighting through walls. */
+void scene_render_gpu_set_particle_ndcz_pervertex(SceneRendererGPU *r, const float ndcZ[4]);
 
 /* Return the GPU texture for tile_idx within slot tex_idx, or NULL if out of range. */
 SDL_GPUTexture *scene_render_gpu_get_tile_texture(SceneRendererGPU *r, int tex_idx, int tile_idx);

--- a/PROJECTS/ROLLER/scene_render_gpu.h
+++ b/PROJECTS/ROLLER/scene_render_gpu.h
@@ -170,4 +170,13 @@ void scene_render_gpu_queue_car_draw(SceneRendererGPU *r,
                                       int               idxCount,
                                       const float       mvp[16]);
 
+/* Queue a car shadow draw — uses carShadowPipeline (LESS_OR_EQUAL, no depth write, biased). */
+void scene_render_gpu_queue_car_shadow_draw(SceneRendererGPU *r,
+                                             SDL_GPUBuffer    *vertBuf,
+                                             SDL_GPUBuffer    *idxBuf,
+                                             SDL_GPUTexture   *texture,
+                                             int               firstIndex,
+                                             int               idxCount,
+                                             const float       mvp[16]);
+
 #endif /* SCENE_RENDER_GPU_H */

--- a/external/Nuklear-4.13.2/nuklear.h
+++ b/external/Nuklear-4.13.2/nuklear.h
@@ -21396,13 +21396,13 @@ nk_nonblock_begin(struct nk_context *ctx,
     win->popup.header = header;
 
     if (!is_active) {
-        win->popup.buf.active = nk_false;
         /* remove read only mode from all parent panels */
         struct nk_panel *root = win->layout;
         while (root) {
             root->flags |= NK_WINDOW_REMOVE_ROM;
             root = root->parent;
         }
+        win->popup.buf.active = 0;
         return is_active;
     }
     popup->bounds = body;


### PR DESCRIPTION
- fixed car shadows
- fixed particles rendering through walls
- fixed rear mirror selection (basic/advanced cars)
- added option "Show car on explosion"
- added disable mipmap option (Android debug)