### PR TITLE
fix cars/signs render order (#258) and rebuild car name tags as real GPU billboards (#256)

### DIFF
--- a/PROJECTS/ROLLER/game_render.c
+++ b/PROJECTS/ROLLER/game_render.c
@@ -137,6 +137,11 @@ void game_render_begin_frame(GameRenderer *renderer) {
         renderer->mode           = renderer->pendingMode;
         renderer->pendingModeSet = false;
         scene_render_set_use_gpu(renderer->scene, renderer->mode == GAME_RENDER_GPU);
+        /* Name-tag EMA smoothing state goes stale whenever GPU mode isn't the
+         * one actually drawing tags -- reset on every switch (either
+         * direction) so resuming GPU mode never blends in from a stale
+         * position (see game_render_hw_reset_name_tags doc comment). */
+        game_render_hw_reset_name_tags();
     }
     if (renderer->mode == GAME_RENDER_SOFTWARE)
         game_render_sw_begin_frame(renderer->sw);
@@ -681,6 +686,14 @@ void game_render_quad_screen_hud(GameRenderer *renderer, tPolyParams *poly,
         ? game_render_sw_get_texture_handle(renderer->sw, tex_idx)
         : TEXTURE_HANDLE_INVALID;
     game_render_sw_quad_screen(renderer->sw, poly, swHandle, palette_remap);
+}
+
+SceneRendererGPU *game_render_get_gpu(GameRenderer *renderer) {
+    return renderer ? renderer->gpu : NULL;
+}
+
+SDL_GPUDevice *game_render_get_device(GameRenderer *renderer) {
+    return renderer ? renderer->device : NULL;
 }
 
 void game_render_quad_world(GameRenderer *renderer,

--- a/PROJECTS/ROLLER/game_render.h
+++ b/PROJECTS/ROLLER/game_render.h
@@ -8,6 +8,8 @@
 #include "scene_render.h"
 #include "crt_filter.h"
 
+typedef struct SceneRendererGPU SceneRendererGPU;
+
 typedef enum {
     GAME_RENDER_GPU,
     GAME_RENDER_SOFTWARE
@@ -239,6 +241,18 @@ void game_render_quad_screen_hud(GameRenderer *renderer,
                                  tPolyParams *poly,
                                  TextureHandle handle,
                                  const uint8 *palette_remap);
+
+// Direct access to the underlying GPU sub-renderer for GPU-only callers that
+// need scene_render_gpu.h functions not otherwise wrapped here (e.g. name-tag
+// billboards in game_render_hardware.c, which need scene_render_gpu_upload_rgba/
+// screen_quad_textured/set_particle_ndcz directly). Returns NULL in SW mode or
+// if the GPU device is unavailable.
+SceneRendererGPU *game_render_get_gpu(GameRenderer *renderer);
+
+// Direct access to the underlying GPU device, for GPU-only callers that need
+// to create/release their own textures directly (e.g. name-tag label texture
+// caching in game_render_hardware.c). Returns NULL in SW mode.
+SDL_GPUDevice *game_render_get_device(GameRenderer *renderer);
 
 // Set the clip-space depth (NDC Z in [0,1]) for the next game_render_quad_screen
 // call so GPU particles are depth-tested against scene geometry.

--- a/PROJECTS/ROLLER/game_render_hardware.c
+++ b/PROJECTS/ROLLER/game_render_hardware.c
@@ -8,7 +8,8 @@
 #include "3d.h"          /* cartex_vga[], Car[], localdata[], CarBox, g_pGameRenderer, names_on, winw/winh, viewx/y/z, xbase/ybase, scr_size, VIEWDIST, tcos/tsin, mirror, intro */
 #include "transfrm.h"    /* vk1-vk9 */
 #include "drawtrk3.h"    /* NamesLeft */
-#include "func2.h"       /* mini_prt_string, language_buffer, screen_pointer */
+#include "func2.h"       /* mini_prt_string, language_buffer, screen_pointer, ascii_conv3 */
+#include "func3.h"       /* tBlockHeader */
 #include "frontend.h"    /* human_control, racers */
 #include "moving.h"      /* replaytype */
 #include "control.h"     /* getgroundz(), calculateseparatedcoordinatesystem() — real terrain queries, chunk-local coords */
@@ -62,16 +63,101 @@ struct GameRendererHardware {
     GRHWCarMesh    meshes[GAME_RENDER_HW_NUM_CARS];
 };
 
-/* Smoothed scrY for each car's name tag (EMA filter, -1 = uninitialised).
+/* Smoothed scrX/scrY for each car's name tag (EMA filter, -1 = uninitialised).
  * Keyed by [viewSlot][carIdx]: in 2-player mode the same car's tag is drawn
  * once per player's view (from that player's own camera), so a single
  * carIdx-only array would blend two unrelated camera-relative computations
  * together via the EMA -- see [[project_car_name_tags]]. */
 #define GAME_RENDER_HW_MAX_VIEW_SLOTS 2
+static int s_tagScrX[GAME_RENDER_HW_MAX_VIEW_SLOTS][GAME_RENDER_HW_NUM_CARS] = {
+    { -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1 },
+    { -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1 }
+};
 static int s_tagScrY[GAME_RENDER_HW_MAX_VIEW_SLOTS][GAME_RENDER_HW_NUM_CARS] = {
     { -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1 },
     { -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1 }
 };
+
+void game_render_hw_reset_name_tags(void)
+{
+    for (int slot = 0; slot < GAME_RENDER_HW_MAX_VIEW_SLOTS; slot++) {
+        for (int car = 0; car < GAME_RENDER_HW_NUM_CARS; car++) {
+            s_tagScrX[slot][car] = -1;
+            s_tagScrY[slot][car] = -1;
+        }
+    }
+}
+
+/* Cached per-car name-tag label texture, so real GPU billboards (depth-tested
+ * against the actual scene, unlike the old flat scrbuf-HUD text draw) don't
+ * need to rasterise glyphs every frame -- only when the label string itself
+ * changes (name/position rarely change frame to frame). Composed from the
+ * exact same glyph data mini_prt_string used (ascii_conv3 + rev_vga[0]), so
+ * it looks pixel-identical to the old SW-drawn text. */
+#define GAME_RENDER_HW_TAG_LABEL_MAX 32
+typedef struct {
+    char            label[GAME_RENDER_HW_TAG_LABEL_MAX];
+    SDL_GPUTexture *tex;
+    int             texW, texH;
+} GRHWTagLabelCache;
+static GRHWTagLabelCache s_tagLabelCache[GAME_RENDER_HW_NUM_CARS];
+
+/* Composes `label` into cache->tex if it differs from what's already cached
+ * for this car. Returns false (cache left as-is) if the label is empty or
+ * the atlas glyph data can't produce a non-empty bitmap -- caller should
+ * skip drawing the tag text in that case. */
+static bool ensure_tag_label_texture(SDL_GPUDevice *device, const char *label,
+                                     GRHWTagLabelCache *cache)
+{
+    if (cache->tex && strncmp(cache->label, label, GAME_RENDER_HW_TAG_LABEL_MAX) == 0)
+        return true;
+
+    int totalW = 0, maxH = 0;
+    for (const char *s = label; *s; s++) {
+        uint8 ci = (uint8)ascii_conv3[(uint8)*s];
+        if (ci == 255) { totalW += 4; continue; }
+        const tBlockHeader *g = &rev_vga[0][ci];
+        totalW += g->iWidth;
+        if (g->iHeight > maxH) maxH = g->iHeight;
+    }
+    if (totalW <= 0 || maxH <= 0) return false;
+
+    uint8 *rgba = calloc((size_t)totalW * (size_t)maxH, 4);
+    if (!rgba) return false;
+
+    int penX = 0;
+    for (const char *s = label; *s; s++) {
+        uint8 ci = (uint8)ascii_conv3[(uint8)*s];
+        if (ci == 255) { penX += 4; continue; }
+        const tBlockHeader *g = &rev_vga[0][ci];
+        const uint8 *bitmap = (const uint8 *)rev_vga[0] + g->iDataOffset;
+        for (int row = 0; row < g->iHeight; row++) {
+            for (int col = 0; col < g->iWidth; col++) {
+                uint8 idx = bitmap[row * g->iWidth + col];
+                if (!idx) continue; /* transparent, matches SW's "0 = don't draw" */
+                const tColor *c = &palette[idx];
+                uint8 *px = &rgba[((size_t)row * totalW + (penX + col)) * 4];
+                px[0] = (uint8)(c->byR * 255 / 63);
+                px[1] = (uint8)(c->byG * 255 / 63);
+                px[2] = (uint8)(c->byB * 255 / 63);
+                px[3] = 255;
+            }
+        }
+        penX += g->iWidth;
+    }
+
+    SDL_GPUTexture *newTex = scene_render_gpu_upload_rgba(device, rgba, totalW, maxH, false);
+    free(rgba);
+    if (!newTex) return false;
+
+    if (cache->tex) SDL_ReleaseGPUTexture(device, cache->tex);
+    cache->tex  = newTex;
+    cache->texW = totalW;
+    cache->texH = maxH;
+    strncpy(cache->label, label, GAME_RENDER_HW_TAG_LABEL_MAX - 1);
+    cache->label[GAME_RENDER_HW_TAG_LABEL_MAX - 1] = 0;
+    return true;
+}
 
 /* ==========================================================================
  * Car texture atlas
@@ -451,6 +537,10 @@ void game_render_hw_destroy(GameRendererHardware *r)
         if (m->indexBuf)  SDL_ReleaseGPUBuffer(r->device, m->indexBuf);
         if (m->atlas)     SDL_ReleaseGPUTexture(r->device, m->atlas);
     }
+    for (int i = 0; i < GAME_RENDER_HW_NUM_CARS; i++) {
+        if (s_tagLabelCache[i].tex) SDL_ReleaseGPUTexture(r->device, s_tagLabelCache[i].tex);
+        s_tagLabelCache[i] = (GRHWTagLabelCache){0};
+    }
     free(r);
 }
 
@@ -668,7 +758,7 @@ void game_render_hw_draw_car_name_tag(int carIdx, const GameRenderCarPose *pose,
     if (viewSlot < 0 || viewSlot >= GAME_RENDER_HW_MAX_VIEW_SLOTS) viewSlot = 0;
 
     tCar *pCar = &Car[carIdx];
-    if (pCar->byStatusFlags & 2) { s_tagScrY[viewSlot][carIdx] = -1; return; }
+    if (pCar->byStatusFlags & 2) { s_tagScrX[viewSlot][carIdx] = -1; s_tagScrY[viewSlot][carIdx] = -1; return; }
     if (!(names_on == 1 || (names_on == 2 && human_control[pCar->iDriverIdx]))) return;
 
     int carDesignIndex = pCar->byCarDesignIdx;
@@ -727,14 +817,40 @@ void game_render_hw_draw_car_name_tag(int carIdx, const GameRenderCarPose *pose,
     double fVX0 = dX0*vk1 + dY0*vk4 + dZ0*vk7;
     double fVY0 = dX0*vk2 + dY0*vk5 + dZ0*vk8;
     double fCamZ0 = dX0*vk3 + dY0*vk6 + dZ0*vk9;
-    if (fCamZ0 <= 0.0) return;
+    if (fCamZ0 <= 0.0) {
+        /* Car behind camera -- not visible this frame. Reset the smoothing
+         * state instead of leaving it frozen at its last value: otherwise,
+         * when the car comes back into view, the EMA blends from that stale
+         * position toward the real one over several frames instead of
+         * popping in fresh, which reads as the tag "sliding in" from the
+         * edge of the screen. */
+        s_tagScrX[viewSlot][carIdx] = -1;
+        s_tagScrY[viewSlot][carIdx] = -1;
+        return;
+    }
     double fClZ0 = fCamZ0 < 80.0 ? 80.0 : fCamZ0;
     int scrX = hw_d2i((double)VIEWDIST * fVX0 / fClZ0 + xbase) * scr_size >> 6;
+
+    /* Smooth scrX with an EMA (K=4), same treatment as scrY below -- raw 1/z
+     * projection noise shows up on X too (most visibly for distant cars, where
+     * a small world-space wobble maps to a disproportionate screen-space swing),
+     * and unlike scrY this had no smoothing at all before, so it jumped frame to
+     * frame. Reset instantly on large deltas (car first appearing, large jump). */
+    {
+        int prev = s_tagScrX[viewSlot][carIdx];
+        int delta = (prev < 0) ? (winw + 1) : (scrX - prev);
+        if (delta < 0) delta = -delta;
+        if (prev < 0 || delta > winw / 4)
+            s_tagScrX[viewSlot][carIdx] = scrX;
+        else
+            s_tagScrX[viewSlot][carIdx] = (3 * prev + scrX + 2) / 4;
+        scrX = s_tagScrX[viewSlot][carIdx];
+    }
 
     /* scrY from same centre-top point as scrX.  The old approach scanned four
      * hitbox corners and took the highest-projecting one; as the car rotates
      * different corners win, producing visible Y jitter.  The centre point is
-     * yaw-independent so scrY is smooth without needing EMA. */
+     * yaw-independent, but residual 1/z noise still needs the EMA below. */
     double sY0 = (double)VIEWDIST * fVY0 / fClZ0 + ybase;
     int scrY = (scr_size * (199 - hw_d2i(sY0))) >> 6;
 
@@ -751,6 +867,20 @@ void game_render_hw_draw_car_name_tag(int carIdx, const GameRenderCarPose *pose,
         scrY = s_tagScrY[viewSlot][carIdx];
     }
 
+    /* Real GPU billboard from here on: a screen-space, depth-tested quad (the
+     * same mechanism smoke/particle quads already use -- scene_render_gpu_
+     * screen_quad_textured/flat + set_particle_ndcz), NOT the old flat
+     * scrbuf-HUD text draw. SW's own name tags have no depth/occlusion
+     * concept at all (matches DisplayCarWithPose, car.c ~2061-2147), so real
+     * occlusion behind walls is a GPU-only enhancement, not a SW-parity fix
+     * -- but unlike an earlier CPU depth-readback attempt at the same thing,
+     * this gets real hardware depth testing with no staleness/sync risk,
+     * since it's just another queued draw in the same per-view pass cars/
+     * signs/trees already use (so 2P/mirror "for free" too). */
+    SceneRendererGPU *gpu = game_render_get_gpu(g_pGameRenderer);
+    SDL_GPUDevice *device = game_render_get_device(g_pGameRenderer);
+    if (!gpu || !device) return;
+
     /* Build label string: "NAME (POS)". */
     char tagLabel[32];
     if (pCar->byRacePosition < racers - 1 || racers == 1)
@@ -759,38 +889,88 @@ void game_render_hw_draw_car_name_tag(int carIdx, const GameRenderCarPose *pose,
     else
         sprintf(tagLabel, "%s (%s)", driver_names[carIdx], &language_buffer[1344]);
 
-    int iNameWidth = 0;
-    for (int i = 0; tagLabel[i]; i++) iNameWidth += 5;
-    int iNameHalfWidth = iNameWidth / 2;
+    if (!ensure_tag_label_texture(device, tagLabel, &s_tagLabelCache[carIdx]))
+        return;
+    int texW = s_tagLabelCache[carIdx].texW;
+    int texH = s_tagLabelCache[carIdx].texH;
 
-    int iDisplayX = mirror ? scrX + iNameHalfWidth : scrX - iNameHalfWidth;
-    int iDisplayY = scrY - 16;
+    /* Text's TOP edge sits at a fixed scrY-16 offset (matches the old
+     * iDisplayY = scrY - 16 convention exactly -- that -16 is a fixed margin
+     * above the anchor, not "the text is 16px tall"), extending down by the
+     * label's own real height; the triangle marker below occupies scrY-7 to
+     * scrY-1, so this leaves the same gap between text and triangle the old
+     * SW-drawn text had. Centred horizontally on scrX -- no mirror-direction
+     * handling needed here (unlike the old mini_prt_string_rev asymmetric
+     * left/right-edge anchor) since a centred quad doesn't care which way
+     * text used to be drawn; mirror is instead handled below as a genuine
+     * horizontal flip of the quad itself, so the text still reads correctly
+     * in the rearview mirror's flipped camera. */
+    float leftOff = -(float)(texW / 2), rightOff = leftOff + (float)texW;
+    float topOff  = -16.0f,             bottomOff = topOff + (float)texH;
+    if (scrX + rightOff <= 0 || scrX + leftOff >= winw
+        || scrY + bottomOff <= 0 || scrY + topOff >= winh)
+        return;
 
-    if (iNameWidth <= 0) return;
-    if (iDisplayX < 0 || iDisplayX >= winw - iNameWidth) return;
-    if (iDisplayY <= 0 || iDisplayY >= winh - 16) return;
+    float zF = SCENE_GPU_FAR / (SCENE_GPU_FAR - SCENE_GPU_NEAR);
+    float zB = -(SCENE_GPU_FAR * SCENE_GPU_NEAR) / (SCENE_GPU_FAR - SCENE_GPU_NEAR);
+    float tagDepth = zF + zB / (float)fCamZ0;
 
-    int iPrevScrSize = scr_size;
-    scr_size = 64;
-    if (mirror)
-        mini_prt_string_rev(rev_vga[0], tagLabel, iDisplayX, iDisplayY);
-    else
-        mini_prt_string(rev_vga[0], tagLabel, iDisplayX, iDisplayY);
-    scr_size = iPrevScrSize;
+    /* Project each corner from an offset in the SAME camera-space coordinates
+     * (fVX0/fVY0/fClZ0) the anchor itself was derived from, inverting exactly
+     * the SW scrX/scrY pixel formulas above, then through scene_render_gpu_
+     * project_to_ndc -- NOT a scrX/winw-based NDC conversion (see that
+     * function's comment for why that breaks in "Render Scale (native)"
+     * mode: the pixel-space intermediate bakes in the SW-implied FOV, which
+     * only matches the GPU's actual FOV when the GPU viewport isn't
+     * independently widened). pixToFv converts a FINAL screen-pixel offset
+     * (texW/texH and the fixed triangle offsets below, all in real output-
+     * pixel units) into a camera-space X/Y offset at this point's depth; Y is
+     * negated since screen-down is -fV.y. The scrX/scrY formulas above have
+     * an extra "* scr_size >> 6" beyond the raw VIEWDIST*fV/fClZ0 term this
+     * inverts, so a FINAL-pixel delta needs an extra 64/scr_size factor to
+     * convert to the same "raw" units first (that factor happens to cancel
+     * back out against fovX/fovY's own scr_size dependence inside
+     * project_to_ndc, so the net result is correct at every scr_size). */
+    double pixToFv = (64.0 / (double)scr_size) * (fClZ0 / (double)VIEWDIST);
+    float ndcX[4], ndcY[4], tNdcX[4], tNdcY[4];
+    /* v0=top-right, v1=top-left, v2=bottom-left, v3=bottom-right normally;
+     * mirror swaps v0<->v1 and v2<->v3, same flip trick used elsewhere in
+     * this file's GPU code (game_render.c's picture-quad flipH). */
+    float dx4[4], dy4[4];
+    if (mirror) {
+        dx4[0]=leftOff;  dy4[0]=topOff;    dx4[1]=rightOff; dy4[1]=topOff;
+        dx4[2]=rightOff; dy4[2]=bottomOff; dx4[3]=leftOff;  dy4[3]=bottomOff;
+    } else {
+        dx4[0]=rightOff; dy4[0]=topOff;    dx4[1]=leftOff;  dy4[1]=topOff;
+        dx4[2]=leftOff;  dy4[2]=bottomOff; dx4[3]=rightOff; dy4[3]=bottomOff;
+    }
+    for (int i = 0; i < 4; i++) {
+        double cFVX = fVX0 + (double)dx4[i] * pixToFv;
+        double cFVY = fVY0 - (double)dy4[i] * pixToFv;
+        scene_render_gpu_project_to_ndc(gpu, cFVX, cFVY, fClZ0, &ndcX[i], &ndcY[i]);
+    }
+    scene_render_gpu_set_particle_ndcz(gpu, tagDepth);
+    scene_render_gpu_screen_quad_textured(gpu, ndcX, ndcY, s_tagLabelCache[carIdx].tex,
+                                          1.0f, 1.0f, 1.0f, 1.0f);
 
-    /* Coloured downward-pointing triangle above car.
-     * Uses the HUD-overlay path (SW rasterizer into scrbuf), not the regular
-     * GPU particle path: this is a HUD-style marker, not a real depth-tested
-     * particle, and drawing it as a scrbuf pixel write lets it composite
-     * correctly in split-screen modes (2-player) the same way the text above
-     * already does, with no per-view GPU render pass capture needed. */
-    CarPol.vertices[0].x = scrX + 6;  CarPol.vertices[0].y = scrY - 7;
-    CarPol.vertices[1].x = scrX - 5;  CarPol.vertices[1].y = scrY - 7;
-    CarPol.vertices[2].x = scrX;      CarPol.vertices[2].y = scrY - 1;
-    CarPol.vertices[3].x = scrX + 6;  CarPol.vertices[3].y = scrY - 7;
-    CarPol.iSurfaceType = team_col[carDesignIndex];
-    CarPol.uiNumVerts = 4;
-    game_render_quad_screen_hud(g_pGameRenderer, &CarPol, TEXTURE_HANDLE_INVALID, NULL);
+    /* Coloured downward-pointing triangle above car, same depth as the text. */
+    float ttx4[4] = { 6.0f, -5.0f, 0.0f, 6.0f };
+    float tty4[4] = { -7.0f, -7.0f, -1.0f, -7.0f };
+    for (int i = 0; i < 4; i++) {
+        double cFVX = fVX0 + (double)ttx4[i] * pixToFv;
+        double cFVY = fVY0 - (double)tty4[i] * pixToFv;
+        scene_render_gpu_project_to_ndc(gpu, cFVX, cFVY, fClZ0, &tNdcX[i], &tNdcY[i]);
+    }
+    /* Textured (not flat) so this survives 2-player mode -- see
+     * scene_render_gpu_get_flat_color_texture's comment: flat-particle quads
+     * draw as a whole batch before textured ones regardless of queue order,
+     * and each player's composited view is itself an opaque textured quad
+     * that would otherwise paint right over a flat triangle queued earlier. */
+    SDL_GPUTexture *teamTex = scene_render_gpu_get_flat_color_texture(gpu, (uint8)team_col[carDesignIndex]);
+    if (teamTex) {
+        scene_render_gpu_set_particle_ndcz(gpu, tagDepth);
+        scene_render_gpu_screen_quad_textured(gpu, tNdcX, tNdcY, teamTex, 1.0f, 1.0f, 1.0f, 1.0f);
+    }
 }
 
 void game_render_hw_draw_fps_overlay(void)

--- a/PROJECTS/ROLLER/game_render_hardware.h
+++ b/PROJECTS/ROLLER/game_render_hardware.h
@@ -26,6 +26,16 @@ void game_render_hw_draw_car(GameRendererHardware       *r,
  * player's view doesn't inherit the other's camera-relative computation. */
 void game_render_hw_draw_car_name_tag(int carIdx, const GameRenderCarPose *pose, int viewSlot);
 
+/* Reset all name-tag EMA smoothing state (both scrX and scrY, every car/view
+ * slot) to uninitialised. Call on any SW<->GPU render-mode switch: while GPU
+ * mode is inactive this smoothing state goes stale (frozen at wherever it was
+ * last time GPU mode drew a frame) but keeps existing, so resuming GPU mode
+ * later would otherwise blend from that stale position toward the current
+ * real one over several frames -- visible as tags "flying in" right after a
+ * mode switch, the same class of bug as the camera-visibility case handled
+ * inside game_render_hw_draw_car_name_tag itself. */
+void game_render_hw_reset_name_tags(void);
+
 /* Draw FPS counter into scrbuf at the corner specified by g_iFpsDisplay (1-4; 0=off). */
 void game_render_hw_draw_fps_overlay(void);
 

--- a/PROJECTS/ROLLER/scene_render_gpu.c
+++ b/PROJECTS/ROLLER/scene_render_gpu.c
@@ -184,6 +184,7 @@ struct SceneRendererGPU {
     SDL_GPUTexture *signDepthCopyTex; /* depth snapshot taken after BUILDING, before SIGN; sampled by sign depth-check shader */
     int             depthTexW, depthTexH;
 
+
     SDL_GPUBuffer        *vertexBuf;
     SDL_GPUTransferBuffer *vertexXfer;
     SceneGPUVertex       *vertices;      /* heap-allocated, SCENE_GPU_MAX_VERTICES */
@@ -731,6 +732,11 @@ static SDL_GPUTexture *get_flat_color_texture(SceneRendererGPU *r, int colorIdx)
     return r->flatColorCache[colorIdx];
 }
 
+SDL_GPUTexture *scene_render_gpu_get_flat_color_texture(SceneRendererGPU *r, int colorIdx)
+{
+    return r ? get_flat_color_texture(r, colorIdx) : NULL;
+}
+
 /* Build column-major 4×4 VP (= MVP for world-space geometry with identity model).
  *
  * Software renderer (drawtrk3.c) equations:
@@ -794,6 +800,40 @@ void scene_render_gpu_build_vp(const SceneRendererGPU *r, float vp[16])
     int vpW = r->viewportW > 0 ? r->viewportW : 640;
     int vpH = r->viewportH > 0 ? r->viewportH : 400;
     build_mvp(vp, &r->camera, &r->proj, vpW, vpH, r->fovMultiplier);
+}
+
+bool scene_render_gpu_project_to_ndc(const SceneRendererGPU *r,
+                                     double fvx, double fvy, double fvz,
+                                     float *outNdcX, float *outNdcY)
+{
+    if (!r || fvz <= 0.0) return false;
+    int vpW = r->viewportW > 0 ? r->viewportW : 640;
+    int vpH = r->viewportH > 0 ? r->viewportH : 400;
+    /* Exactly mirrors build_mvp's per-vertex math (see its comment for the
+     * derivation) for a single already-camera-space point (fvx,fvy,fvz --
+     * same R·(world-cam) coordinates the SW vk1-9 transform produces, see
+     * callers), instead of going through a SW-pixel-space (scrX/scrY)
+     * intermediate: that intermediate bakes in the SW-implied FOV, which
+     * only matches the GPU's own FOV when vpW/vpH equal winw/winh exactly --
+     * false in "Render Scale (native)" mode, which widens vpW independent of
+     * winw to show a genuinely wider FOV, not just more pixels for the same
+     * content. Projecting straight from camera-space is correct in every mode. */
+    float ss   = (float)r->proj.screenScale / 64.0f;
+    float fovX = (2.0f * r->camera.fovScale * r->fovMultiplier * ss) / (float)vpW;
+    float fovY = (2.0f * r->camera.fovScale * r->fovMultiplier * ss) / (float)vpH;
+    float horizon_y = ss * (199.0f - (float)r->proj.centerY);
+    float shift_y   = ((float)vpH * 0.5f - horizon_y) / ((float)vpH * 0.5f);
+    *outNdcX = (float)(fovX * fvx / fvz);
+    /* NOT negated here -- matches build_mvp exactly (see its own comment):
+     * the shader-compiler's automatic D3D-Y-up -> Vulkan-Y-down negation is
+     * applied uniformly to every vertex shader's output, including the
+     * particle/HUD shaders screen_quad_textured/flat use, so this function
+     * (like build_mvp, and like the working ndcY = 1 - y/wh*2 pattern used
+     * elsewhere for these same quads) must supply pre-negation "D3D-style" Y
+     * and let that one automatic negation do its job. Adding an explicit '-'
+     * here double-negates and flips the result upside-down. */
+    *outNdcY = (float)(fovY * fvy / fvz + (double)shift_y);
+    return true;
 }
 
 static SDL_GPUShader *load_shader(SDL_GPUDevice *dev, SDL_GPUShaderStage stage,
@@ -3060,12 +3100,16 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
     scene_render_gpu_build_vp(r, viewVP);
     SDL_PushGPUVertexUniformData(r->cmdBuf, 0, viewVP, sizeof(viewVP));
 
-    /* Draw order: OPAQUE → WALL → BUILDING → SIGN
+    /* Draw order: OPAQUE → WALL → BUILDING → TREE → TRACK_DARKEN → BLEND →
+     * CARS → shadows → PARTICLES → SIGN (last, in its own post-copy pass).
      * Opaque and wall establish the depth buffer for solid track geometry.
      * Building polygons follow (LESS_OR_EQUAL + small bias for coplanar decals).
-     * Signs come last so the full depth buffer is owned before they test;
-     * LESS_OR_EQUAL + large negative bias lets signs coplanar with their wall
-     * still pass, while signs behind opaque geometry are correctly rejected. */
+     * Everything else that needs to test against real scene depth (trees,
+     * track-darken, translucent blend, cars, shadows, particles) draws next,
+     * all still inside this one continuous render pass -- see #258 below for
+     * why cars in particular must never cross the sign depth-copy's pass
+     * boundary. Signs come last of all, in their own pass, so the full depth
+     * buffer (now including cars/trees/everything) is owned before they test. */
     if (r->opaquePipeline) {
         SDL_BindGPUGraphicsPipeline(rp, r->opaquePipeline);
         draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_OPAQUE);
@@ -3086,70 +3130,12 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
         SDL_BindGPUGraphicsPipeline(rp, r->bfBuildingPipeline);
         draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_BF_BUILDING);
     }
-    /* Sign rendering: the depth-copy split (End Pass A / snapshot depth / begin Pass B)
-     * caused issue #258 -- cars rendering through narrow walls carrying signs, primary
-     * single-player pass only (2P/mirror never used this split and never showed the bug).
-     * Disabled for now (`0 &&`) so every path uses the same bias-based pipeline that
-     * MSAA and 2P/mirror already use; kept in place, not deleted, in case the canyon-wall
-     * sign self-occlusion behavior below needs to be restored. */
-    if (0 && !useMSAA && r->signDepthPipeline && r->signBkDepthPipeline && r->signDepthCopyTex) {
-        /* End Pass A, snapshot depth, begin Pass B. */
-        SDL_EndGPURenderPass(rp);
-        rp = NULL;
-
-        SDL_GPUCopyPass *dcp = SDL_BeginGPUCopyPass(r->cmdBuf);
-        SDL_GPUTextureLocation dcSrc = { .texture = r->depthTex };
-        SDL_GPUTextureLocation dcDst = { .texture = r->signDepthCopyTex };
-        SDL_CopyGPUTextureToTexture(dcp, &dcSrc, &dcDst, (Uint32)renderW, (Uint32)renderH, 1, false);
-        SDL_EndGPUCopyPass(dcp);
-
-        SDL_GPUColorTargetInfo colorInfoB = colorInfo;
-        colorInfoB.load_op  = SDL_GPU_LOADOP_LOAD;
-        colorInfoB.store_op = SDL_GPU_STOREOP_STORE;
-        SDL_GPUDepthStencilTargetInfo depthInfoB = {
-            .texture     = r->depthTex,
-            .load_op     = SDL_GPU_LOADOP_LOAD,
-            .store_op    = SDL_GPU_STOREOP_DONT_CARE,
-            .clear_depth = 1.0f
-        };
-        rp = SDL_BeginGPURenderPass(r->cmdBuf, &colorInfoB, 1, &depthInfoB);
-        SDL_SetGPUViewport(rp, &vp);
-        SDL_BindGPUVertexBuffers(rp, 0, &vbb, 1);
-        SDL_PushGPUFragmentUniformData(r->cmdBuf, 0, &pfu, sizeof(pfu));
-        SDL_PushGPUVertexUniformData(r->cmdBuf, 0, viewVP, sizeof(viewVP));
-
-        /* Each sign draw binds slot 0 (scene tex, varies per command) + slot 1
-         * (depth copy, constant for the whole pass). Slot 1 is set once here;
-         * draw_cmd_kind takes care of slot 0 (including skipping redundant
-         * rebinds) and now also benefits from the same sorted draw order as
-         * every other kind, instead of the raw unsorted queue order this
-         * used before. */
-        SDL_GPUTextureSamplerBinding signTsbSlot0 = {0};
-        SDL_GPUTextureSamplerBinding signTsbSlot1 = {
-            .texture = r->signDepthCopyTex,
-            .sampler = r->samplerNearest
-        };
-
-        SDL_BindGPUGraphicsPipeline(rp, r->signDepthPipeline);
-        draw_cmd_kind(r, rp, &signTsbSlot0, &signTsbSlot1, drawOrder, SCENE_GPU_DRAW_SIGN);
-        SDL_BindGPUGraphicsPipeline(rp, r->signBkDepthPipeline);
-        draw_cmd_kind(r, rp, &signTsbSlot0, &signTsbSlot1, drawOrder, SCENE_GPU_DRAW_SIGN_BK);
-    } else {
-        if (r->signPipeline) {
-            SDL_BindGPUGraphicsPipeline(rp, r->signPipeline);
-            draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_SIGN);
-        }
-        if (r->signBkPipeline) {
-            SDL_BindGPUGraphicsPipeline(rp, r->signBkPipeline);
-            draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_SIGN_BK);
-        }
-    }
     if (r->treePipeline) {
         SDL_BindGPUGraphicsPipeline(rp, r->treePipeline);
         draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_TREE);
     }
     /* Multiply-blend darken pass for TRANSPARENT non-textured track quads (glass/
-     * divider walls) -- must run after opaque/wall/building/sign/tree so there's
+     * divider walls) -- must run after opaque/wall/building/tree so there's
      * real colour underneath to darken; see trackDarkenPipeline comment. */
     SDL_GPUGraphicsPipeline *trackDarkenPipeline = track_darken_pipeline_for_draw(r);
     if (trackDarkenPipeline) {
@@ -3243,6 +3229,73 @@ void scene_render_gpu_end_frame(SceneRendererGPU *r)
                 1,
                 (Uint32)r->texParticleRanges[ri].start,
                 0);
