### PR TITLE
Fix hardware menu volume bars and black screen on HW/SW switch (#266)

### DIFF
--- a/PROJECTS/ROLLER/frontend.h
+++ b/PROJECTS/ROLLER/frontend.h
@@ -262,7 +262,7 @@ void snapshot_render_menu_select_disk(void);
 void snapshot_render_menu_select_car(void);
 void snapshot_render_menu_configure(void);
 void front_displaycalibrationbar(int iY, int iX, int iValue);
-void front_volumebar(int iY, int iVolumeLevel, int iFillColor);
+void front_volumebar(MenuRenderer *pRenderer, int iY, int iVolumeLevel, int iFillColor, const tColor *pal);
 void snapshot_render_menu_select_players(void);
 void snapshot_render_menu_select_type(void);
 void snapshot_render_menu_select_track(void);

--- a/PROJECTS/ROLLER/frontend_config.c
+++ b/PROJECTS/ROLLER/frontend_config.c
@@ -1647,23 +1647,23 @@ void frontend_config_update(void)
           byColor_15 = 0xAB;
         else
           byColor_15 = 0xA5;
-        front_volumebar(80, EngineVolume, byColor_15);
+        front_volumebar(mr, 80, EngineVolume, byColor_15, pal_addr);
         if (iFrontendConfigVolumeSelection == 2)
           byColor_16 = 0xAB;
         else
           byColor_16 = 0xA5;
-        front_volumebar(104, SFXVolume, byColor_16);
+        front_volumebar(mr, 104, SFXVolume, byColor_16, pal_addr);
         if (iFrontendConfigVolumeSelection == 3)
           byColor_17 = 0xAB;
         else
           byColor_17 = 0xA5;
         iFrontendConfigVolumeSelection_1 = iFrontendConfigVolumeSelection;
-        front_volumebar(128, SpeechVolume, byColor_17);
+        front_volumebar(mr, 128, SpeechVolume, byColor_17, pal_addr);
         if (iFrontendConfigVolumeSelection_1 == 4)
           byColor_18 = 0xAB;
         else
           byColor_18 = 0xA5;
-        front_volumebar(152, MusicVolume, byColor_18);
+        front_volumebar(mr, 152, MusicVolume, byColor_18, pal_addr);
         goto RENDER_FRAME;
       case 2:
         iFrontendConfigMenuSelection = 3;
@@ -3448,11 +3448,26 @@ void front_displaycalibrationbar(int iY, int iX, int iValue)
 
 //-------------------------------------------------------------------------------------------------
 //00046F40
-void front_volumebar(int iY, int iVolumeLevel, int iFillColor)
+void front_volumebar(MenuRenderer *pRenderer, int iY, int iVolumeLevel, int iFillColor, const tColor *pal)
 {
   uint8 *pbyScreenPos; // ecx
   int iRow; // esi
   int iScreenWidth; // eax
+
+  /* GPU mode never composites the legacy scrbuf overlay in the main menu (unlike the
+   * in-race HUD/pause menu, which does) -- the raw writes below are then a silent
+   * no-op, which is why the volume bars were invisible in hardware mode (issue #266).
+   * Draw the same bar geometry via the mode-dispatching menu_render_box/_fill instead. */
+  if (menu_render_get_mode(pRenderer) == MENU_RENDER_GPU) {
+    int iFillWidth = 160 * iVolumeLevel / 127;
+    menu_render_fill(pRenderer, 430, iY,      162, 1,  0x8F, pal);   // top border
+    menu_render_fill(pRenderer, 430, iY + 16, 162, 1,  0x8F, pal);   // bottom border
+    menu_render_fill(pRenderer, 430, iY + 1,  1,   15, 0x8F, pal);   // left border
+    menu_render_fill(pRenderer, 591, iY + 1,  1,   15, 0x8F, pal);   // right border
+    if (iFillWidth > 0)
+      menu_render_fill(pRenderer, 431, iY + 1, iFillWidth, 15, iFillColor, pal);
+    return;
+  }
 
   pbyScreenPos = &scrbuf[winw * iY + 430];      // Calculate starting position in screen buffer (430 pixels from left edge)
   for (iRow = 0; iRow < 17; ++iRow)           // Draw 17 rows for the volume bar

--- a/PROJECTS/ROLLER/menu_render.c
+++ b/PROJECTS/ROLLER/menu_render.c
@@ -36,9 +36,16 @@ static int menu_render_wants_gpu_assets(MenuRenderer *renderer) {
 static MenuRenderMode menu_render_effective_mode(MenuRenderer *renderer) {
     if (!renderer)
         return MENU_RENDER_SOFTWARE;
-    if (renderer->pendingMode == MENU_RENDER_GPU && !renderer->gpu)
+    /* Fades must target whichever renderer is actually drawing THIS frame, i.e.
+     * "mode" -- not "pendingMode", which only takes effect at the next
+     * begin_frame. Routing on pendingMode let a fade begun on the same frame
+     * as a mode-switch request land on the renderer that wasn't drawing yet,
+     * permanently orphaning its fade state (e.g. stuck fully opaque black)
+     * since the switch's own end of the fade pair would then dispatch to the
+     * OTHER renderer once mode had caught up. */
+    if (renderer->mode == MENU_RENDER_GPU && !renderer->gpu)
         return MENU_RENDER_SOFTWARE;
-    return renderer->pendingMode;
+    return renderer->mode;
 }
 
 static int menu_render_upload_gpu_slot(MenuRenderer *renderer, int slot) {

--- a/PROJECTS/ROLLER/menu_render.c
+++ b/PROJECTS/ROLLER/menu_render.c
@@ -210,6 +210,17 @@ void menu_render_box(MenuRenderer *renderer, int x, int y, int width,
                            colorIndex, palette);
 }
 
+void menu_render_fill(MenuRenderer *renderer, int x, int y, int width,
+                      int height, uint8 colorIndex, const tColor *palette) {
+    if (!renderer) return;
+    if (renderer->mode == MENU_RENDER_GPU && renderer->gpu)
+        menu_render_gpu_fill(renderer->gpu, x, y, width, height,
+                             colorIndex, palette);
+    else
+        menu_render_sw_fill(renderer->sw, x, y, width, height,
+                            colorIndex, palette);
+}
+
 void menu_render_begin_fade(MenuRenderer *renderer, int direction,
                             int durationFrames) {
     if (!renderer) return;

--- a/PROJECTS/ROLLER/menu_render.h
+++ b/PROJECTS/ROLLER/menu_render.h
@@ -45,6 +45,8 @@ void menu_render_sprite(MenuRenderer *renderer, int slot, int blockIdx,
                         const tColor *palette);
 void menu_render_box(MenuRenderer *renderer, int x, int y, int width,
                      int height, uint8 colorIndex, const tColor *palette);
+void menu_render_fill(MenuRenderer *renderer, int x, int y, int width,
+                      int height, uint8 colorIndex, const tColor *palette);
 
 // Fade system
 void menu_render_begin_fade(MenuRenderer *renderer, int direction, int durationFrames);

--- a/PROJECTS/ROLLER/menu_render_gpu.c
+++ b/PROJECTS/ROLLER/menu_render_gpu.c
@@ -876,6 +876,37 @@ void menu_render_gpu_box(MenuRendererGPU *r, int x, int y, int width,
     }
 }
 
+/* Solid filled rectangle (menu_render_gpu_box above is outline-only, matching
+ * SW's box_screen -- this is the separate primitive for a filled area, e.g.
+ * a volume bar's fill portion). */
+void menu_render_gpu_fill(MenuRendererGPU *r, int x, int y, int width,
+                          int height, uint8 colorIdx, const tColor *pal)
+{
+    int x2;
+    int y2;
+
+    if (!r || width <= 0 || height <= 0)
+        return;
+
+    x2 = x + width - 1;
+    y2 = y + height - 1;
+    if (x2 < 0 || y2 < 0 || x >= MENU_WIDTH || y >= MENU_HEIGHT)
+        return;
+
+    if (x < 0)
+        x = 0;
+    if (y < 0)
+        y = 0;
+    if (x2 >= MENU_WIDTH)
+        x2 = MENU_WIDTH - 1;
+    if (y2 >= MENU_HEIGHT)
+        y2 = MENU_HEIGHT - 1;
+    if (x2 < x || y2 < y)
+        return;
+
+    menu_render_gpu_solid_quad(r, x, y, x2 - x + 1, y2 - y + 1, colorIdx, pal);
+}
+
 //---------------------------------------------------------------------------
 // Text rendering
 //---------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/menu_render_gpu.h
+++ b/PROJECTS/ROLLER/menu_render_gpu.h
@@ -38,6 +38,8 @@ void menu_render_gpu_sprite(MenuRendererGPU *renderer, int slot, int blockIdx,
                         const tColor *palette);
 void menu_render_gpu_box(MenuRendererGPU *renderer, int x, int y, int width,
                          int height, uint8 colorIndex, const tColor *palette);
+void menu_render_gpu_fill(MenuRendererGPU *renderer, int x, int y, int width,
+                          int height, uint8 colorIndex, const tColor *palette);
 
 // Fade system
 void menu_render_gpu_begin_fade(MenuRendererGPU *renderer, int direction, int durationFrames);

--- a/PROJECTS/ROLLER/menu_render_software.c
+++ b/PROJECTS/ROLLER/menu_render_software.c
@@ -143,6 +143,39 @@ void menu_render_sw_box(MenuRendererSoftware *sw, int x, int y, int width,
     winw = savedWinW;
 }
 
+/* Solid filled rectangle (menu_render_sw_box above is outline-only, matching
+ * box_screen -- this is the separate primitive for a filled area, e.g. a
+ * volume bar's fill portion). */
+void menu_render_sw_fill(MenuRendererSoftware *sw, int x, int y, int width,
+                         int height, uint8 colorIndex, const tColor *palette) {
+    int x2, y2, row;
+    uint8 *pRow;
+
+    (void)sw;
+    (void)palette;
+
+    if (!scrbuf || width <= 0 || height <= 0)
+        return;
+
+    x2 = x + width - 1;
+    y2 = y + height - 1;
+    if (x2 < 0 || y2 < 0 || x >= MENU_SW_WIDTH || y >= MENU_SW_HEIGHT)
+        return;
+
+    if (x < 0)  x = 0;
+    if (y < 0)  y = 0;
+    if (x2 >= MENU_SW_WIDTH)  x2 = MENU_SW_WIDTH - 1;
+    if (y2 >= MENU_SW_HEIGHT) y2 = MENU_SW_HEIGHT - 1;
+    if (x2 < x || y2 < y)
+        return;
+
+    pRow = &scrbuf[MENU_SW_WIDTH * y + x];
+    for (row = y; row <= y2; row++) {
+        memset(pRow, colorIndex, x2 - x + 1);
+        pRow += MENU_SW_WIDTH;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Fade system
 // ---------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/menu_render_software.h
+++ b/PROJECTS/ROLLER/menu_render_software.h
@@ -26,6 +26,8 @@ void menu_render_sw_sprite(MenuRendererSoftware *sw, int slot, int blockIdx,
                            const tColor *palette);
 void menu_render_sw_box(MenuRendererSoftware *sw, int x, int y, int width,
                         int height, uint8 colorIndex, const tColor *palette);
+void menu_render_sw_fill(MenuRendererSoftware *sw, int x, int y, int width,
+                         int height, uint8 colorIndex, const tColor *palette);
 
 // Fade system
 void menu_render_sw_begin_fade(MenuRendererSoftware *sw, int direction,


### PR DESCRIPTION
Fixes #266.

Two separate bugs reported under the same issue:

1. Volume bars were invisible in the hardware main menu, then visible
   but not filling with color. menu_render_box/menu_render_gpu_box
   mirror SW's outline-only box_screen and additionally reject any
   1px-thick strip, so neither the border nor a solid fill could be
   drawn with it. Added a real solid-fill primitive
   (menu_render_fill/_gpu_fill/_sw_fill) and switched the volume bar
   to use it for both the border and the fill.

2. Switching to hardware rendering could turn the screen fully black.
   menu_render_effective_mode() decided which renderer (GPU or SW) a
   fade-in/fade-out call should target using pendingMode, but actual
   frame rendering dispatches on mode, which only catches up to
   pendingMode at the next begin_frame. On the one frame where a mode
   switch was requested but not yet applied, a fade-out issued that
   frame got routed to the renderer that wasn't drawing yet, leaving
   its fade state stuck at fully opaque black with no corresponding
   fade-in ever arriving to clear it. Switched the routing to use mode
   instead.