### PR TITLE
fix HUD perf, loop-arch shadows, mid-race renderer switch; add Free Camera/Pick Textures debug toggles

### DIFF
--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -2627,6 +2627,7 @@ void draw_road(uint8 *pScrPtr, int iCarIdx, unsigned int uiViewMode, int iCopyIm
   game_render_set_target(g_pGameRenderer, pScrPtr, winw, winw, winh);
   calculateview(uiViewMode, iCarIdx, iChaseCamIdx); // Calculate camera view matrix and projection parameters
   noclip_camera_apply();
+  chase_look_apply(); // Debug "Free Camera": hold RMB + move mouse to free-look, gated on the debug-overlay checkbox
   extern float viewx, viewy, viewz;
   extern int worlddirn, VIEWDIST;
   GameRenderCamera cam = {

--- a/PROJECTS/ROLLER/debug_overlay.c
+++ b/PROJECTS/ROLLER/debug_overlay.c
@@ -1212,6 +1212,11 @@ static void DrawDebugPanel(DebugOverlay *pOverlay) {
       }
 
       nk_layout_row_dynamic(pCtx, DEBUG_ROW_H, 1);
+      int bRenderStatsLog = (int)g_bRenderStatsLog;
+      if (nk_checkbox_label(pCtx, "Render Stats Log", &bRenderStatsLog))
+        g_bRenderStatsLog = (bool)bRenderStatsLog;
+
+      nk_layout_row_dynamic(pCtx, DEBUG_ROW_H, 1);
       int bSurfDbg = (int)g_bSurfaceDebugViz;
       if (nk_checkbox_label(pCtx, "Surface debug labels", &bSurfDbg))
         g_bSurfaceDebugViz = (bool)bSurfDbg;
@@ -1220,11 +1225,6 @@ static void DrawDebugPanel(DebugOverlay *pOverlay) {
       int bSurfLog = (int)g_bSurfaceLog;
       if (nk_checkbox_label(pCtx, "Surface Log", &bSurfLog))
         g_bSurfaceLog = (bool)bSurfLog;
-
-      nk_layout_row_dynamic(pCtx, DEBUG_ROW_H, 1);
-      int bRenderStatsLog = (int)g_bRenderStatsLog;
-      if (nk_checkbox_label(pCtx, "Render Stats Log", &bRenderStatsLog))
-        g_bRenderStatsLog = (bool)bRenderStatsLog;
 
       {
         static char s_surfLogIdBuf[8] = "";

--- a/PROJECTS/ROLLER/debug_overlay.c
+++ b/PROJECTS/ROLLER/debug_overlay.c
@@ -876,6 +876,12 @@ static void DrawDebugPanel(DebugOverlay *pOverlay) {
       InputSaveConfig();
     }
 
+    int bFreeCamera = (int)g_bFreeCamera;
+    nk_layout_row_dynamic(pCtx, DEBUG_ROW_H, 1);
+    if (nk_checkbox_label(pCtx, "Free Camera", &bFreeCamera)) {
+      g_bFreeCamera = (bool)bFreeCamera;
+    }
+
 #if defined(_WIN32)
     {
       static const char *apszInputBackends[] = { "WinMM", "SDL DirectInput" };
@@ -1210,6 +1216,11 @@ static void DrawDebugPanel(DebugOverlay *pOverlay) {
         g_bWireframe = (bool)bWireframe;
         game_render_set_wireframe(g_pGameRenderer, g_bWireframe);
       }
+
+      nk_layout_row_dynamic(pCtx, DEBUG_ROW_H, 1);
+      int bPickTextures = (int)g_bPickTextures;
+      if (nk_checkbox_label(pCtx, "Pick Textures", &bPickTextures))
+        g_bPickTextures = (bool)bPickTextures;
 
       nk_layout_row_dynamic(pCtx, DEBUG_ROW_H, 1);
       int bRenderStatsLog = (int)g_bRenderStatsLog;

--- a/PROJECTS/ROLLER/game_render.c
+++ b/PROJECTS/ROLLER/game_render.c
@@ -72,10 +72,12 @@ void game_render_set_mode(GameRenderer *renderer, GameRenderMode mode) {
     if (!renderer)
         return;
     /* GPU textures are only uploaded when the race/session starts in GPU mode.
-     * If they were skipped (started in SW), switching to GPU mid-session would
-     * render with an empty atlas — block it. */
+     * If they were skipped (started in SW), switching to GPU mid-session used
+     * to just be blocked outright (would've rendered with an empty atlas).
+     * Instead, lazily upload every already-loaded texture's still-live pixel
+     * data to the GPU atlas now, so the switch can proceed safely. */
     if (mode == GAME_RENDER_GPU && !scene_render_get_gpu_load_enabled(renderer->scene))
-        return;
+        scene_render_reload_gpu_textures(renderer->scene);
     /* Defer the actual switch to the next begin_frame so it never fires
      * mid-frame while a GPU command buffer is open. */
     renderer->pendingMode    = mode;

--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -114,6 +114,7 @@ bool g_bFixCarMenuBug = true;
 bool g_bImprovedJumpLanding = true;
 bool g_bNoclip = false;
 bool g_bShowCarOnExplosion = false;
+bool g_bFreeCamera = false;
 int   g_iTextureFilter   = 0;
 int   g_iAnisotropyLevel = 3;     /* default 16x */
 bool  g_bTrilinear       = false;
@@ -141,9 +142,13 @@ bool  g_bSurfaceDebugViz = false;
 bool  g_bSurfaceLog      = false;
 int   g_iSurfaceLogId    = -2;
 bool  g_bRenderStatsLog  = false;
+bool  g_bPickTextures     = false;
 bool  g_pendingClickQuery = false;
 float g_clickQueryNX      = 0.0f;
 float g_clickQueryNY      = 0.0f;
+bool  g_bChaseLookRightDown = false;
+float g_fChaseLookAccumX    = 0.0f;
+float g_fChaseLookAccumY    = 0.0f;
 bool  g_bKeepWindowSize  = false;
 int g_iCurrentSong = 0;
 uint64 g_ullTimer150Ms = 0;
@@ -1633,8 +1638,9 @@ void UpdateSDL()
     }
 
     /* Right-click surface pick: record normalised game-viewport coords before
-     * the overlay consumes the event. Works whether the overlay is open or not. */
-    if (e.type == SDL_EVENT_MOUSE_BUTTON_DOWN && e.button.button == SDL_BUTTON_RIGHT) {
+     * the overlay consumes the event. Works whether the overlay is open or not.
+     * Gated behind the "Pick Textures" debug checkbox. */
+    if (g_bPickTextures && e.type == SDL_EVENT_MOUSE_BUTTON_DOWN && e.button.button == SDL_BUTTON_RIGHT) {
       int wpx = 0, wpy = 0;
       if (SDL_GetWindowSizeInPixels(s_pWindow, &wpx, &wpy) && wpx > 0 && wpy > 0) {
         SDL_GPUViewport vp;
@@ -1645,6 +1651,20 @@ void UpdateSDL()
           g_pendingClickQuery = true;
         }
       }
+    }
+
+    /* Debug free-look (view.c chase_look_apply): track RMB hold + accumulate
+     * raw motion deltas directly off events instead of SDL's relative-mouse-
+     * mode grab -- that grab has a confirmed quirk here where it doesn't
+     * actually start delivering motion until the window loses and regains
+     * focus, so we read xrel/yrel straight from SDL_EVENT_MOUSE_MOTION. */
+    if (e.type == SDL_EVENT_MOUSE_BUTTON_DOWN && e.button.button == SDL_BUTTON_RIGHT) {
+      g_bChaseLookRightDown = true;
+    } else if (e.type == SDL_EVENT_MOUSE_BUTTON_UP && e.button.button == SDL_BUTTON_RIGHT) {
+      g_bChaseLookRightDown = false;
+    } else if (e.type == SDL_EVENT_MOUSE_MOTION && g_bChaseLookRightDown) {
+      g_fChaseLookAccumX += e.motion.xrel;
+      g_fChaseLookAccumY += e.motion.yrel;
     }
 
     if (debug_overlay_handle_event(s_pDebugOverlay, &e))

--- a/PROJECTS/ROLLER/roller.h
+++ b/PROJECTS/ROLLER/roller.h
@@ -19,6 +19,7 @@ extern bool g_bFixCarMenuBug;
 extern bool g_bImprovedJumpLanding;
 extern bool g_bNoclip;
 extern bool g_bShowCarOnExplosion; /* true = keep car mesh visible during explosion animation */
+extern bool g_bFreeCamera; /* debug: hold RMB + move mouse to free-look in any view (see view.c chase_look_apply) */
 extern int   g_iTextureFilter;   /* 0=nearest, 1=bilinear, 2=anisotropic */
 extern int   g_iAnisotropyLevel; /* 0=2x, 1=4x, 2=8x, 3=16x */
 extern bool  g_bTrilinear;       /* true = blend linearly between mip levels */
@@ -46,9 +47,13 @@ extern bool  g_bSurfaceDebugViz; /* draw surface-type + flag labels on each quad
 extern bool  g_bSurfaceLog;      /* enable pair UV SDL_Log (not saved to INI) */
 extern int   g_iSurfaceLogId;    /* -2=disabled(empty), -1=all, >=0=specific surfIdx (not saved) */
 extern bool  g_bRenderStatsLog;  /* enable periodic drawcmd/vertex-count SDL_Log (not saved to INI) */
+extern bool  g_bPickTextures;    /* debug: enable right-click surface pick (see "Pick Textures" checkbox) */
 extern bool  g_pendingClickQuery; /* right-click surface pick: set by event loop, cleared after render */
 extern float g_clickQueryNX;     /* normalised [0,1] click X within game viewport */
 extern float g_clickQueryNY;     /* normalised [0,1] click Y within game viewport */
+extern bool  g_bChaseLookRightDown; /* debug free-look (view.c): RMB currently held */
+extern float g_fChaseLookAccumX; /* debug free-look: accumulated raw xrel since last consumed */
+extern float g_fChaseLookAccumY; /* debug free-look: accumulated raw yrel since last consumed */
 extern bool  g_bKeepWindowSize; /* persist window size to ROLLER.INI */
 extern bool g_bRepeat;
 extern int g_iNumTracks;

--- a/PROJECTS/ROLLER/scene_render.c
+++ b/PROJECTS/ROLLER/scene_render.c
@@ -40,6 +40,27 @@ bool scene_render_get_gpu_load_enabled(SceneRenderer *renderer) {
     return renderer && renderer->gpu_load_enabled;
 }
 
+static void scene_render_reload_gpu_textures_cb(void *ctx, uint8 *pixels,
+                                                int width, int height,
+                                                int tex_idx, int texHalfRes) {
+    SceneRenderer *renderer = (SceneRenderer *)ctx;
+    scene_render_gpu_load_texture(renderer->gpu, pixels, width, height, tex_idx, texHalfRes);
+}
+
+/* Lazily populates the GPU atlas from textures that were only ever registered
+ * with the SW renderer -- e.g. a race that started in SW mode, where
+ * scene_render_load_texture's gpu_load_enabled check skipped the GPU upload
+ * for every texture. Re-feeds each texture's still-live pixel data (kept
+ * around in the SW renderer's texSlots[] for as long as it's loaded) through
+ * scene_render_gpu_load_texture. Lets game_render_set_mode allow a mid-race
+ * switch to GPU instead of just blocking it outright. */
+void scene_render_reload_gpu_textures(SceneRenderer *renderer) {
+    if (!renderer || !renderer->gpu)
+        return;
+    renderer->gpu_load_enabled = true;
+    scene_render_sw_for_each_texture(renderer->sw, scene_render_reload_gpu_textures_cb, renderer);
+}
+
 void scene_render_destroy(SceneRenderer *renderer) {
     if (!renderer)
         return;

--- a/PROJECTS/ROLLER/scene_render.h
+++ b/PROJECTS/ROLLER/scene_render.h
@@ -42,6 +42,7 @@ void scene_render_quad_world_legacy(SceneRenderer *renderer,
 void scene_render_set_use_gpu(SceneRenderer *renderer, bool use_gpu);
 void scene_render_set_gpu_load_enabled(SceneRenderer *renderer, bool enabled);
 bool scene_render_get_gpu_load_enabled(SceneRenderer *renderer);
+void scene_render_reload_gpu_textures(SceneRenderer *renderer);
 void scene_render_set_split_screen(SceneRenderer *renderer, bool split);
 void scene_render_set_debug_overlay(SceneRenderer *renderer, DebugOverlay *overlay);
 

--- a/PROJECTS/ROLLER/scene_render_gpu.c
+++ b/PROJECTS/ROLLER/scene_render_gpu.c
@@ -4303,9 +4303,11 @@ void scene_render_gpu_quad_world_legacy(SceneRendererGPU *r,
      * both sides — SW's polyt() never culls them.
      * CONCAVE = SW's facing_ok check is bypassed for concave outer-wall sections
      * (LLOWALL/LUOWALL/RLOWALL/RUOWALL in drawtrk3.c), so these surfaces always
-     * render in SW regardless of winding. Loop sections rely on this: the outer
-     * walls at section boundaries are back-facing from outside the loop but must
-     * render to produce the dark dividing lines between sections. */
+     * render in SW regardless of winding; bypass here too so GPU doesn't cull
+     * them either. (NOT the source of the black divider lines seen in the
+     * looping road in SW -- investigated 2026-07-08, see [[project_gpu_backlog]]:
+     * a click-to-pick diagnostic found no separate quad at those positions at
+     * all, in either renderer; concluded to be a SW rasterizer artifact.) */
     /* CPU backface cull removed for track surfaces.
      * The screen-space cross-product check was unreliable near the near-plane
      * (clamping artefacts flipped the sign for valley/slope surfaces) and it
@@ -4367,9 +4369,14 @@ void scene_render_gpu_quad_world_legacy(SceneRendererGPU *r,
 
     if (!gpuTex) {
         if (surfaceFlags & SURFACE_FLAG_APPLY_TEXTURE) {
-            /* PARTIAL_TRANS and CONCAVE surfaces are rendered as flat-color in SW
-             * (poly()/twpoly() with palette[surfIdx]).  Fall through to the
-             * flat-color path below to replicate that appearance. */
+            /* We only reach here because the real atlas texture lookup above
+             * failed (gpuTex is still NULL) -- this is NOT how SW normally
+             * renders PARTIAL_TRANS+APPLY_TEXTURE surfaces (that's polyt() in
+             * polytex.c, a real textured/colorkey-transparent render). This is
+             * just a graceful degradation for the "texture not loaded" case:
+             * fall through to the flat-color path below instead of skipping
+             * the surface entirely, which is a reasonable approximation but
+             * won't exactly match polyt()'s appearance. */
             if (surfaceFlags & SURFACE_FLAG_PARTIAL_TRANS) {
                 /* fall through — use flat-color path below */
             } else {

--- a/PROJECTS/ROLLER/scene_render_gpu.c
+++ b/PROJECTS/ROLLER/scene_render_gpu.c
@@ -188,7 +188,29 @@ struct SceneRendererGPU {
     Uint64           frameStartNs;
     Uint64           queueNs;
     Uint64           sortRepackNs;
-    Uint64           uploadNs;
+    Uint64           uploadNs;         /* sum of the 5 sub-phases below */
+    Uint64           vertexMapWaitNs;  /* subset of vertexUploadNs: time inside the
+                                        * vertex transfer buffer's SDL_MapGPUTransferBuffer
+                                        * call alone (cycle=true can block until the
+                                        * GPU is done with a previous use of the
+                                        * buffer) -- isolates a GPU-availability
+                                        * stall from the actual memcpy/copy-pass cost. */
+    Uint64           vertexUploadNs;
+    Uint64           hudUploadNs;      /* indexed_to_rgba (full hudW*hudH CPU convert,
+                                        * same cost every frame regardless of scene
+                                        * complexity) + HUD texture upload -- prime
+                                        * suspect for uploadNs staying ~flat regardless
+                                        * of vertex count. */
+    Uint64           hudMapWaitNs;     /* subset of hudUploadNs: HUD transfer buffer's
+                                        * own SDL_MapGPUTransferBuffer call alone. */
+    Uint64           hudConvertNs;     /* subset of hudUploadNs: indexed_to_rgba call
+                                        * alone (CPU palette lookup, hudPixelCount
+                                        * iterations) -- isolates the CPU conversion
+                                        * cost from the surrounding GPU upload calls. */
+    int              hudPixelCount;    /* hudSrcW*hudSrcH last frame HUD was uploaded. */
+    Uint64           skyUploadNs;
+    Uint64           particleUploadNs;
+    Uint64           texParticleUploadNs;
     Uint64           drawNs;
     Uint64           hudPostNs;
     Uint64           submitNs;
@@ -364,18 +386,36 @@ struct SceneRendererGPU {
 static void indexed_to_rgba(const uint8 *src, const tColor *pal,
                              uint8 *dst, int count)
 {
+    /* dst is typically SDL_MapGPUTransferBuffer-mapped memory (upload-heap,
+     * often write-combined/uncached on the CPU side) -- four separate 1-byte
+     * stores per pixel there is dramatically slower than one combined 4-byte
+     * store, since WC write-combining buffers need a full aligned burst to
+     * combine efficiently. Confirmed via CPU frame-time instrumentation: a
+     * first attempt at this fix (precomputed LUT, but still 4 byte stores
+     * per pixel) barely moved the ~4.8-5.4ms/frame HUD-convert cost, which
+     * only dropping the (byR*255)/63 divisions should NOT have left
+     * unchanged if division were the real bottleneck -- the byte-store
+     * pattern is. Fixed by packing dst as uint32_t and writing one store per
+     * pixel; the LUT is also now a pure uint32 pack (R,G,B,A memory order,
+     * matching SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM, native byte order on
+     * this little-endian target), so per-pixel work is one table read + one
+     * store, no division either way. */
+    uint32_t lut[256];
     if (!pal) {
-        for (int i = 0; i < count; i++) {
-            dst[i*4+0] = 255; dst[i*4+1] = 0; dst[i*4+2] = 255; dst[i*4+3] = 255;
+        for (int i = 0; i < 256; i++) lut[i] = 0xFFFF00FFu; /* magenta, opaque: R=FF G=00 B=FF A=FF (memory order R,G,B,A) */
+    } else {
+        for (int i = 0; i < 256; i++) {
+            const tColor *c = &pal[i];
+            uint32_t r = (uint32_t)((c->byR * 255) / 63);
+            uint32_t g = (uint32_t)((c->byG * 255) / 63);
+            uint32_t b = (uint32_t)((c->byB * 255) / 63);
+            uint32_t a = (i == 0) ? 0u : 255u;
+            lut[i] = r | (g << 8) | (b << 16) | (a << 24);
         }
-        return;
     }
+    uint32_t *dst32 = (uint32_t *)dst;
     for (int i = 0; i < count; i++) {
-        const tColor *c = &pal[src[i]];
-        dst[i * 4 + 0] = (uint8)((c->byR * 255) / 63);
-        dst[i * 4 + 1] = (uint8)((c->byG * 255) / 63);
-        dst[i * 4 + 2] = (uint8)((c->byB * 255) / 63);
-        dst[i * 4 + 3] = (src[i] == 0) ? 0 : 255;
+        dst32[i] = lut[src[i]];
     }
 }
 
@@ -2583,8 +2623,11 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
     Uint64 tSortRepack = SDL_GetTicksNS();
     r->sortRepackNs = tSortRepack - tQueueEnd;
 
+    r->vertexMapWaitNs = 0;
     if (r->vertexCount > 0) {
+        Uint64 tMapStart = SDL_GetTicksNS();
         void *mapped = SDL_MapGPUTransferBuffer(r->device, r->vertexXfer, true);
+        r->vertexMapWaitNs = SDL_GetTicksNS() - tMapStart;
         if (mapped) {
             memcpy(mapped, r->vertices, (size_t)r->vertexCount * sizeof(SceneGPUVertex));
             SDL_UnmapGPUTransferBuffer(r->device, r->vertexXfer);
@@ -2598,7 +2641,13 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
         }
     }
 
+    Uint64 tVertexUpload = SDL_GetTicksNS();
+    r->vertexUploadNs = tVertexUpload - tSortRepack;
+
     bool drawHUD = false;
+    r->hudMapWaitNs = 0;
+    r->hudConvertNs = 0;
+    r->hudPixelCount = 0;
     if (r->hudSrcBuf && r->hudSrcW > 0 && r->hudSrcH > 0) {
         int hw = r->hudSrcW, hh = r->hudSrcH;
         Uint32 sz = (Uint32)(hw * hh * 4);
@@ -2629,9 +2678,14 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
         }
 
         if (r->hudOverlayTex && r->hudXfer) {
+            Uint64 tHudMapStart = SDL_GetTicksNS();
             uint8 *mapped = SDL_MapGPUTransferBuffer(r->device, r->hudXfer, true);
+            r->hudMapWaitNs = SDL_GetTicksNS() - tHudMapStart;
             if (mapped) {
+                Uint64 tHudConvertStart = SDL_GetTicksNS();
                 indexed_to_rgba(r->hudSrcBuf, palette, mapped, hw * hh);
+                r->hudConvertNs = SDL_GetTicksNS() - tHudConvertStart;
+
                 SDL_UnmapGPUTransferBuffer(r->device, r->hudXfer);
 
                 SDL_GPUCopyPass *cp = SDL_BeginGPUCopyPass(r->cmdBuf);
@@ -2645,11 +2699,18 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
                 drawHUD = true;
             }
         }
+        r->hudPixelCount = hw * hh;
     }
+
+    Uint64 tHudUpload = SDL_GetTicksNS();
+    r->hudUploadNs = tHudUpload - tVertexUpload;
 
     /* ---- Sky polygon vertex upload ---- */
     int skyVertCount = 0;
     bool drawSky = upload_sky_polygon(r, &skyVertCount);
+
+    Uint64 tSkyUpload = SDL_GetTicksNS();
+    r->skyUploadNs = tSkyUpload - tHudUpload;
 
     /* ---- Particle vertex upload ----
      * cycle=true: not currently written more than once per frame (flat
@@ -2676,6 +2737,9 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
             drawParticles = false;
         }
     }
+
+    Uint64 tParticleUpload = SDL_GetTicksNS();
+    r->particleUploadNs = tParticleUpload - tSkyUpload;
 
     /* ---- Textured particle vertex upload ----
      * cycle=true: in 2-player mode, scene_render_gpu_flush_secondary_view()
@@ -2705,6 +2769,7 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
     }
 
     Uint64 tUpload = SDL_GetTicksNS();
+    r->texParticleUploadNs = tUpload - tParticleUpload;
     r->uploadNs = tUpload - tSortRepack;
 
     if (!r->swapchainTex) {
@@ -3092,13 +3157,25 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
                      r->peakDrawCmdCount, r->peakVertexCount,
                      r->gpuDrawCallsThisFrame, r->gpuBindsThisFrame);
             SDL_Log("RENDER CPU TIME (ms): queue=%.3f sort/repack=%.3f "
-                     "upload=%.3f draw=%.3f hud/post=%.3f submit=%.3f total=%.3f",
-                     r->queueNs      / 1000000.0,
-                     r->sortRepackNs / 1000000.0,
-                     r->uploadNs     / 1000000.0,
-                     r->drawNs       / 1000000.0,
-                     r->hudPostNs    / 1000000.0,
-                     r->submitNs     / 1000000.0,
+                     "upload=%.3f [vtx=%.3f(map-wait=%.3f) "
+                     "hud=%.3f(px=%d map-wait=%.3f convert=%.3f) sky=%.3f "
+                     "particle=%.3f texParticle=%.3f] draw=%.3f hud/post=%.3f "
+                     "submit=%.3f total=%.3f",
+                     r->queueNs             / 1000000.0,
+                     r->sortRepackNs        / 1000000.0,
+                     r->uploadNs            / 1000000.0,
+                     r->vertexUploadNs      / 1000000.0,
+                     r->vertexMapWaitNs     / 1000000.0,
+                     r->hudUploadNs         / 1000000.0,
+                     r->hudPixelCount,
+                     r->hudMapWaitNs        / 1000000.0,
+                     r->hudConvertNs        / 1000000.0,
+                     r->skyUploadNs         / 1000000.0,
+                     r->particleUploadNs    / 1000000.0,
+                     r->texParticleUploadNs / 1000000.0,
+                     r->drawNs              / 1000000.0,
+                     r->hudPostNs           / 1000000.0,
+                     r->submitNs            / 1000000.0,
                      (r->queueNs + r->sortRepackNs + r->uploadNs
                       + r->drawNs + r->hudPostNs + r->submitNs) / 1000000.0);
         }

--- a/PROJECTS/ROLLER/scene_render_gpu.c
+++ b/PROJECTS/ROLLER/scene_render_gpu.c
@@ -34,6 +34,19 @@ extern int backwards;          /* drawtrk3.c: -1 = camera looks backward along t
 #define SCENE_GPU_MAX_SECONDARY_VIEWS 2 /* rearview/side mirror uses slot 0; 2-player uses slots 0/1 */
 /* SCENE_GPU_NEAR / SCENE_GPU_FAR defined in scene_render_gpu.h */
 
+/* Mirrors polyf.c's SHADE_PALETTE_LEVELS (5) -- shadow_poly()'s per-pixel
+ * palette-darken remap for TRANSPARENT non-textured track quads (glass/
+ * divider walls). Levels 0-3 are a straight brightness ramp (see
+ * func2.c's shade_palette builder: each level subtracts ~1/5 of the
+ * ORIGINAL colour per level, so level k keeps roughly (4-k)/5 brightness);
+ * level 4 is a special blend-toward-teal(0xDB) shade that this
+ * approximation doesn't replicate exactly -- just uses a similarly dark
+ * flat value for it. */
+#define SCENE_GPU_SHADE_LEVELS 5
+static const float g_sceneGpuShadeFactor[SCENE_GPU_SHADE_LEVELS] = {
+    0.8f, 0.6f, 0.4f, 0.2f, 0.3f
+};
+
 /* --------------------------------------------------------------------------
  * Vertex layouts
  * -------------------------------------------------------------------------- */
@@ -101,7 +114,7 @@ typedef struct {
 /* --------------------------------------------------------------------------
  * Deferred draw commands
  * -------------------------------------------------------------------------- */
-typedef enum { SCENE_GPU_DRAW_OPAQUE = 0, SCENE_GPU_DRAW_BLEND, SCENE_GPU_DRAW_BUILDING, SCENE_GPU_DRAW_BF_BUILDING, SCENE_GPU_DRAW_SIGN, SCENE_GPU_DRAW_SIGN_BK, SCENE_GPU_DRAW_TREE, SCENE_GPU_DRAW_WALL, SCENE_GPU_DRAW_BF_WALL, SCENE_GPU_DRAW_SHADOW } SceneGPUDrawKind;
+typedef enum { SCENE_GPU_DRAW_OPAQUE = 0, SCENE_GPU_DRAW_BLEND, SCENE_GPU_DRAW_BUILDING, SCENE_GPU_DRAW_BF_BUILDING, SCENE_GPU_DRAW_SIGN, SCENE_GPU_DRAW_SIGN_BK, SCENE_GPU_DRAW_TREE, SCENE_GPU_DRAW_WALL, SCENE_GPU_DRAW_BF_WALL, SCENE_GPU_DRAW_SHADOW, SCENE_GPU_DRAW_TRACK_DARKEN } SceneGPUDrawKind;
 
 typedef struct {
     SDL_GPUTexture  *texture;
@@ -140,6 +153,14 @@ struct SceneRendererGPU {
     SDL_GPUGraphicsPipeline *wallPipeline;     /* sfBl + LESS_OR_EQUAL; for TEXTURE_PAIR surfaces */
     SDL_GPUGraphicsPipeline *bfWallPipeline;  /* like wallPipeline + small depth bias; for TEXTURE_PAIR|FLIP_BACKFACE surfaces coplanar with adjacent walls */
     SDL_GPUGraphicsPipeline *shadowPipeline;   /* blend + LESS_OR_EQUAL + no depth write + large bias; for car shadow quads coplanar with road */
+    SDL_GPUGraphicsPipeline *trackDarkenPipeline; /* multiply blend (DST_COLOR*ZERO) + LESS_OR_EQUAL, no depth write;
+                                                    * for TRANSPARENT non-textured TRACK world quads (drawtrk3.c glass/
+                                                    * divider walls) -- SW renders these via shadow_poly()'s per-pixel
+                                                    * palette-darken remap (polyf.c), not a fixed-alpha blend toward
+                                                    * black. This was previously misrouted through shadowTex/SHADOW
+                                                    * (a genuine car-shadow-only path that real car shadows never
+                                                    * actually reach -- they use carShadowDraws[]/screen quads
+                                                    * instead), which under-darkened these track surfaces. */
     SDL_GPUSampler          *sampler;
     SDL_GPUSampler          *samplerNearest; /* always-nearest, used for cloud quads */
 
@@ -271,6 +292,12 @@ struct SceneRendererGPU {
     uint32_t        paletteCacheHash;
     SDL_GPUTexture *shadowTex;       /* 50%-transparent black for car shadow quads */
     SDL_GPUTexture *darkenTex;       /* fully-opaque black for the pause-menu darken quad */
+    SDL_GPUTexture *shadeLevelTex[SCENE_GPU_SHADE_LEVELS]; /* solid gray, one per shade_palette
+                                                             * darkening level (see trackDarkenPipeline) --
+                                                             * bound as an opaque source texture for the
+                                                             * multiply-blend track-darken pass; RGB =
+                                                             * shadeFactor*255 approximating shade_palette's
+                                                             * per-level brightness (~80/60/40/20/30%). */
 
     /* Offscreen colour target rendered at native resolution, blitted to the
      * swapchain with letterbox/pillarbox scaling to fill the window. */
@@ -892,6 +919,67 @@ static SDL_GPUGraphicsPipeline *make_shadow_pipeline(SceneRendererGPU *r,
          * car pass) blocks the shadow where the car body is; only road pixels
          * (D_road ≈ D_shadow) get darkened.  A small bias overcomes fp noise
          * on the coplanar road surface without punching through kerbs. */
+        .depth_stencil_state = { .enable_depth_test  = true,
+                                 .enable_depth_write = false,
+                                 .compare_op         = SDL_GPU_COMPAREOP_LESS_OR_EQUAL },
+        .rasterizer_state = { .fill_mode  = fillMode,
+                              .front_face = SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE,
+                              .enable_depth_bias          = true,
+                              .depth_bias_constant_factor = -50.0f,
+                              .depth_bias_slope_factor    = -1.0f }
+    };
+    return SDL_CreateGPUGraphicsPipeline(r->device, &pi);
+}
+
+/* Multiply blend (result = srcColor * dstColor): approximates shadow_poly()'s
+ * per-pixel palette-darken remap for TRANSPARENT non-textured track quads
+ * (see trackDarkenPipeline / shadeLevelTex comments). LESS_OR_EQUAL depth
+ * test against the opaque geometry already drawn beneath it, no depth write
+ * -- lets two adjacent/overlapping track-darken quads (e.g. at a chunk
+ * boundary) both composite rather than the second one losing a depth tie,
+ * matching SW's no-depth-buffer painter-style double-darkening at seams. */
+static SDL_GPUGraphicsPipeline *make_track_darken_pipeline(SceneRendererGPU *r,
+                                                            SDL_GPUShader *vert,
+                                                            SDL_GPUShader *frag,
+                                                            SDL_GPUSampleCount sc,
+                                                            SDL_GPUFillMode fillMode)
+{
+    SDL_GPUVertexAttribute attrs[2] = {
+        {.location=0, .format=SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3,
+         .offset=(Uint32)offsetof(SceneGPUVertex, x)},
+        {.location=1, .format=SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2,
+         .offset=(Uint32)offsetof(SceneGPUVertex, u)},
+    };
+    SDL_GPUVertexBufferDescription binding = { .pitch = sizeof(SceneGPUVertex),
+                                               .input_rate = SDL_GPU_VERTEXINPUTRATE_VERTEX };
+    SDL_GPUColorTargetDescription ct = {
+        .format = SDL_GetGPUSwapchainTextureFormat(r->device, r->window),
+        .blend_state = {
+            .enable_blend          = true,
+            .src_color_blendfactor = SDL_GPU_BLENDFACTOR_DST_COLOR,
+            .dst_color_blendfactor = SDL_GPU_BLENDFACTOR_ZERO,
+            .color_blend_op        = SDL_GPU_BLENDOP_ADD,
+            .src_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ZERO,
+            .dst_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ONE,
+            .alpha_blend_op        = SDL_GPU_BLENDOP_ADD
+        }
+    };
+    SDL_GPUGraphicsPipelineCreateInfo pi = {
+        .vertex_shader   = vert,
+        .fragment_shader = frag,
+        .primitive_type  = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
+        .vertex_input_state = { .vertex_attributes = attrs, .num_vertex_attributes = 2,
+                                .vertex_buffer_descriptions = &binding, .num_vertex_buffers = 1 },
+        .target_info = { .color_target_descriptions = &ct, .num_color_targets = 1,
+                         .has_depth_stencil_target = true,
+                         .depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D32_FLOAT },
+        .multisample_state = { .sample_count = sc },
+        /* Same fp-noise concern as make_shadow_pipeline's bias comment: these
+         * quads are ordinary track geometry (walls/floors), and are very
+         * plausibly coincident (or a hair further) than an adjacent already-
+         * drawn opaque quad at the exact same screen position -- LESS_OR_EQUAL
+         * alone can lose that tie to floating-point rounding and silently
+         * never draw despite being correctly queued. */
         .depth_stencil_state = { .enable_depth_test  = true,
                                  .enable_depth_write = false,
                                  .compare_op         = SDL_GPU_COMPAREOP_LESS_OR_EQUAL },
@@ -1535,9 +1623,23 @@ SceneRendererGPU *scene_render_gpu_create(SDL_GPUDevice *device, SDL_Window *win
         r->darkenTex = scene_render_gpu_upload_rgba(device, darkenRgba, 4, 4, true);
     }
 
+    /* Solid gray textures approximating each shade_palette darkening level
+     * (see g_sceneGpuShadeFactor / trackDarkenPipeline comments). Sampled as
+     * the multiply-blend pass's source colour for TRANSPARENT non-textured
+     * track quads. */
+    for (int i = 0; i < SCENE_GPU_SHADE_LEVELS; i++) {
+        uint8 shadeRgba[4 * 4 * 4];
+        uint8 v = (uint8)(g_sceneGpuShadeFactor[i] * 255.0f);
+        for (int p = 0; p < 16; p++) {
+            shadeRgba[p*4+0] = v; shadeRgba[p*4+1] = v;
+            shadeRgba[p*4+2] = v; shadeRgba[p*4+3] = 255;
+        }
+        r->shadeLevelTex[i] = scene_render_gpu_upload_rgba(device, shadeRgba, 4, 4, true);
+    }
+
     /* ---- Scene shaders + pipelines ---- */
     rebuild_scene_pipelines(r, SDL_GPU_SAMPLECOUNT_1, SDL_GPU_FILLMODE_FILL);
-    if (!r->opaquePipeline || !r->blendPipeline || !r->buildingPipeline || !r->bfBuildingPipeline || !r->signPipeline || !r->signBkPipeline || !r->signDepthPipeline || !r->signBkDepthPipeline || !r->treePipeline || !r->wallPipeline || !r->bfWallPipeline || !r->shadowPipeline || !r->skyPipeline) goto fail;
+    if (!r->opaquePipeline || !r->blendPipeline || !r->buildingPipeline || !r->bfBuildingPipeline || !r->signPipeline || !r->signBkPipeline || !r->signDepthPipeline || !r->signBkDepthPipeline || !r->treePipeline || !r->wallPipeline || !r->bfWallPipeline || !r->shadowPipeline || !r->trackDarkenPipeline || !r->skyPipeline) goto fail;
 
     /* ---- Car shaders (game_car_* add fog+gamma; menu_mesh_* kept for menu) ---- */
     SDL_GPUShader *cv = load_shader(device, SDL_GPU_SHADERSTAGE_VERTEX,
@@ -1685,6 +1787,9 @@ void scene_render_gpu_destroy(SceneRendererGPU *r)
     }
     if (r->shadowTex)     SDL_ReleaseGPUTexture(r->device, r->shadowTex);
     if (r->darkenTex)     SDL_ReleaseGPUTexture(r->device, r->darkenTex);
+    for (int i = 0; i < SCENE_GPU_SHADE_LEVELS; i++) {
+        if (r->shadeLevelTex[i]) SDL_ReleaseGPUTexture(r->device, r->shadeLevelTex[i]);
+    }
     if (r->offscreenTex)  SDL_ReleaseGPUTexture(r->device, r->offscreenTex);
     for (int i = 0; i < SCENE_GPU_MAX_SECONDARY_VIEWS; i++) {
         if (r->secondaryColorTex[i]) SDL_ReleaseGPUTexture(r->device, r->secondaryColorTex[i]);
@@ -1719,6 +1824,7 @@ void scene_render_gpu_destroy(SceneRendererGPU *r)
     if (r->wallPipeline)     SDL_ReleaseGPUGraphicsPipeline(r->device, r->wallPipeline);
     if (r->bfWallPipeline)   SDL_ReleaseGPUGraphicsPipeline(r->device, r->bfWallPipeline);
     if (r->shadowPipeline)      SDL_ReleaseGPUGraphicsPipeline(r->device, r->shadowPipeline);
+    if (r->trackDarkenPipeline) SDL_ReleaseGPUGraphicsPipeline(r->device, r->trackDarkenPipeline);
     if (r->carPipeline)         SDL_ReleaseGPUGraphicsPipeline(r->device, r->carPipeline);
     if (r->carShadowPipeline)   SDL_ReleaseGPUGraphicsPipeline(r->device, r->carShadowPipeline);
     if (r->skyPipeline)         SDL_ReleaseGPUGraphicsPipeline(r->device, r->skyPipeline);
@@ -2401,6 +2507,10 @@ SDL_GPUTexture *scene_render_gpu_flush_secondary_view(SceneRendererGPU *r, int s
     if (r->signPipeline)   { SDL_BindGPUGraphicsPipeline(rp, r->signPipeline);   draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_SIGN); }
     if (r->signBkPipeline) { SDL_BindGPUGraphicsPipeline(rp, r->signBkPipeline); draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_SIGN_BK); }
     if (r->treePipeline)   { SDL_BindGPUGraphicsPipeline(rp, r->treePipeline);   draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_TREE); }
+    /* Multiply-blend darken pass for TRANSPARENT non-textured track quads (glass/
+     * divider walls) -- must run after opaque/wall/building/sign/tree so there's
+     * real colour underneath to darken; see trackDarkenPipeline comment. */
+    if (r->trackDarkenPipeline) { SDL_BindGPUGraphicsPipeline(rp, r->trackDarkenPipeline); draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_TRACK_DARKEN); }
     if (r->blendPipeline)  { SDL_BindGPUGraphicsPipeline(rp, r->blendPipeline);  draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_BLEND); }
 
     if (r->carDrawCount > 0 && r->carPipeline) {
@@ -2965,6 +3075,13 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
         SDL_BindGPUGraphicsPipeline(rp, r->treePipeline);
         draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_TREE);
     }
+    /* Multiply-blend darken pass for TRANSPARENT non-textured track quads (glass/
+     * divider walls) -- must run after opaque/wall/building/sign/tree so there's
+     * real colour underneath to darken; see trackDarkenPipeline comment. */
+    if (r->trackDarkenPipeline) {
+        SDL_BindGPUGraphicsPipeline(rp, r->trackDarkenPipeline);
+        draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_TRACK_DARKEN);
+    }
     if (r->blendPipeline) {
         SDL_BindGPUGraphicsPipeline(rp, r->blendPipeline);
         draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_BLEND);
@@ -3402,6 +3519,7 @@ static void rebuild_scene_pipelines(SceneRendererGPU *r, SDL_GPUSampleCount sc, 
         r->wallPipeline          = make_scene_pipeline  (r, sv, sfBl, false, true,  0.0f,   0.0f, sc, fm);
         r->bfWallPipeline        = make_scene_pipeline  (r, sv, sfBl, false, true,  -20.0f, 0.0f, sc, fm);
         r->shadowPipeline        = make_shadow_pipeline (r, sv, sfBl,               sc, fm);
+        r->trackDarkenPipeline   = make_track_darken_pipeline(r, sv, sfOp,          sc, fm);
         r->skyPipeline           = make_sky_pipeline    (r, sv, sfOp, sc);
         r->treePipeline          = make_tree_pipeline   (r, sv, sfOp,               sc, fm);
     }
@@ -3434,6 +3552,7 @@ void scene_render_gpu_set_wireframe(SceneRendererGPU *r, bool enabled)
     if (r->wallPipeline)         { SDL_ReleaseGPUGraphicsPipeline(r->device, r->wallPipeline);         r->wallPipeline         = NULL; }
     if (r->bfWallPipeline)       { SDL_ReleaseGPUGraphicsPipeline(r->device, r->bfWallPipeline);       r->bfWallPipeline       = NULL; }
     if (r->shadowPipeline)       { SDL_ReleaseGPUGraphicsPipeline(r->device, r->shadowPipeline);       r->shadowPipeline       = NULL; }
+    if (r->trackDarkenPipeline)  { SDL_ReleaseGPUGraphicsPipeline(r->device, r->trackDarkenPipeline);  r->trackDarkenPipeline  = NULL; }
     if (r->carPipeline)          { SDL_ReleaseGPUGraphicsPipeline(r->device, r->carPipeline);          r->carPipeline          = NULL; }
     if (r->carShadowPipeline)    { SDL_ReleaseGPUGraphicsPipeline(r->device, r->carShadowPipeline);    r->carShadowPipeline    = NULL; }
     if (r->skyPipeline)          { SDL_ReleaseGPUGraphicsPipeline(r->device, r->skyPipeline);          r->skyPipeline          = NULL; }
@@ -3475,6 +3594,7 @@ void scene_render_gpu_set_cull_mode(SceneRendererGPU *r, int mode)
     if (r->wallPipeline)        { SDL_ReleaseGPUGraphicsPipeline(r->device, r->wallPipeline);        r->wallPipeline        = NULL; }
     if (r->bfWallPipeline)      { SDL_ReleaseGPUGraphicsPipeline(r->device, r->bfWallPipeline);      r->bfWallPipeline      = NULL; }
     if (r->shadowPipeline)      { SDL_ReleaseGPUGraphicsPipeline(r->device, r->shadowPipeline);      r->shadowPipeline      = NULL; }
+    if (r->trackDarkenPipeline) { SDL_ReleaseGPUGraphicsPipeline(r->device, r->trackDarkenPipeline); r->trackDarkenPipeline = NULL; }
     if (r->skyPipeline)         { SDL_ReleaseGPUGraphicsPipeline(r->device, r->skyPipeline);         r->skyPipeline         = NULL; }
 
     SDL_GPUFillMode fm = r->wireframe ? SDL_GPU_FILLMODE_LINE : SDL_GPU_FILLMODE_FILL;
@@ -3504,6 +3624,7 @@ void scene_render_gpu_set_msaa(SceneRendererGPU *r, int level)
     if (r->wallPipeline)         { SDL_ReleaseGPUGraphicsPipeline(r->device, r->wallPipeline);         r->wallPipeline         = NULL; }
     if (r->bfWallPipeline)       { SDL_ReleaseGPUGraphicsPipeline(r->device, r->bfWallPipeline);       r->bfWallPipeline       = NULL; }
     if (r->shadowPipeline)       { SDL_ReleaseGPUGraphicsPipeline(r->device, r->shadowPipeline);       r->shadowPipeline       = NULL; }
+    if (r->trackDarkenPipeline)  { SDL_ReleaseGPUGraphicsPipeline(r->device, r->trackDarkenPipeline);  r->trackDarkenPipeline  = NULL; }
     if (r->carPipeline)          { SDL_ReleaseGPUGraphicsPipeline(r->device, r->carPipeline);          r->carPipeline          = NULL; }
     if (r->carShadowPipeline)    { SDL_ReleaseGPUGraphicsPipeline(r->device, r->carShadowPipeline);    r->carShadowPipeline    = NULL; }
     if (r->skyPipeline)          { SDL_ReleaseGPUGraphicsPipeline(r->device, r->skyPipeline);          r->skyPipeline          = NULL; }
@@ -3549,6 +3670,7 @@ void scene_render_gpu_set_msaa(SceneRendererGPU *r, int level)
         r->wallPipeline     = make_scene_pipeline  (r, sv, sfBl, false, true,   0.0f, 0.0f, sc, fm);
         r->bfWallPipeline   = make_scene_pipeline  (r, sv, sfBl, false, true,  -20.0f, 0.0f, sc, fm);
         r->shadowPipeline   = make_shadow_pipeline(r, sv, sfBl,       sc,    fm);
+        r->trackDarkenPipeline = make_track_darken_pipeline(r, sv, sfOp, sc, fm);
         r->skyPipeline      = make_sky_pipeline(r, sv, sfOp, sc);
     }
     if (sv && sfSign) {
@@ -4137,6 +4259,7 @@ void scene_render_gpu_quad_world_legacy(SceneRendererGPU *r,
     }
 
     bool isFlatColor = false;
+    bool isTrackDarken = false;
     int  surfIdx     = surfaceFlags & SURFACE_MASK_TEXTURE_INDEX;
 
     /* SW applies texture_back[] substitution when SURFACE_FLAG_BACK (0x800) is set
@@ -4264,9 +4387,23 @@ void scene_render_gpu_quad_world_legacy(SceneRendererGPU *r,
             }
         }
         if (surfaceFlags & SURFACE_FLAG_TRANSPARENT) {
-            /* Car shadow polygon: route through blend pass (LESS_OR_EQUAL depth,
-             * no depth write) as a 50%-transparent black quad. */
-            gpuTex = r->shadowTex;
+            /* NOT a car shadow -- real car shadows never reach this function
+             * (they use carShadowDraws[]/carShadowPipeline, a separate mesh-
+             * based system, or the legacy 2D screen-quad path via
+             * game_render_quad_screen). A TRANSPARENT world quad with no
+             * texture reaching here is drawtrk3.c/building.c track geometry
+             * (glass walls, loop-section divider walls) that SW renders via
+             * shadow_poly() (polyf.c) -- a per-pixel palette-darken remap of
+             * whatever's already on screen, NOT a blend toward a fixed colour.
+             * Approximate it with a multiply-blend pass instead of the old
+             * shadowTex/SHADOW routing (see [[project_gpu_backlog]] "black
+             * lines in loop" -- that fixed-alpha blend under-darkened these
+             * surfaces badly enough that they were effectively invisible). */
+            int shadeLevel = surfIdx;
+            if (shadeLevel < 0) shadeLevel = 0;
+            if (shadeLevel >= SCENE_GPU_SHADE_LEVELS) shadeLevel = SCENE_GPU_SHADE_LEVELS - 1;
+            gpuTex = r->shadeLevelTex[shadeLevel];
+            isTrackDarken = true;
             if (!gpuTex) return;
         } else {
             int colorIdx = surfaceFlags & SURFACE_MASK_TEXTURE_INDEX;
@@ -4297,6 +4434,8 @@ void scene_render_gpu_quad_world_legacy(SceneRendererGPU *r,
         kind = SCENE_GPU_DRAW_SIGN_BK;
     else if (gpuTex == r->shadowTex)
         kind = SCENE_GPU_DRAW_SHADOW;
+    else if (isTrackDarken)
+        kind = SCENE_GPU_DRAW_TRACK_DARKEN;
     else if (surfaceFlags & SURFACE_FLAG_TRANSPARENT)
         kind = SCENE_GPU_DRAW_BLEND;
     else if ((surfaceFlags & SURFACE_FLAG_PARTIAL_TRANS) && (surfaceFlags & SURFACE_FLAG_FLIP_BACKFACE))
@@ -4311,7 +4450,6 @@ void scene_render_gpu_quad_world_legacy(SceneRendererGPU *r,
         kind = SCENE_GPU_DRAW_BUILDING;
     else
         kind = SCENE_GPU_DRAW_OPAQUE;
-
 
     float cu[4], cv[4];
     if (isFlatColor) {

--- a/PROJECTS/ROLLER/scene_render_software.c
+++ b/PROJECTS/ROLLER/scene_render_software.c
@@ -1519,6 +1519,24 @@ SceneTextureHandle scene_render_sw_get_texture_handle(SceneRendererSoftware *sw,
     return SCENE_TEXTURE_HANDLE_INVALID;
 }
 
+/* Re-feeds every currently-loaded texture's still-live pixel data (kept
+ * around in texSlots[] for as long as it's loaded, never discarded) through
+ * cb. Lets a caller lazily populate the GPU atlas for textures that were
+ * only ever registered with the SW renderer (e.g. a race that started in
+ * SW mode, where scene_render_load_texture skips the GPU upload) -- see
+ * scene_render_reload_gpu_textures. */
+void scene_render_sw_for_each_texture(SceneRendererSoftware *sw,
+                                      SceneRenderSwTextureCallback cb,
+                                      void *ctx) {
+    if (!sw || !cb)
+        return;
+    for (int i = 1; i < SCENE_RENDER_MAX_TEXTURE_SLOTS; i++) {
+        SceneTextureSlot *slot = &sw->texSlots[i];
+        if (slot->in_use && slot->pixels)
+            cb(ctx, slot->pixels, slot->width, slot->height, slot->tex_idx, slot->texHalfRes);
+    }
+}
+
 void scene_render_sw_quad_world_legacy(SceneRendererSoftware *sw,
                                        const SceneRenderVertex *verts,
                                        SceneTextureHandle handle,

--- a/PROJECTS/ROLLER/scene_render_software.h
+++ b/PROJECTS/ROLLER/scene_render_software.h
@@ -28,6 +28,13 @@ void scene_render_sw_free_texture(SceneRendererSoftware *sw,
 SceneTextureHandle scene_render_sw_get_texture_handle(SceneRendererSoftware *sw,
                                                       int tex_idx);
 
+typedef void (*SceneRenderSwTextureCallback)(void *ctx, uint8 *pixels,
+                                             int width, int height,
+                                             int tex_idx, int texHalfRes);
+void scene_render_sw_for_each_texture(SceneRendererSoftware *sw,
+                                      SceneRenderSwTextureCallback cb,
+                                      void *ctx);
+
 void scene_render_sw_quad_world_legacy(SceneRendererSoftware *sw,
                                        const SceneRenderVertex *verts,
                                        SceneTextureHandle handle,

--- a/PROJECTS/ROLLER/view.c
+++ b/PROJECTS/ROLLER/view.c
@@ -59,6 +59,12 @@ static bool s_bNoclipFastWasDown = false;
 static bool s_bNoclipSlowWasDown = false;
 static uint64 s_ullNoclipLastUpdateNs = 0;
 
+/* Set by chase_look_apply() below. Deliberately does not touch SDL's
+ * relative-mouse-mode grab (that grab has a confirmed quirk here where it
+ * doesn't start delivering motion until the window loses and regains focus)
+ * -- motion is instead read from raw event deltas accumulated in roller.c. */
+static bool s_bChaseLookActive = false;
+
 static int noclip_angle14(int iAngle)
 {
   return iAngle & 0x3FFF;
@@ -110,6 +116,57 @@ void noclip_camera_reset(void)
   s_bNoclipSlowWasDown = false;
   s_ullNoclipLastUpdateNs = 0;
   noclip_sync_mouse_mode();
+}
+
+/* Debug free-look: hold the right mouse button and move the mouse to orbit
+ * the look direction in any view except cockpit and the rearview mirror.
+ * Applied as a rotate-only post-process after calculateview() has already
+ * produced viewx/viewy/viewz (the final camera position for whichever view
+ * branch ran) -- re-running calculatetransform with the same position and a
+ * rotated direction/elevation leaves that view's own position/smoothing
+ * logic completely untouched. */
+#define CHASE_LOOK_MOUSE_SENSITIVITY 8.0f
+
+static int  s_iChaseLookYaw = 0;
+static int  s_iChaseLookPitch = 0;
+
+extern bool  g_bChaseLookRightDown;
+extern float g_fChaseLookAccumX;
+extern float g_fChaseLookAccumY;
+extern bool  g_bFreeCamera;
+
+static void chase_look_deactivate(void)
+{
+  s_bChaseLookActive = false;
+  s_iChaseLookYaw = 0;
+  s_iChaseLookPitch = 0;
+}
+
+void chase_look_apply(void)
+{
+  /* Gated purely on the "Free Camera" debug checkbox -- user preference is
+   * for this to work unconditionally in every view (including cockpit and
+   * the mirror pass) once enabled, no per-view exclusions. */
+  if (!g_bFreeCamera || !g_bChaseLookRightDown) {
+    chase_look_deactivate();
+    g_fChaseLookAccumX = 0.0f;
+    g_fChaseLookAccumY = 0.0f;
+    return;
+  }
+
+  s_bChaseLookActive = true;
+  float fMouseX = g_fChaseLookAccumX;
+  float fMouseY = g_fChaseLookAccumY;
+  g_fChaseLookAccumX = 0.0f;
+  g_fChaseLookAccumY = 0.0f;
+  s_iChaseLookYaw = noclip_angle14(s_iChaseLookYaw - (int)(fMouseX * CHASE_LOOK_MOUSE_SENSITIVITY));
+  s_iChaseLookPitch = noclip_clamp_pitch(s_iChaseLookPitch - (int)(fMouseY * CHASE_LOOK_MOUSE_SENSITIVITY));
+
+  int iRenderDirection = noclip_angle14(worlddirn + s_iChaseLookYaw);
+  int iRenderElevation = noclip_angle14(noclip_clamp_pitch(noclip_signed_angle(worldelev) + s_iChaseLookPitch));
+  calculatetransform(-1, iRenderDirection, iRenderElevation, worldtilt, viewx, viewy, viewz, 0.0f, 0.0f, 0.0f);
+  worlddirn = iRenderDirection;
+  worldelev = iRenderElevation;
 }
 
 void noclip_camera_set_input_enabled(bool bEnabled)

--- a/PROJECTS/ROLLER/view.h
+++ b/PROJECTS/ROLLER/view.h
@@ -52,6 +52,7 @@ void noclip_camera_reset(void);
 void noclip_camera_set_input_enabled(bool bEnabled);
 void noclip_camera_update(void);
 void noclip_camera_apply(void);
+void chase_look_apply(void);
 
 //-------------------------------------------------------------------------------------------------
 #endif


### PR DESCRIPTION
## Summary
- Performance: fixed `indexed_to_rgba` HUD conversion hot loop (single packed 32-bit store instead of 4 byte stores) and added a full CPU frame-time breakdown to the render stats log — the biggest real-world win was actually discovering the VS Code build task defaulted to Debug mode; confirmed ~50% real-world FPS improvement once measured/built in Release.
- Fix: loop-arch shadows on the pit-lane wall were invisible in GPU mode — added a `TRACK_DARKEN` multiply-blend pass to replicate SW's `shadow_poly()` per-pixel palette darkening for transparent, untextured track quads (previously misrouted through the car-shadow pipeline, which they never actually use).
- Fix: allow switching to hardware (GPU) rendering mid-race after starting in software mode, by lazily re-uploading the software renderer's still-cached texture data to the GPU atlas at switch time instead of just blocking the switch.
- Corrected two stale/misleading comments in `scene_render_gpu.c` found during investigation.
- Debug: added "Free Camera" (hold right mouse button + move to free-look in any view) and "Pick Textures" (gates the existing right-click surface-pick query) debug-overlay checkboxes — both default off, session-only, not persisted.