+        }
+    }
+
+    /* Sign rendering, last of all: non-MSAA uses a depth-copy pass split so signs
+     * behind canyon walls are correctly hidden without z-fighting their own host
+     * wall; MSAA falls back to the old bias-based pipeline. This used to run right
+     * after BUILDING, with cars/trees/blend/particles drawn afterward in the same
+     * post-copy pass -- that caused issue #258 (cars rendering through narrow
+     * walls, single-player only): something about resuming a render pass on the
+     * same depth-stencil texture across an End/Copy/Begin boundary didn't reliably
+     * preserve real depth values for whatever drew after it. Moving signs to be
+     * the LAST thing drawn means every other kind (including cars) now stays
+     * entirely within the one continuous Pass A render pass, never crossing that
+     * boundary at all -- only the sign draws themselves, which don't write depth
+     * and only ever read the snapshot, are downstream of it. As a bonus, the
+     * snapshot now also includes cars/trees/blend, so signs occlude correctly
+     * against them too, not just walls/buildings. */
+    if (!useMSAA && r->signDepthPipeline && r->signBkDepthPipeline && r->signDepthCopyTex) {
+        /* End Pass A, snapshot depth, begin Pass B. */
+        SDL_EndGPURenderPass(rp);
+        rp = NULL;
+
+        SDL_GPUCopyPass *dcp = SDL_BeginGPUCopyPass(r->cmdBuf);
+        SDL_GPUTextureLocation dcSrc = { .texture = r->depthTex };
+        SDL_GPUTextureLocation dcDst = { .texture = r->signDepthCopyTex };
+        SDL_CopyGPUTextureToTexture(dcp, &dcSrc, &dcDst, (Uint32)renderW, (Uint32)renderH, 1, false);
+        SDL_EndGPUCopyPass(dcp);
+
+        SDL_GPUColorTargetInfo colorInfoB = colorInfo;
+        colorInfoB.load_op  = SDL_GPU_LOADOP_LOAD;
+        colorInfoB.store_op = SDL_GPU_STOREOP_STORE;
+        SDL_GPUDepthStencilTargetInfo depthInfoB = {
+            .texture     = r->depthTex,
+            .load_op     = SDL_GPU_LOADOP_LOAD,
+            .store_op    = SDL_GPU_STOREOP_DONT_CARE,
+            .clear_depth = 1.0f
+        };
+        rp = SDL_BeginGPURenderPass(r->cmdBuf, &colorInfoB, 1, &depthInfoB);
+        SDL_SetGPUViewport(rp, &vp);
+        SDL_BindGPUVertexBuffers(rp, 0, &vbb, 1);
+        SDL_PushGPUFragmentUniformData(r->cmdBuf, 0, &pfu, sizeof(pfu));
+        SDL_PushGPUVertexUniformData(r->cmdBuf, 0, viewVP, sizeof(viewVP));
+
+        /* Each sign draw binds slot 0 (scene tex, varies per command) + slot 1
+         * (depth copy, constant for the whole pass). Slot 1 is set once here;
+         * draw_cmd_kind takes care of slot 0 (including skipping redundant
+         * rebinds) and now also benefits from the same sorted draw order as
+         * every other kind, instead of the raw unsorted queue order this
+         * used before. */
+        SDL_GPUTextureSamplerBinding signTsbSlot0 = {0};
+        SDL_GPUTextureSamplerBinding signTsbSlot1 = {
+            .texture = r->signDepthCopyTex,
+            .sampler = r->samplerNearest
+        };
+
+        SDL_BindGPUGraphicsPipeline(rp, r->signDepthPipeline);
+        draw_cmd_kind(r, rp, &signTsbSlot0, &signTsbSlot1, drawOrder, SCENE_GPU_DRAW_SIGN);
+        SDL_BindGPUGraphicsPipeline(rp, r->signBkDepthPipeline);
+        draw_cmd_kind(r, rp, &signTsbSlot0, &signTsbSlot1, drawOrder, SCENE_GPU_DRAW_SIGN_BK);
+    } else {
+        if (r->signPipeline) {
+            SDL_BindGPUGraphicsPipeline(rp, r->signPipeline);
+            draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_SIGN);
+        }
+        if (r->signBkPipeline) {
+            SDL_BindGPUGraphicsPipeline(rp, r->signBkPipeline);
+            draw_cmd_kind(r, rp, &tsb, NULL, drawOrder, SCENE_GPU_DRAW_SIGN_BK);
         }
     }
 

