### PR TITLE
port MAYTE nitro boost cheat from Brazilian FATAL.EXE (#76)

### DIFF
--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -2989,6 +2989,8 @@ int main(int argc, const char **argv, const char **envp)
   tick_on = 0;
   ROLLERremove("../REPLAYS/REPLAY.TMP");
   readsoundconfig();
+  if (strcmp(languagename, "Brazilian") == 0)
+    g_bBrazilianMayte = true;
   InputLoadConfig();
   loadcheatnames();
   cdxinit();

--- a/PROJECTS/ROLLER/car.c
+++ b/PROJECTS/ROLLER/car.c
@@ -2147,6 +2147,11 @@ LABEL_117:
   }
 }
 
+/* Extra GPU depth bias for MAYTE's nitro flame specifically (on top of the
+ * general 0.000002f rounding bias below) -- tuned live via debug-overlay
+ * slider against the car body it sits closest to. */
+#define MAYTE_FLAME_DEPTH_BIAS 0.0001f
+
 /* Draw smoke/spray particles for a car using proper 3D perspective projection.
  * In the SW path this is handled inside DisplayCarWithPose (car.c ~1762).
  * In GPU mode DisplayCarWithPose does not run, so we call this separately. */
@@ -2219,6 +2224,11 @@ void DisplayCarSmoke(int carIdx, const CarRenderPose *pose)
          * Keep it minimal so crash-smoke at wall depth doesn't bleed through. */
         float gndcZ = (camZ - SCENE_GPU_NEAR) * (SCENE_GPU_FAR / (SCENE_GPU_FAR - SCENE_GPU_NEAR)) / camZ;
         gndcZ -= 0.000002f;
+        /* MAYTE's nitro flame sits low and close to the car body -- the tiny bias
+         * above isn't quite enough to keep it from being clipped by the car's own
+         * mesh on the GPU path (SW's own depth-sort doesn't have this issue). */
+        if (pCar->byCarDesignIdx == CAR_DESIGN_MAYTE)
+          gndcZ -= MAYTE_FLAME_DEPTH_BIAS;
         if (gndcZ < 0.0f) gndcZ = 0.0f;
         game_render_set_particle_depth(g_pGameRenderer, gndcZ);
 
@@ -2259,6 +2269,8 @@ void DisplayCarSmoke(int carIdx, const CarRenderPose *pose)
                 float tailNdcZ = (camZ2 - SCENE_GPU_NEAR) *
                                  (SCENE_GPU_FAR / (SCENE_GPU_FAR - SCENE_GPU_NEAR)) / camZ2;
                 tailNdcZ -= 0.000002f;
+                if (pCar->byCarDesignIdx == CAR_DESIGN_MAYTE)
+                  tailNdcZ -= MAYTE_FLAME_DEPTH_BIAS;
                 if (tailNdcZ < 0.0f) tailNdcZ = 0.0f;
                 const float ndcZv[4] = {tailNdcZ, tailNdcZ, gndcZ, gndcZ};
                 game_render_set_particle_depth_pervertex(g_pGameRenderer, ndcZv);

--- a/PROJECTS/ROLLER/control.c
+++ b/PROJECTS/ROLLER/control.c
@@ -309,26 +309,6 @@ void humancar(int iCarIdx)
       } else if (Car[iCarIdx_1].fRPMRatio < 1.0f) {
         mayte_spawn_boost_spray(&Car[iCarIdx_1], Car[iCarIdx_1].iDriverIdx);
       }
-      // TEMPORARY DEBUG -- remove once the flame pile-size question is resolved.
-      {
-        static int dbgFrameCounter = 0;
-        if (++dbgFrameCounter % 30 == 0) {
-          int iDriverIdxDbg = Car[iCarIdx_1].iDriverIdx;
-          int iAliveCount = 0;
-          for (int dbgI = 0; dbgI < 32; ++dbgI) {
-            tCarSpray *pDbg = &CarSpray[iDriverIdxDbg][dbgI];
-            if (pDbg->iType == 1 && pDbg->iLifeTime > 0) {
-              SDL_Log("[MAYTE DEBUG] slot=%d life=%d timer=%d velX=%.1f velY=%.1f velZ=%.1f size=%.1f pos=(%.1f,%.1f,%.1f)",
-                      dbgI, pDbg->iLifeTime, pDbg->iTimer, pDbg->velocity.fX, pDbg->velocity.fY, pDbg->velocity.fZ,
-                      pDbg->fSize, pDbg->position.fX, pDbg->position.fY, pDbg->position.fZ);
-              ++iAliveCount;
-            }
-          }
-          SDL_Log("[MAYTE DEBUG] car=%d alive_type1=%d ammo=%d cooldown=%d overflow=%.1f rpm=%.2f",
-                  iDriverIdxDbg, iAliveCount, Car[iCarIdx_1].byCheatAmmo, Car[iCarIdx_1].byCheatCooldown,
-                  Car[iCarIdx_1].fSpeedOverflow, Car[iCarIdx_1].fRPMRatio);
-        }
-      }
       TRAK_LEN = iTrakLen;
       Car[iCarIdx_1].byCheatCooldown = 36;          // shared switch-tail behavior, matches SUICYCO
       goto PROCESS_VEHICLE_CONTROLS;
