### PR TITLE
fix cars rendering through walls in single-player (#258)

### DIFF
--- a/PROJECTS/ROLLER/scene_render_gpu.c
+++ b/PROJECTS/ROLLER/scene_render_gpu.c
@@ -3086,9 +3086,13 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
         SDL_BindGPUGraphicsPipeline(rp, r->bfBuildingPipeline);
         draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_BF_BUILDING);
     }
-    /* Sign rendering: non-MSAA uses depth-copy pass split so signs behind canyon walls
-     * are correctly hidden; MSAA falls back to the old bias-based pipeline. */
-    if (!useMSAA && r->signDepthPipeline && r->signBkDepthPipeline && r->signDepthCopyTex) {
+    /* Sign rendering: the depth-copy split (End Pass A / snapshot depth / begin Pass B)
+     * caused issue #258 -- cars rendering through narrow walls carrying signs, primary
+     * single-player pass only (2P/mirror never used this split and never showed the bug).
+     * Disabled for now (`0 &&`) so every path uses the same bias-based pipeline that
+     * MSAA and 2P/mirror already use; kept in place, not deleted, in case the canyon-wall
+     * sign self-occlusion behavior below needs to be restored. */
+    if (0 && !useMSAA && r->signDepthPipeline && r->signBkDepthPipeline && r->signDepthCopyTex) {
         /* End Pass A, snapshot depth, begin Pass B. */
         SDL_EndGPURenderPass(rp);
         rp = NULL;


### PR DESCRIPTION
Fixes #258 — cars visible through walls, single-player only (2P/mirror was always correct).

Root cause: the primary render pass has a "sign depth-copy split" — after drawing wall/building geometry it ends the render pass, snapshots the depth buffer (so signs can hide correctly behind separate walls without z-fighting their own host wall), then reopens a new render pass reusing that depth buffer before drawing cars. That reopened pass doesn't reliably preserve real depth values afterward, so cars drawn later no longer test correctly against nearby walls.

Fix: disabled the depth-copy split; signs now always use the same simpler bias-based pipeline that MSAA and 2P/mirror already used. Confirmed live that the bug is gone and "Signs on top" still renders correctly. Old code kept in place (disabled, not deleted) in case the underlying pass-boundary issue is worth revisiting later.