--- a/PROJECTS/ROLLER/scene_render_gpu.h
+++ b/PROJECTS/ROLLER/scene_render_gpu.h
@@ -37,6 +37,7 @@ void scene_render_gpu_discard_queued(SceneRendererGPU *r);
 
 void scene_render_gpu_set_viewport(SceneRendererGPU *r,
                                    int x, int y, int w, int h);
+
 void scene_render_gpu_set_camera(SceneRendererGPU *r,
                                  const SceneRenderCamera *cam);
 void scene_render_gpu_set_projection(SceneRendererGPU *r,
@@ -141,6 +142,17 @@ void scene_render_gpu_set_crt_filter(SceneRendererGPU *r, struct CRTFilter *filt
 void scene_render_gpu_build_vp(const SceneRendererGPU *r, float vp[16]);
 int  scene_render_gpu_get_render_chunk(const SceneRendererGPU *r);
 
+/* Project an already-camera-space point (fvx,fvy,fvz -- the same R·(world-cam)
+ * coordinates the SW vk1-9 transform produces) to NDC, using the SAME FOV/
+ * viewport math as the real 3D scene (build_mvp), rather than a SW-pixel-space
+ * (scrX/scrY) intermediate -- see the definition for why that intermediate
+ * breaks in "Render Scale (native)" mode. Returns false (leaves outNdcX/Y
+ * untouched) if fvz <= 0 (point behind camera). */
+bool scene_render_gpu_project_to_ndc(const SceneRendererGPU *r,
+                                     double fvx, double fvy, double fvz,
+                                     float *outNdcX, float *outNdcY);
+
+
 /* Queue a flat-colour screen-space quad for the particle pass.
  * ndcX[4], ndcY[4]: NDC coordinates of the four corners (v0=top-right, v1=top-left,
  * v2=bottom-left, v3=bottom-right; same winding as tPolyParams SW quads).
@@ -161,6 +173,14 @@ void scene_render_gpu_set_particle_ndcz_pervertex(SceneRendererGPU *r, const flo
 
 /* Return the GPU texture for tile_idx within slot tex_idx, or NULL if out of range. */
 SDL_GPUTexture *scene_render_gpu_get_tile_texture(SceneRendererGPU *r, int tex_idx, int tile_idx);
+
+/* Cached flat-colour texture for a palette index (built once per index, reused
+ * after). Use via screen_quad_textured (NOT screen_quad_flat) for any UI
+ * element that must draw correctly in 2-player mode: flat-particle quads draw
+ * as a whole batch BEFORE textured-particle quads in the same render pass
+ * regardless of queue order, and each player's composited view is itself an
+ * opaque textured quad -- a flat quad queued earlier gets painted over. */
+SDL_GPUTexture *scene_render_gpu_get_flat_color_texture(SceneRendererGPU *r, int colorIdx);
 
 /* Return the particle-variant tile texture (palette index 0 = opaque white) for tile_idx.
  * Only cargen (tex_idx 18) has a particle variant; other slots fall back to the normal tile. */


### PR DESCRIPTION
Two related fixes bundled together since they touch overlapping code:

**#258 (cars rendering through walls)**: reorder the primary GPU pass so cars, trees, track-darken, blend, and shadows all draw before the sign depth-copy split instead of after — they now stay entirely within one continuous render pass and never cross the pass boundary that was corrupting depth for whatever drew after it. Signs draw last, in their own pass, against a depth snapshot that now also includes cars/trees/blend (a small accuracy improvement for sign occlusion too).

**#256 (jumpy/occluded-through-walls car name tags)**: replaced the flat SW-drawn scrbuf text+triangle with real GPU billboards — a per-car cached label texture (composed from the same glyph data SW's own text renderer uses) and a team-color triangle, both drawn as depth-tested screen-space quads through the same mechanism smoke particles already use. This gives real hardware depth occlusion (tags now correctly hide behind walls) with no extra latency, and fixes the EMA position-smoothing resets that were still causing tags to "fly in" after a car re-enters view or the renderer switches between SW/GPU. Along the way, fixed: a mode-switch NDC projection that only worked correctly at "Render Scale (4:3)" (native/widescreen mode genuinely widens the FOV, not just pixel density, so tags now project through the same camera math the real 3D scene uses); a Y-axis double-negation that flipped the triangle upside-down; a missing scr_size scale factor that made both quads oversized; and 2-player mode eating the triangle (flat quads draw before textured ones regardless of queue order, so it now uses the same textured-quad path as the label).