@@ -6892,11 +6872,20 @@ void dospray(tCar *pCar, int iCinematicMode, tCarSpray *pCarSpray)
               iRandomUnk5_2 = ROLLERrandRaw();
               iCalculatedUnk5 = GetHighOrderRand(200, iRandomUnk5_2) + 200;
               //iCalculatedUnk5 = ((200 * iRandomUnk5_2 - (__CFSHL__((200 * iRandomUnk5_2) >> 31, 15) + ((200 * iRandomUnk5_2) >> 31 << 15))) >> 15) + 200;
-            } else {
+            } else if (iTimer <= 3) {
               pCarSpray->velocity.fX = (float)(-105 - GetHighOrderRand(150, iRandomVelX3));
               //pCarSpray->velocity.fX = (float)(-105 - ((150 * iRandomVelX3 - (__CFSHL__((150 * iRandomVelX3) >> 31, 15) + ((150 * iRandomVelX3) >> 31 << 15))) >> 15));
               iRandomVelY8 = ROLLERrandRaw();
-              pCarSpray->velocity.fY = (float)GetHighOrderRand(400, iRandomVelY8);
+              pCarSpray->velocity.fY = (float)(GetHighOrderRand(400, iRandomVelY8) - 200);
+              //pCarSpray->velocity.fY = (float)(((400 * iRandomVelY8 - (__CFSHL__((400 * iRandomVelY8) >> 31, 15) + ((400 * iRandomVelY8) >> 31 << 15))) >> 15) - 200);
+              iRandomUnk5_3 = ROLLERrandRaw();
+              iCalculatedUnk5 = GetHighOrderRand(30, iRandomUnk5_3) - 20;
+              //iCalculatedUnk5 = ((30 * iRandomUnk5_3 - (__CFSHL__((30 * iRandomUnk5_3) >> 31, 15) + ((30 * iRandomUnk5_3) >> 31 << 15))) >> 15) - 20;
+            } else {                          // iTimer > 3: stronger kick, same signed lateral spread as the 2-3 tier
+              pCarSpray->velocity.fX = (float)(-200 - GetHighOrderRand(300, iRandomVelX3));
+              //pCarSpray->velocity.fX = (float)(-200 - ((300 * iRandomVelX3 - (__CFSHL__((300 * iRandomVelX3) >> 31, 15) + ((300 * iRandomVelX3) >> 31 << 15))) >> 15));
+              iRandomVelY8 = ROLLERrandRaw();
+              pCarSpray->velocity.fY = (float)(GetHighOrderRand(400, iRandomVelY8) - 200);
               //pCarSpray->velocity.fY = (float)(((400 * iRandomVelY8 - (__CFSHL__((400 * iRandomVelY8) >> 31, 15) + ((400 * iRandomVelY8) >> 31 << 15))) >> 15) - 200);
               iRandomUnk5_3 = ROLLERrandRaw();
               iCalculatedUnk5 = GetHighOrderRand(30, iRandomUnk5_3) - 20;

--- a/PROJECTS/ROLLER/control.c
+++ b/PROJECTS/ROLLER/control.c
@@ -66,6 +66,47 @@ int fudge_wait;                   //00149DC4
 char RecordNames[25][9];          //00149DC8
 
 //-------------------------------------------------------------------------------------------------
+/* MAYTE cheat nitro boost (Brazilian FATAL.EXE only): spawns one fire/smoke
+ * spray particle at a rear exhaust attachment point, reusing the same
+ * tCarSpray/CarDesigns infrastructure dospray() already uses for damage
+ * smoke. Ported from the Brazilian binary's own trigger function
+ * (sub_3A024), called as a standalone spawn rather than through the main
+ * per-frame health-based spawn loop.
+ *
+ * Skips spawning while SelectedView[0] is cockpit/in-car/behind-car (0/2/7)
+ * -- those views don't show this car's own exhaust. Scales the attachment
+ * point down for CHEAT_MODE_TINY_CARS, matching dospray()'s own 0.25/0.5
+ * scaling for the same case. iColor/velocity are deliberately left
+ * untouched, matching the original -- whatever a previous occupant of this
+ * CarSpray slot set them to carries over. */
+static void mayte_spawn_boost_spray(tCar *pCar, int iDriverIdx)
+{
+  if (!SelectedView[0] || SelectedView[0] == 2 || SelectedView[0] == 7)
+    return;
+  int *pPlaces = CarDesigns[pCar->byCarDesignIdx].pPlaces;
+  if (pPlaces == (int *)-1)
+    return;
+  tCarSpray *pCarSpray = CarSpray[iDriverIdx];
+  for (int i = 0; i < 32; ++i, ++pCarSpray) {
+    if (pCarSpray->iLifeTime <= 0) {
+      int iPlacementIdx = (ROLLERrand() & 1) ? 3 : 2;   // rear exhaust points
+      tVec3 *pCoord = &CarDesigns[pCar->byCarDesignIdx].pCoords[pPlaces[iPlacementIdx]];
+      pCarSpray->iType = 1;
+      pCarSpray->iLifeTime = GetHighOrderRand(24, ROLLERrandRaw()) + 24;
+      if ((cheat_mode & CHEAT_MODE_TINY_CARS) == 0) {
+        pCarSpray->position = *pCoord;
+      } else {
+        pCarSpray->position.fX = pCoord->fX * 0.25f;
+        pCarSpray->position.fY = pCoord->fY * 0.25f;
+        pCarSpray->position.fZ = pCoord->fZ * 0.5f;
+      }
+      pCarSpray->iTimer = iPlacementIdx + 2;
+      break;
+    }
+  }
+}
+
+//-------------------------------------------------------------------------------------------------
 //00029640
 void humancar(int iCarIdx)
 {
@@ -214,10 +255,51 @@ void humancar(int iCarIdx)
       iTrakLen = TRAK_LEN;
       Car[iCarIdx_1].byCheatCooldown = 36;      // Set cheat power cooldown (36 frames) after use
       goto PROCESS_VEHICLE_CONTROLS;
-    case 9:                                     // MAYTE (top speed)
+    case 9: {                                    // MAYTE (nitro boost with fire), ported bit-for-bit
+      // from the Brazilian FATAL.EXE's humancar_ case 9 (English only ever had the auto-throttle
+      // line below). "Ready" is NOT a dedicated charge meter -- it's the car's own existing engine
+      // state: fRPMRatio==1.0 (at redline) AND byGearAyMax==5 (already in top/6th gear, matching
+      // this cheat car's fixed gear count), i.e. genuinely flooring it with nothing left to shift
+      // into. fSpeedOverflow doubles as the one-shot gate: a trigger adds 300 (see below), and
+      // requires <10 to fire again -- this decays back down on its own via the *existing* shared
+      // deceleration physics (control.c's Decelerate()/per-frame speed update), not any MAYTE-
+      // specific timer, which is why repeated real-world use looks like "waiting a few seconds"
+      // rather than a fixed cooldown. Airborne cars bypass the ready check entirely (traced
+      // directly), so a MAYTE car can still boost while jumping even without being pinned at
+      // redline in top gear.
       iControlFlags = iControlFlags | 1;
-      //LOBYTE(unControlFlags) = unControlFlags | 1;
+      bool bReady = (Car[iCarIdx_1].fRPMRatio >= 1.0f && (char)Car[iCarIdx_1].byGearAyMax == 5)
+                    || (Car[iCarIdx_1].nCurrChunk == -1);
+      if (bReady) {
+        if (Car[iCarIdx_1].fSpeedOverflow >= 10.0f) {
+          if (Car[iCarIdx_1].fRPMRatio < 1.0f)
+            mayte_spawn_boost_spray(&Car[iCarIdx_1], Car[iCarIdx_1].iDriverIdx);
+        } else if (!Car[iCarIdx_1].byCheatCooldown) {
+          if (!Car[iCarIdx_1].byCheatAmmo) {
+            TRAK_LEN = iTrakLen;
+            if (cheatsampleok(iCarIdx_1))
+              sfxsample(SOUND_SAMPLE_BLOP, 0x8000);
+          } else {
+            --Car[iCarIdx_1].byCheatAmmo;
+            // exact velocity impulse, traced through the Brazilian binary's x87 stack:
+            // fHorizontalSpeed += tcos[pitch]*300; direction.X/Y get the same term further
+            // scaled by tcos[yaw]/tsin[yaw]; direction.Z gets tsin[pitch]*300 directly.
+            float fBoostPitchTerm = tcos[Car[iCarIdx_1].nPitch] * 300.0f;
+            Car[iCarIdx_1].fHorizontalSpeed += fBoostPitchTerm;
+            Car[iCarIdx_1].direction.fX += fBoostPitchTerm * tcos[Car[iCarIdx_1].nYaw];
+            Car[iCarIdx_1].direction.fY += fBoostPitchTerm * tsin[Car[iCarIdx_1].nYaw];
+            Car[iCarIdx_1].direction.fZ += tsin[Car[iCarIdx_1].nPitch] * 300.0f;
+            Car[iCarIdx_1].fSpeedOverflow += 400.0f;
+            mayte_spawn_boost_spray(&Car[iCarIdx_1], Car[iCarIdx_1].iDriverIdx);
+          }
+        }
+      } else if (Car[iCarIdx_1].fRPMRatio < 1.0f) {
+        mayte_spawn_boost_spray(&Car[iCarIdx_1], Car[iCarIdx_1].iDriverIdx);
+      }
+      TRAK_LEN = iTrakLen;
+      Car[iCarIdx_1].byCheatCooldown = 36;          // shared switch-tail behavior, matches SUICYCO
       goto PROCESS_VEHICLE_CONTROLS;
+    }
     case 10:                                    // 2X4B523P (flip opponent)
       if (Car[iCarIndex2].byCheatCooldown)
         goto PROCESS_VEHICLE_CONTROLS;

--- a/PROJECTS/ROLLER/control.c
+++ b/PROJECTS/ROLLER/control.c
@@ -255,19 +255,22 @@ void humancar(int iCarIdx)
       iTrakLen = TRAK_LEN;
       Car[iCarIdx_1].byCheatCooldown = 36;      // Set cheat power cooldown (36 frames) after use
       goto PROCESS_VEHICLE_CONTROLS;
-    case 9: {                                    // MAYTE (nitro boost with fire), ported bit-for-bit
-      // from the Brazilian FATAL.EXE's humancar_ case 9 (English only ever had the auto-throttle
-      // line below). "Ready" is NOT a dedicated charge meter -- it's the car's own existing engine
-      // state: fRPMRatio==1.0 (at redline) AND byGearAyMax==5 (already in top/6th gear, matching
-      // this cheat car's fixed gear count), i.e. genuinely flooring it with nothing left to shift
-      // into. fSpeedOverflow doubles as the one-shot gate: a trigger adds 300 (see below), and
-      // requires <10 to fire again -- this decays back down on its own via the *existing* shared
-      // deceleration physics (control.c's Decelerate()/per-frame speed update), not any MAYTE-
-      // specific timer, which is why repeated real-world use looks like "waiting a few seconds"
-      // rather than a fixed cooldown. Airborne cars bypass the ready check entirely (traced
-      // directly), so a MAYTE car can still boost while jumping even without being pinned at
-      // redline in top gear.
+    case 9: {                                    // MAYTE (top speed); MAYTEB selects the Brazilian
+                                                   // nitro-boost variant below via CHEAT_MODE_MAYTE_BRAZILIAN
       iControlFlags = iControlFlags | 1;
+      if (!(cheat_mode & CHEAT_MODE_MAYTE_BRAZILIAN))
+        goto PROCESS_VEHICLE_CONTROLS;
+      // Nitro boost with fire, ported bit-for-bit from the Brazilian FATAL.EXE's humancar_ case 9
+      // (English only ever had the auto-throttle line above). "Ready" is NOT a dedicated charge
+      // meter -- it's the car's own existing engine state: fRPMRatio==1.0 (at redline) AND
+      // byGearAyMax==5 (already in top/6th gear, matching this cheat car's fixed gear count), i.e.
+      // genuinely flooring it with nothing left to shift into. fSpeedOverflow doubles as the
+      // one-shot gate: a trigger adds 300 (see below), and requires <10 to fire again -- this
+      // decays back down on its own via the *existing* shared deceleration physics (control.c's
+      // Decelerate()/per-frame speed update), not any MAYTE-specific timer, which is why repeated
+      // real-world use looks like "waiting a few seconds" rather than a fixed cooldown. Airborne
+      // cars bypass the ready check entirely (traced directly), so a MAYTE car can still boost
+      // while jumping even without being pinned at redline in top gear.
       bool bReady = (Car[iCarIdx_1].fRPMRatio >= 1.0f && (char)Car[iCarIdx_1].byGearAyMax == 5)
                     || (Car[iCarIdx_1].nCurrChunk == -1);
       if (bReady) {

--- a/PROJECTS/ROLLER/control.c
+++ b/PROJECTS/ROLLER/control.c
@@ -89,10 +89,15 @@ static void mayte_spawn_boost_spray(tCar *pCar, int iDriverIdx)
   tCarSpray *pCarSpray = CarSpray[iDriverIdx];
   for (int i = 0; i < 32; ++i, ++pCarSpray) {
     if (pCarSpray->iLifeTime <= 0) {
-      int iPlacementIdx = (ROLLERrand() & 1) ? 3 : 2;   // rear exhaust points
-      tVec3 *pCoord = &CarDesigns[pCar->byCarDesignIdx].pCoords[pPlaces[iPlacementIdx]];
+      // RNG draw order matches sub_3A024 exactly: lifetime first, placement second --
+      // both come off the same shared PRNG stream, so which draw feeds which field matters.
       pCarSpray->iType = 1;
       pCarSpray->iLifeTime = GetHighOrderRand(24, ROLLERrandRaw()) + 24;
+      // GetHighOrderRand(2, raw) picks the exhaust point, matching sub_3A024: it checks the raw
+      // value's high bit (upper vs lower half of its range). This LCG's low bits are weak, so a
+      // plain bitmask on the raw value would bias the result toward one side.
+      int iPlacementIdx = GetHighOrderRand(2, ROLLERrandRaw()) + 2;   // rear exhaust points (2 or 3)
+      tVec3 *pCoord = &CarDesigns[pCar->byCarDesignIdx].pCoords[pPlaces[iPlacementIdx]];
       if ((cheat_mode & CHEAT_MODE_TINY_CARS) == 0) {
         pCarSpray->position = *pCoord;
       } else {
@@ -101,7 +106,8 @@ static void mayte_spawn_boost_spray(tCar *pCar, int iDriverIdx)
         pCarSpray->position.fZ = pCoord->fZ * 0.5f;
       }
       pCarSpray->iTimer = iPlacementIdx + 2;
-      break;
+      // No break: sub_3A024's loop has no early exit either -- it spawns into every
+      // eligible free slot in a single call, not just the first one it finds.
     }
   }
 }
@@ -255,10 +261,10 @@ void humancar(int iCarIdx)
       iTrakLen = TRAK_LEN;
       Car[iCarIdx_1].byCheatCooldown = 36;      // Set cheat power cooldown (36 frames) after use
       goto PROCESS_VEHICLE_CONTROLS;
-    case 9: {                                    // MAYTE (top speed); MAYTEB selects the Brazilian
-                                                   // nitro-boost variant below via CHEAT_MODE_MAYTE_BRAZILIAN
+    case 9: {                                    // MAYTE (top speed); debug-overlay "Brazilian MAYTE"
+                                                   // checkbox (g_bBrazilianMayte) selects the nitro-boost variant below
       iControlFlags = iControlFlags | 1;
-      if (!(cheat_mode & CHEAT_MODE_MAYTE_BRAZILIAN))
+      if (!g_bBrazilianMayte)
         goto PROCESS_VEHICLE_CONTROLS;
       // Nitro boost with fire, ported bit-for-bit from the Brazilian FATAL.EXE's humancar_ case 9
       // (English only ever had the auto-throttle line above). "Ready" is NOT a dedicated charge
@@ -284,20 +290,44 @@ void humancar(int iCarIdx)
               sfxsample(SOUND_SAMPLE_BLOP, 0x8000);
           } else {
             --Car[iCarIdx_1].byCheatAmmo;
-            // exact velocity impulse, traced through the Brazilian binary's x87 stack:
-            // fHorizontalSpeed += tcos[pitch]*300; direction.X/Y get the same term further
-            // scaled by tcos[yaw]/tsin[yaw]; direction.Z gets tsin[pitch]*300 directly.
-            float fBoostPitchTerm = tcos[Car[iCarIdx_1].nPitch] * 300.0f;
-            Car[iCarIdx_1].fHorizontalSpeed += fBoostPitchTerm;
-            Car[iCarIdx_1].direction.fX += fBoostPitchTerm * tcos[Car[iCarIdx_1].nYaw];
-            Car[iCarIdx_1].direction.fY += fBoostPitchTerm * tsin[Car[iCarIdx_1].nYaw];
-            Car[iCarIdx_1].direction.fZ += tsin[Car[iCarIdx_1].nPitch] * 300.0f;
+            // Direct velocity impulse only applies airborne -- traced through the Brazilian
+            // binary's x87 stack, the tcos/tsin push is inside its own "nCurrChunk == -1" check,
+            // separate from the unconditional fSpeedOverflow/spawn below. On the ground the speed
+            // gain alone (fSpeedOverflow -> fFinalSpeed) is the whole effect; airborne movement
+            // isn't driven by fFinalSpeed, so it needs the direct push to do anything at all.
+            if (Car[iCarIdx_1].nCurrChunk == -1) {
+              float fBoostPitchTerm = tcos[Car[iCarIdx_1].nPitch] * 300.0f;
+              Car[iCarIdx_1].fHorizontalSpeed += fBoostPitchTerm;
+              Car[iCarIdx_1].direction.fX += fBoostPitchTerm * tcos[Car[iCarIdx_1].nYaw];
+              Car[iCarIdx_1].direction.fY += fBoostPitchTerm * tsin[Car[iCarIdx_1].nYaw];
+              Car[iCarIdx_1].direction.fZ += tsin[Car[iCarIdx_1].nPitch] * 300.0f;
+            }
             Car[iCarIdx_1].fSpeedOverflow += 400.0f;
             mayte_spawn_boost_spray(&Car[iCarIdx_1], Car[iCarIdx_1].iDriverIdx);
           }
         }
       } else if (Car[iCarIdx_1].fRPMRatio < 1.0f) {
         mayte_spawn_boost_spray(&Car[iCarIdx_1], Car[iCarIdx_1].iDriverIdx);
+      }
+      // TEMPORARY DEBUG -- remove once the flame pile-size question is resolved.
+      {
+        static int dbgFrameCounter = 0;
+        if (++dbgFrameCounter % 30 == 0) {
+          int iDriverIdxDbg = Car[iCarIdx_1].iDriverIdx;
+          int iAliveCount = 0;
+          for (int dbgI = 0; dbgI < 32; ++dbgI) {
+            tCarSpray *pDbg = &CarSpray[iDriverIdxDbg][dbgI];
+            if (pDbg->iType == 1 && pDbg->iLifeTime > 0) {
+              SDL_Log("[MAYTE DEBUG] slot=%d life=%d timer=%d velX=%.1f velY=%.1f velZ=%.1f size=%.1f pos=(%.1f,%.1f,%.1f)",
+                      dbgI, pDbg->iLifeTime, pDbg->iTimer, pDbg->velocity.fX, pDbg->velocity.fY, pDbg->velocity.fZ,
+                      pDbg->fSize, pDbg->position.fX, pDbg->position.fY, pDbg->position.fZ);
+              ++iAliveCount;
+            }
+          }
+          SDL_Log("[MAYTE DEBUG] car=%d alive_type1=%d ammo=%d cooldown=%d overflow=%.1f rpm=%.2f",
+                  iDriverIdxDbg, iAliveCount, Car[iCarIdx_1].byCheatAmmo, Car[iCarIdx_1].byCheatCooldown,
+                  Car[iCarIdx_1].fSpeedOverflow, Car[iCarIdx_1].fRPMRatio);
+        }
       }
       TRAK_LEN = iTrakLen;
       Car[iCarIdx_1].byCheatCooldown = 36;          // shared switch-tail behavior, matches SUICYCO

--- a/PROJECTS/ROLLER/debug_overlay.c
+++ b/PROJECTS/ROLLER/debug_overlay.c
@@ -1032,6 +1032,13 @@ static void DrawDebugPanel(DebugOverlay *pOverlay) {
       InputSaveConfig();
     }
 
+    int bBrazilianMayte = (int)g_bBrazilianMayte;
+    nk_layout_row_dynamic(pCtx, DEBUG_ROW_H, 1);
+    if (nk_checkbox_label(pCtx, "Brazilian MAYTE", &bBrazilianMayte)) {
+      g_bBrazilianMayte = (bool)bBrazilianMayte;
+      InputSaveConfig();
+    }
+
     int bFreeCamera = (int)g_bFreeCamera;
     nk_layout_row_dynamic(pCtx, DEBUG_ROW_H, 1);
     if (nk_checkbox_label(pCtx, "Free Camera", &bFreeCamera)) {

--- a/PROJECTS/ROLLER/debug_overlay.c
+++ b/PROJECTS/ROLLER/debug_overlay.c
@@ -964,9 +964,9 @@ static void DrawDebugPanel(DebugOverlay *pOverlay) {
     if (iNewMusicSel != iMusicSel) {
       stopmusic();
       const char *pszSel = apszMusic[iNewMusicSel];
-      if (pszSel == "CD")          { MusicCD = -1; MusicCard = 0;  MusicOS = 0;  MusicOPL = 0; }
-      else if (pszSel == "MIDI (OPL3)") { MusicCD = 0;  MusicCard = 0;  MusicOS = 0;  MusicOPL = -1; }
-      else if (pszSel == "MIDI (OS)")   { MusicCD = 0;  MusicCard = 0;  MusicOS = -1; MusicOPL = 0; }
+      if (strcmp(pszSel, "CD") == 0)          { MusicCD = -1; MusicCard = 0;  MusicOS = 0;  MusicOPL = 0; }
+      else if (strcmp(pszSel, "MIDI (OPL3)") == 0) { MusicCD = 0;  MusicCard = 0;  MusicOS = 0;  MusicOPL = -1; }
+      else if (strcmp(pszSel, "MIDI (OS)") == 0)   { MusicCD = 0;  MusicCard = 0;  MusicOS = -1; MusicOPL = 0; }
       else                         { MusicCD = 0;  MusicCard = -1; MusicOS = 0;  MusicOPL = 0; }
       startmusic(g_iCurrentSong);
       InputSaveConfig();

--- a/PROJECTS/ROLLER/frontend_util.c
+++ b/PROJECTS/ROLLER/frontend_util.c
@@ -275,6 +275,14 @@ int CheckNames(char *szPlayerName, int iPlayerIdx)
       cheat_mode |= CHEAT_MODE_CHEAT_CAR;
       break;
     }
+    else if (name_cmp(szPlayerName, "MAYTEB")) {
+      // Same MAYTE cheat car; CHEAT_MODE_MAYTE_BRAZILIAN switches control.c's case 9 to the
+      // Brazilian FATAL.EXE's nitro-boost behavior instead of the original top-speed one.
+      Players_Cars[iPlayerIdx] = CAR_DESIGN_MAYTE;
+      name_copy(szPlayerName, "DAMON");
+      cheat_mode |= CHEAT_MODE_CHEAT_CAR | CHEAT_MODE_MAYTE_BRAZILIAN;
+      break;
+    }
 
     // Move to next cheat name
     szCurrCheat += 9;

--- a/PROJECTS/ROLLER/frontend_util.c
+++ b/PROJECTS/ROLLER/frontend_util.c
@@ -275,15 +275,6 @@ int CheckNames(char *szPlayerName, int iPlayerIdx)
       cheat_mode |= CHEAT_MODE_CHEAT_CAR;
       break;
     }
-    else if (name_cmp(szPlayerName, "MAYTEB")) {
-      // Same MAYTE cheat car; CHEAT_MODE_MAYTE_BRAZILIAN switches control.c's case 9 to the
-      // Brazilian FATAL.EXE's nitro-boost behavior instead of the original top-speed one.
-      Players_Cars[iPlayerIdx] = CAR_DESIGN_MAYTE;
-      name_copy(szPlayerName, "DAMON");
-      cheat_mode |= CHEAT_MODE_CHEAT_CAR | CHEAT_MODE_MAYTE_BRAZILIAN;
-      break;
-    }
-
     // Move to next cheat name
     szCurrCheat += 9;
     iCheatIdx++;

--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -115,6 +115,7 @@ bool g_bFixCarMenuBug = true;
 bool g_bImprovedJumpLanding = true;
 bool g_bNoclip = false;
 bool g_bShowCarOnExplosion = false;
+bool g_bBrazilianMayte = false;
 bool g_bFreeCamera = false;
 int   g_iTextureFilter   = 0;
 int   g_iAnisotropyLevel = 3;     /* default 16x */

--- a/PROJECTS/ROLLER/roller.h
+++ b/PROJECTS/ROLLER/roller.h
@@ -19,6 +19,7 @@ extern bool g_bFixCarMenuBug;
 extern bool g_bImprovedJumpLanding;
 extern bool g_bNoclip;
 extern bool g_bShowCarOnExplosion; /* true = keep car mesh visible during explosion animation */
+extern bool g_bBrazilianMayte; /* true = MAYTE cheat car uses the Brazilian FATAL.EXE's nitro-boost behavior instead of the original top-speed one, regardless of whether the boost is currently active */
 extern bool g_bFreeCamera; /* debug: hold RMB + move mouse to free-look in any view (see view.c chase_look_apply) */
 extern int   g_iTextureFilter;   /* 0=nearest, 1=bilinear, 2=anisotropic */
 extern int   g_iAnisotropyLevel; /* 0=2x, 1=4x, 2=8x, 3=16x */

--- a/PROJECTS/ROLLER/rollerinput.c
+++ b/PROJECTS/ROLLER/rollerinput.c
@@ -3056,6 +3056,13 @@ static int InputParseDebugSetting(const char *szName, const char *szValue)
     return 1;
   }
 
+  if (InputStringEqualsNoCase(szName, "BrazilianMayte")) {
+    g_bBrazilianMayte = InputStringEqualsNoCase(szValue, "On") ||
+                         InputStringEqualsNoCase(szValue, "1")  ||
+                         InputStringEqualsNoCase(szValue, "True");
+    return 1;
+  }
+
   if (InputStringEqualsNoCase(szName, "CRTFilter")) {
     g_bCRTFilter = InputStringEqualsNoCase(szValue, "On") ||
                    InputStringEqualsNoCase(szValue, "1")  ||
@@ -3462,6 +3469,7 @@ void InputSaveConfig(void)
   fprintf(fp, "Vsync=%s\n", g_bVsync ? "On" : "Off");
   fprintf(fp, "EmulateSoftwareTrackBorders=%s\n", g_bEmulateSoftwareTrackBorders ? "On" : "Off");
   fprintf(fp, "ShowCarOnExplosion=%s\n", g_bShowCarOnExplosion ? "On" : "Off");
+  fprintf(fp, "BrazilianMayte=%s\n", g_bBrazilianMayte ? "On" : "Off");
   fprintf(fp, "CRTFilter=%s\n",   g_bCRTFilter   ? "On" : "Off");
   fprintf(fp, "SignsOnTop=%s\n",  g_bSignsOnTop  ? "On" : "Off");
   fprintf(fp, "ShiftFreeze=%s\n", g_bShiftFreezeEnabled ? "On" : "Off");

--- a/PROJECTS/ROLLER/scene_render_gpu.c
+++ b/PROJECTS/ROLLER/scene_render_gpu.c
@@ -5256,7 +5256,18 @@ void scene_render_gpu_quad_world_legacy(SceneRendererGPU *r,
             int newIdx  = newType & SURFACE_MASK_TEXTURE_INDEX;
             if (newIdx >= 0 && newIdx < slot->numTiles) {
                 surfIdx = newIdx;
-                isBackTexSign = true;
+                /* Route through the extreme-bias/COMPARE_ALWAYS sign pipeline only for
+                 * real advert signs (SURFACE_FLAG_GPU_IS_SIGN) -- that treatment exists
+                 * so a sign panel reliably wins against the coplanar wall it sits on, but
+                 * applied to an ordinary two-sided wall that merely uses texture_back[]
+                 * for a plain reverse-side texture (no coplanar partner to win against),
+                 * it instead makes the wall win against everything indiscriminately,
+                 * including the car and the pause-menu darken overlay. Non-sign back-tex
+                 * surfaces keep the texture substitution but fall through to their normal
+                 * (properly depth-tested) pipeline via the FLIP_BACKFACE/TEXTURE_PAIR/etc.
+                 * classification below. */
+                if (surfaceFlags & SURFACE_FLAG_GPU_IS_SIGN)
+                    isBackTexSign = true;
             }
         }
         s_lastUV.backTexApplied = isBackTexSign;

--- a/PROJECTS/ROLLER/types.h
+++ b/PROJECTS/ROLLER/types.h
@@ -91,6 +91,7 @@
 #define CHEAT_MODE_TINY_CARS            0x00008000
 #define CHEAT_MODE_WARP                 0x00010000
 #define CHEAT_MODE_FREAKY               0x00020000
+#define CHEAT_MODE_MAYTE_BRAZILIAN      0x00040000  // ROLLER-added: MAYTEB cheat name (see frontend_util.c)
 
 //-------------------------------------------------------------------------------------------------
 // textures_off flags

--- a/PROJECTS/ROLLER/types.h
+++ b/PROJECTS/ROLLER/types.h
@@ -91,7 +91,6 @@
 #define CHEAT_MODE_TINY_CARS            0x00008000
 #define CHEAT_MODE_WARP                 0x00010000
 #define CHEAT_MODE_FREAKY               0x00020000
-#define CHEAT_MODE_MAYTE_BRAZILIAN      0x00040000  // ROLLER-added: MAYTEB cheat name (see frontend_util.c)
 
 //-------------------------------------------------------------------------------------------------
 // textures_off flags


### PR DESCRIPTION
## Summary
- Ports the Brazilian FATAL.EXE-exclusive MAYTE "nitro boost with fire" cheat mechanic (issue #76) — the English release's MAYTE only ever forced auto-throttle.
- Trigger: car pinned at redline in top (6th) gear, or airborne; consumes ammo, applies a real velocity impulse (exact constants/formula traced from the Brazilian binary's disassembly), and spawns a fire/spark particle reusing the existing CarSpray/dospray() infrastructure.
- Re-trigger is gated by `fSpeedOverflow` (an existing shared-physics field, not a new charge meter), which only decays via the game's own deceleration code — matches the real binary's behavior, verified via live A/B testing against the actual DOSBox Brazilian executable.