### PR TITLE
fix wheel animation stuck on stationary frame at high speed (#264)

### DIFF
--- a/PROJECTS/ROLLER/game_render_hardware.c
+++ b/PROJECTS/ROLLER/game_render_hardware.c
@@ -34,7 +34,8 @@ static inline int hw_d2i(double d) {
 
 #define GAME_RENDER_HW_NUM_CARS      16
 #define GAME_RENDER_HW_MAX_CAR_DRAWS 32  /* 16 cars × up to 2 draws each */
-#define GRHW_ANIM_FRAMES             4   /* wheel animation frames 0-3 */
+#define GRHW_ANIM_FRAMES             5   /* wheel animation frames: 0-3 rolling, 4 = high-speed
+                                            * (control.c sets byWheelAnimationFrame=4 at >=300 speed) */
 
 /* --------------------------------------------------------------------------
  * Vertex layout matching SceneGPUMeshVertex in menu_render_gpu.c (same


### PR DESCRIPTION
## Summary
- Fixes #264: car wheels appear stuck on the stationary texture at high speed in hardware/GPU mode
- Root cause: `GRHW_ANIM_FRAMES` was hardcoded to 4, but `control.c` sets `byWheelAnimationFrame = 4` as a distinct high-speed frame once a car reaches >=300 speed. The GPU mesh cache only pre-built vertex buffers for frames 0-3, so frame 4 silently fell back to frame 0 (stationary-looking) at draw time.
- Bumped `GRHW_ANIM_FRAMES` to 5; every loop/array using the constant is generic and extends automatically, no other code changes needed.