### PR TITLE
Encapsulate frontend state in FSM API

### DIFF
--- a/PROJECTS/ROLLER/3d.c
+++ b/PROJECTS/ROLLER/3d.c
@@ -446,7 +446,7 @@ void frontend_shutdown_enter(void)
 void frontend_shutdown_request(void)
 {
   frontend_shutdown_begin();
-  eFrontendNextState = iFrontendShutdownComplete ? eFRONTEND_STATE_QUIT : eFRONTEND_STATE_SHUTDOWN;
+  frontend_request_state(iFrontendShutdownComplete ? eFRONTEND_STATE_QUIT : eFRONTEND_STATE_SHUTDOWN);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -454,7 +454,7 @@ void frontend_shutdown_request(void)
 void frontend_shutdown_update(void)
 {
   if (frontend_shutdown_pump())
-    eFrontendNextState = eFRONTEND_STATE_QUIT;
+    frontend_request_state(eFRONTEND_STATE_QUIT);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -872,8 +872,8 @@ void champion_race_enter(void)
 int champion_race_update(void)
 {
   race_update();
-  if (eFrontendNextState == eFRONTEND_STATE_RESULTS) {
-    eFrontendNextState = eFRONTEND_STATE_CHAMPIONSHIP_OVER;
+  if (frontend_pending_state() == eFRONTEND_STATE_RESULTS) {
+    frontend_request_state(eFRONTEND_STATE_CHAMPIONSHIP_OVER);
     return -1;
   }
   return 0;
@@ -925,7 +925,7 @@ static void frontend_finish_post_race_sequence(void)
   iFrontendTimeTrialCarIdx = 0;
   iFrontendTimeTrialScreenActive = 0;
   iFrontendTimeTrialScreenActive = 0;
-  eFrontendNextState = quit_game ? eFRONTEND_STATE_QUIT : eFRONTEND_STATE_MAIN_MENU;
+  frontend_request_state(quit_game ? eFRONTEND_STATE_QUIT : eFRONTEND_STATE_MAIN_MENU);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -933,9 +933,9 @@ static void frontend_finish_post_race_sequence(void)
 static void frontend_after_single_result_screens(void)
 {
   if ((cheat_mode & CHEAT_MODE_END_SEQUENCE) != 0) {
-    eFrontendNextState = eFRONTEND_STATE_CHAMPIONSHIP_OVER;
+    frontend_request_state(eFRONTEND_STATE_CHAMPIONSHIP_OVER);
   } else if ((cheat_mode & CHEAT_MODE_CREDITS) != 0) {
-    eFrontendNextState = eFRONTEND_STATE_CREDITS;
+    frontend_request_state(eFRONTEND_STATE_CREDITS);
   } else {
     frontend_finish_post_race_sequence();
   }
@@ -948,9 +948,9 @@ static void frontend_after_championship_lap_records(void)
   ++Race;
   TrackLoad = prev_track + 1;
   if (Race == 8 || (cheat_mode & CHEAT_MODE_END_SEQUENCE) != 0) {
-    eFrontendNextState = eFRONTEND_STATE_CHAMPIONSHIP_OVER;
+    frontend_request_state(eFRONTEND_STATE_CHAMPIONSHIP_OVER);
   } else if ((cheat_mode & CHEAT_MODE_CREDITS) != 0) {
-    eFrontendNextState = eFRONTEND_STATE_CREDITS;
+    frontend_request_state(eFRONTEND_STATE_CREDITS);
   } else {
     frontend_finish_post_race_sequence();
   }
@@ -965,12 +965,12 @@ static void frontend_run_game_loop(eFrontendState eInitialState);
 int main_loop_iteration(void)
 {
   if (quit_game &&
-      eFrontendCurrentState != eFRONTEND_STATE_SHUTDOWN &&
-      eFrontendCurrentState != eFRONTEND_STATE_QUIT)
-    eFrontendNextState = eFRONTEND_STATE_SHUTDOWN;
+      frontend_current_state() != eFRONTEND_STATE_SHUTDOWN &&
+      frontend_current_state() != eFRONTEND_STATE_QUIT)
+    frontend_request_state(eFRONTEND_STATE_SHUTDOWN);
 
-  if (eFrontendCurrentState == eFRONTEND_STATE_QUIT &&
-      eFrontendNextState == eFRONTEND_STATE_QUIT)
+  if (frontend_current_state() == eFRONTEND_STATE_QUIT &&
+      frontend_pending_state() == eFRONTEND_STATE_QUIT)
     return 0;
 
   UpdateSDL();
@@ -983,12 +983,12 @@ int main_loop_iteration(void)
 #endif
 
   if (quit_game &&
-      eFrontendCurrentState != eFRONTEND_STATE_SHUTDOWN &&
-      eFrontendCurrentState != eFRONTEND_STATE_QUIT)
-    eFrontendNextState = eFRONTEND_STATE_SHUTDOWN;
+      frontend_current_state() != eFRONTEND_STATE_SHUTDOWN &&
+      frontend_current_state() != eFRONTEND_STATE_QUIT)
+    frontend_request_state(eFRONTEND_STATE_SHUTDOWN);
 
   frontend_update();
-  return eFrontendCurrentState != eFRONTEND_STATE_QUIT;
+  return frontend_current_state() != eFRONTEND_STATE_QUIT;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1030,7 +1030,7 @@ void frontend_copy_screens_enter(void)
 void frontend_copy_screens_update(void)
 {
   if (CopyScreensUpdate())
-    eFrontendNextState = eFRONTEND_STATE_TITLE;
+    frontend_request_state(eFRONTEND_STATE_TITLE);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1057,15 +1057,15 @@ void frontend_loading_enter(void)
 void frontend_loading_update(void)
 {
   if (quit_game) {
-    eFrontendNextState = eFRONTEND_STATE_QUIT;
+    frontend_request_state(eFRONTEND_STATE_QUIT);
   } else if (game_type < 3) {
-    eFrontendNextState = eFRONTEND_STATE_TITLE;
+    frontend_request_state(eFRONTEND_STATE_TITLE);
   } else if (game_type == 3) {
     eFrontendPostRaceCurrentFlow = eFRONTEND_POST_RACE_STANDALONE_CHAMPIONSHIP;
     iFrontendPostRaceCleanup = 0;
-    eFrontendNextState = eFRONTEND_STATE_CHAMPIONSHIP_STANDINGS;
+    frontend_request_state(eFRONTEND_STATE_CHAMPIONSHIP_STANDINGS);
   } else {
-    eFrontendNextState = eFRONTEND_STATE_RESULTS;
+    frontend_request_state(eFRONTEND_STATE_RESULTS);
   }
 }
 
@@ -1091,7 +1091,7 @@ void frontend_title_update(void)
   net_quit = 0;
   prev_track = TrackLoad;
   race_set_track(TrackLoad);
-  eFrontendNextState = eFRONTEND_STATE_RACING;
+  frontend_request_state(eFRONTEND_STATE_RACING);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1111,7 +1111,7 @@ void frontend_results_update(void)
 
   if (game_type >= 3) {
     eFrontendPostRaceCurrentFlow = eFRONTEND_POST_RACE_RECORDS;
-    eFrontendNextState = eFRONTEND_STATE_LAP_RECORDS;
+    frontend_request_state(eFRONTEND_STATE_LAP_RECORDS);
     return;
   }
 
@@ -1121,7 +1121,7 @@ void frontend_results_update(void)
   if (network_buggered && !iFrontendNetworkErrorHandled) {
     iFrontendGameFlags = 0;
     iFrontendNetworkErrorHandled = -1;
-    eFrontendNextState = eFRONTEND_STATE_NETWORK_ERROR;
+    frontend_request_state(eFRONTEND_STATE_NETWORK_ERROR);
     return;
   }
   if (net_quit || network_buggered) {
@@ -1135,7 +1135,7 @@ void frontend_results_update(void)
   }
   if (cd_error) {
     iFrontendGameFlags = 0;
-    eFrontendNextState = eFRONTEND_STATE_NO_CD_ERROR;
+    frontend_request_state(eFRONTEND_STATE_NO_CD_ERROR);
     return;
   }
   VIEWDIST = 270;
@@ -1147,7 +1147,7 @@ void frontend_results_update(void)
         if (game_type == 2) {
           StoreResult();
           eFrontendPostRaceCurrentFlow = eFRONTEND_POST_RACE_TIME_TRIAL;
-          eFrontendNextState = eFRONTEND_STATE_TIME_TRIAL_RESULTS;
+          frontend_request_state(eFRONTEND_STATE_TIME_TRIAL_RESULTS);
           return;
         }
         frontend_finish_post_race_sequence();
@@ -1156,18 +1156,18 @@ void frontend_results_update(void)
       eFrontendPostRaceCurrentFlow = eFRONTEND_POST_RACE_CHAMPIONSHIP;
       finish_race();                            // Championship mode - handle race completion
       StoreResult();
-      eFrontendNextState = frontend_should_show_winner_screen()
+      frontend_request_state(frontend_should_show_winner_screen()
         ? eFRONTEND_STATE_WINNER_SCREEN
-        : eFRONTEND_STATE_RESULT_ROUNDUP;
+        : eFRONTEND_STATE_RESULT_ROUNDUP);
       return;
     }
     eFrontendPostRaceCurrentFlow = eFRONTEND_POST_RACE_SINGLE;
     if (!gave_up) {
       finish_race();
       StoreResult();
-      eFrontendNextState = frontend_should_show_winner_screen()
+      frontend_request_state(frontend_should_show_winner_screen()
         ? eFRONTEND_STATE_WINNER_SCREEN
-        : eFRONTEND_STATE_RESULT_ROUNDUP;
+        : eFRONTEND_STATE_RESULT_ROUNDUP);
       return;
     }
     frontend_after_single_result_screens();
@@ -1189,7 +1189,7 @@ void frontend_network_error_enter(void)
 void frontend_network_error_update(void)
 {
   if (NetworkFuckedUpdate())
-    eFrontendNextState = eFRONTEND_STATE_RESULTS;
+    frontend_request_state(eFRONTEND_STATE_RESULTS);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1212,7 +1212,7 @@ void frontend_no_cd_update(void)
 {
   if (NoCdUpdate()) {
     quit_game = -1;
-    eFrontendNextState = eFRONTEND_STATE_SHUTDOWN;
+    frontend_request_state(eFRONTEND_STATE_SHUTDOWN);
   }
 }
 
@@ -1230,9 +1230,9 @@ void frontend_winner_screen_update(void)
   if (!WinnerScreenUpdate())
     return;
   if (WinnerScreenResult())
-    eFrontendNextState = eFRONTEND_STATE_WINNER_RACE;
+    frontend_request_state(eFRONTEND_STATE_WINNER_RACE);
   else
-    eFrontendNextState = eFRONTEND_STATE_RESULT_ROUNDUP;
+    frontend_request_state(eFRONTEND_STATE_RESULT_ROUNDUP);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1263,8 +1263,8 @@ void frontend_winner_race_enter(void)
 void frontend_winner_race_update(void)
 {
   race_update();
-  if (eFrontendNextState == eFRONTEND_STATE_RESULTS)
-    eFrontendNextState = eFRONTEND_STATE_RESULT_ROUNDUP;
+  if (frontend_pending_state() == eFRONTEND_STATE_RESULTS)
+    frontend_request_state(eFRONTEND_STATE_RESULT_ROUNDUP);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1288,7 +1288,7 @@ void frontend_result_roundup_update(void)
 {
   if (!ResultRoundUpUpdate())
     return;
-  eFrontendNextState = eFRONTEND_STATE_RACE_RESULT;
+  frontend_request_state(eFRONTEND_STATE_RACE_RESULT);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1312,9 +1312,9 @@ void frontend_race_result_update(void)
   if (!RaceResultUpdate())
     return;
   if (eFrontendPostRaceCurrentFlow == eFRONTEND_POST_RACE_CHAMPIONSHIP)
-    eFrontendNextState = eFRONTEND_STATE_CHAMPIONSHIP_STANDINGS;
+    frontend_request_state(eFRONTEND_STATE_CHAMPIONSHIP_STANDINGS);
   else if (eFrontendPostRaceCurrentFlow == eFRONTEND_POST_RACE_SINGLE)
-    eFrontendNextState = eFRONTEND_STATE_LAP_RECORDS;
+    frontend_request_state(eFRONTEND_STATE_LAP_RECORDS);
   else
     frontend_finish_post_race_sequence();
 }
@@ -1333,9 +1333,9 @@ void frontend_championship_standings_update(void)
   if (!ChampionshipStandingsUpdate())
     return;
   if (frontend_should_show_team_standings()) {
-    eFrontendNextState = eFRONTEND_STATE_TEAM_STANDINGS;
+    frontend_request_state(eFRONTEND_STATE_TEAM_STANDINGS);
   } else if (eFrontendPostRaceCurrentFlow == eFRONTEND_POST_RACE_CHAMPIONSHIP) {
-    eFrontendNextState = eFRONTEND_STATE_LAP_RECORDS;
+    frontend_request_state(eFRONTEND_STATE_LAP_RECORDS);
   } else {
     dontrestart = -1;
     frontend_finish_post_race_sequence();
@@ -1363,7 +1363,7 @@ void frontend_team_standings_update(void)
   if (!TeamStandingsUpdate())
     return;
   if (eFrontendPostRaceCurrentFlow == eFRONTEND_POST_RACE_CHAMPIONSHIP) {
-    eFrontendNextState = eFRONTEND_STATE_LAP_RECORDS;
+    frontend_request_state(eFRONTEND_STATE_LAP_RECORDS);
   } else {
     dontrestart = -1;
     frontend_finish_post_race_sequence();
@@ -1440,7 +1440,7 @@ void frontend_time_trial_results_update(void)
       return;
     }
   }
-  eFrontendNextState = eFRONTEND_STATE_LAP_RECORDS;
+  frontend_request_state(eFRONTEND_STATE_LAP_RECORDS);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1468,7 +1468,7 @@ void frontend_championship_over_update(void)
     return;
   if (eFrontendPostRaceCurrentFlow == eFRONTEND_POST_RACE_SINGLE &&
       (cheat_mode & CHEAT_MODE_CREDITS) != 0)
-    eFrontendNextState = eFRONTEND_STATE_CREDITS;
+    frontend_request_state(eFRONTEND_STATE_CREDITS);
   else
     frontend_finish_post_race_sequence();
 }
@@ -1637,7 +1637,7 @@ void race_update(void)
       return;
 
     iFrontendRaceFadeOutPending = 0;
-    eFrontendNextState = eFRONTEND_STATE_RESULTS;
+    frontend_request_state(eFRONTEND_STATE_RESULTS);
     return;
   }
 
@@ -1648,7 +1648,7 @@ void race_update(void)
       return;
     }
 
-    eFrontendNextState = eFRONTEND_STATE_RESULTS;
+    frontend_request_state(eFRONTEND_STATE_RESULTS);
     return;
   }
 
@@ -2224,11 +2224,11 @@ void doexit()
   frontend_shutdown_request();
 
   if (!frontend_shutdown_complete() &&
-      (eFrontendCurrentState == eFRONTEND_STATE_NONE ||
-       eFrontendCurrentState == eFRONTEND_STATE_QUIT))
+      (frontend_current_state() == eFRONTEND_STATE_NONE ||
+       frontend_current_state() == eFRONTEND_STATE_QUIT))
     frontend_set_state(eFRONTEND_STATE_SHUTDOWN);
 
-  if (eFrontendCurrentState == eFRONTEND_STATE_SHUTDOWN)
+  if (frontend_current_state() == eFRONTEND_STATE_SHUTDOWN)
     frontend_shutdown_update();
 
 #ifndef __EMSCRIPTEN__

--- a/PROJECTS/ROLLER/frontend.c
+++ b/PROJECTS/ROLLER/frontend.c
@@ -18,9 +18,6 @@ typedef struct {
 
 //-------------------------------------------------------------------------------------------------
 
-eFrontendState eFrontendCurrentState = eFRONTEND_STATE_NONE;
-eFrontendState eFrontendNextState = eFRONTEND_STATE_NONE;
-
 #define OVERLAY_STACK_DEPTH 4
 
 static void frontend_fsm_enter(void *pContext);
@@ -116,17 +113,9 @@ static eFrontendState frontend_resolve_state(eFrontendState eState)
 
 //-------------------------------------------------------------------------------------------------
 
-static void frontend_sync_legacy_globals(void)
-{
-  eFrontendCurrentState = (eFrontendState)fsm_current(&sFrontendMachine);
-  eFrontendNextState = (eFrontendState)fsm_pending(&sFrontendMachine);
-}
-
-//-------------------------------------------------------------------------------------------------
-
 static const tFrontendScreen *frontend_current_screen(void)
 {
-  eFrontendState eState = (eFrontendState)fsm_current(&sFrontendMachine);
+  eFrontendState eState = frontend_current_state();
 
   if (!frontend_state_is_valid(eState))
     return NULL;
@@ -141,7 +130,6 @@ static void frontend_fsm_enter(void *pContext)
   const tFrontendScreen *pScreen;
   (void)pContext;
 
-  frontend_sync_legacy_globals();
   pScreen = frontend_current_screen();
   if (pScreen && pScreen->pfnEnter)
     pScreen->pfnEnter();
@@ -152,18 +140,11 @@ static void frontend_fsm_enter(void *pContext)
 static void frontend_fsm_update(void *pContext)
 {
   const tFrontendScreen *pScreen;
-  eFrontendState eRequestedState;
   (void)pContext;
 
-  frontend_sync_legacy_globals();
   pScreen = frontend_current_screen();
   if (pScreen && pScreen->pfnUpdate)
     pScreen->pfnUpdate();
-
-  eRequestedState = frontend_resolve_state(eFrontendNextState);
-  if (eRequestedState != (eFrontendState)fsm_pending(&sFrontendMachine))
-    (void)fsm_request(&sFrontendMachine, eRequestedState);
-  frontend_sync_legacy_globals();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -173,7 +154,6 @@ static void frontend_fsm_draw(void *pContext)
   const tFrontendScreen *pScreen;
   (void)pContext;
 
-  frontend_sync_legacy_globals();
   pScreen = frontend_current_screen();
   if (pScreen && pScreen->pfnDraw)
     pScreen->pfnDraw();
@@ -186,10 +166,30 @@ static void frontend_fsm_exit(void *pContext)
   const tFrontendScreen *pScreen;
   (void)pContext;
 
-  frontend_sync_legacy_globals();
   pScreen = frontend_current_screen();
   if (pScreen && pScreen->pfnExit)
     pScreen->pfnExit();
+}
+
+//-------------------------------------------------------------------------------------------------
+
+eFrontendState frontend_current_state(void)
+{
+  return (eFrontendState)fsm_current(&sFrontendMachine);
+}
+
+//-------------------------------------------------------------------------------------------------
+
+eFrontendState frontend_pending_state(void)
+{
+  return (eFrontendState)fsm_pending(&sFrontendMachine);
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void frontend_request_state(eFrontendState eState)
+{
+  (void)fsm_request(&sFrontendMachine, frontend_resolve_state(eState));
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -198,30 +198,21 @@ void frontend_set_state(eFrontendState eState)
 {
   eState = frontend_resolve_state(eState);
 
-  if (eState == (eFrontendState)fsm_current(&sFrontendMachine)) {
-    (void)fsm_request(&sFrontendMachine, eState);
-    frontend_sync_legacy_globals();
+  if (eState == frontend_current_state()) {
+    frontend_request_state(eState);
     return;
   }
 
   while (fsm_stack_count(&sFrontendOverlayStack) > 0)
     (void)fsm_stack_pop(&sFrontendOverlayStack);
   (void)fsm_transition(&sFrontendMachine, eState);
-  frontend_sync_legacy_globals();
 }
 
 //-------------------------------------------------------------------------------------------------
 
 void frontend_update(void)
 {
-  eFrontendState eRequestedState;
-
-  eRequestedState = frontend_resolve_state(eFrontendNextState);
-  if (eRequestedState != (eFrontendState)fsm_pending(&sFrontendMachine))
-    (void)fsm_request(&sFrontendMachine, eRequestedState);
-
   (void)fsm_step(&sFrontendMachine);
-  frontend_sync_legacy_globals();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -231,16 +222,14 @@ void push_overlay(eFrontendState eOverlay)
   if (!frontend_state_is_valid(eOverlay))
     return;
 
-  if (fsm_stack_push(&sFrontendOverlayStack, eOverlay) == FSM_OK)
-    frontend_sync_legacy_globals();
+  (void)fsm_stack_push(&sFrontendOverlayStack, eOverlay);
 }
 
 //-------------------------------------------------------------------------------------------------
 
 void pop_overlay(void)
 {
-  if (fsm_stack_pop(&sFrontendOverlayStack) == FSM_OK)
-    frontend_sync_legacy_globals();
+  (void)fsm_stack_pop(&sFrontendOverlayStack);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/PROJECTS/ROLLER/frontend.h
+++ b/PROJECTS/ROLLER/frontend.h
@@ -57,9 +57,9 @@ typedef enum {
   eFRONTEND_STATE_QUIT
 } eFrontendState;
 
-extern eFrontendState eFrontendCurrentState;
-extern eFrontendState eFrontendNextState;
-
+eFrontendState frontend_current_state(void);
+eFrontendState frontend_pending_state(void);
+void frontend_request_state(eFrontendState eState);
 void frontend_set_state(eFrontendState eState);
 void frontend_update(void);
 void push_overlay(eFrontendState eOverlay);

--- a/PROJECTS/ROLLER/frontend_config.c
+++ b/PROJECTS/ROLLER/frontend_config.c
@@ -2100,7 +2100,7 @@ void frontend_config_update(void)
         if (iFrontendConfigExitFading) {
           if (!menu_render_fade_active(mr)) {
             iFrontendConfigExitFading = 0;
-            eFrontendNextState = eFRONTEND_STATE_MAIN_MENU;
+            frontend_request_state(eFRONTEND_STATE_MAIN_MENU);
           }
           return;
         }

--- a/PROJECTS/ROLLER/frontend_lobby.c
+++ b/PROJECTS/ROLLER/frontend_lobby.c
@@ -381,7 +381,7 @@ static int lobby_update_exit_fade(void)
   lobby_draw_frame();
   if (!menu_render_fade_active(GetMenuRenderer())) {
     iLobbyExitFading = 0;
-    eFrontendNextState = eLobbyExitTarget;
+    frontend_request_state(eLobbyExitTarget);
     eLobbyExitTarget = eFRONTEND_STATE_NONE;
   }
   return -1;

--- a/PROJECTS/ROLLER/frontend_screens.c
+++ b/PROJECTS/ROLLER/frontend_screens.c
@@ -559,9 +559,9 @@ static int frontend_main_menu_update_network_wait(void)
       no_clear = 0;
       if (!quit_game && !intro) {
         check_cars();
-        eFrontendNextState = eFRONTEND_STATE_LOBBY;
+        frontend_request_state(eFRONTEND_STATE_LOBBY);
       } else {
-        eFrontendNextState = quit_game ? eFRONTEND_STATE_QUIT : eFRONTEND_STATE_LOADING;
+        frontend_request_state(quit_game ? eFRONTEND_STATE_QUIT : eFRONTEND_STATE_LOADING);
       }
       return -1;
 
@@ -1483,14 +1483,14 @@ static void frontend_main_menu_handle_input(void)
     byKey = fatgetch();
     if (iFrontendMainMenuQuitConfirmed) {
       frontend_main_menu_handle_quit_confirmation(byKey);
-      if (eFrontendNextState != eFrontendCurrentState)
+      if (frontend_pending_state() != frontend_current_state())
         return;
       continue;
     }
     if (byKey) {
       if (byKey == 13) {
         frontend_main_menu_handle_enter();
-        if (eFrontendNextState != eFrontendCurrentState)
+        if (frontend_pending_state() != frontend_current_state())
           return;
       }
     } else {
@@ -1558,7 +1558,7 @@ static int frontend_main_menu_update_fade_out(MenuRenderer *mr)
       frontend_main_menu_free_selected_car_textures();
       frontend_main_menu_free_preview_title_assets();
       iFrontendMainMenuResumeFromChild = -1;
-      eFrontendNextState = eFrontendMainMenuPendingChildState;
+      frontend_request_state(eFrontendMainMenuPendingChildState);
       eFrontendMainMenuPendingChildState = eFRONTEND_STATE_NONE;
       break;
     case eMAIN_MENU_FADE_OUT_START_SOUND:
@@ -1587,7 +1587,7 @@ static int frontend_main_menu_update_fade_out(MenuRenderer *mr)
         if (network_on && iFrontendMainMenuSelection == 8 && !intro) {
           iFrontendMainMenuInitialized = 0;
           iFrontendMainMenuStartDelayTarget = 0;
-          eFrontendNextState = eFRONTEND_STATE_LOBBY;
+          frontend_request_state(eFRONTEND_STATE_LOBBY);
           break;
         }
       }
@@ -1601,7 +1601,7 @@ static int frontend_main_menu_update_fade_out(MenuRenderer *mr)
         frontend_main_menu_prepare_race_start();
       iFrontendMainMenuInitialized = 0;
       iFrontendMainMenuStartDelayTarget = 0;
-      eFrontendNextState = quit_game ? eFRONTEND_STATE_QUIT : eFRONTEND_STATE_LOADING;
+      frontend_request_state(quit_game ? eFRONTEND_STATE_QUIT : eFRONTEND_STATE_LOADING);
       break;
     default:
       break;
@@ -1721,7 +1721,7 @@ void frontend_menu_update(void)
 
   frontend_main_menu_handle_mouse();
   frontend_main_menu_handle_input();
-  if (eFrontendNextState != eFrontendCurrentState)
+  if (frontend_pending_state() != frontend_current_state())
     return;
   frontend_main_menu_update_rotation(nFrames);
 }

--- a/PROJECTS/ROLLER/frontend_select_car.c
+++ b/PROJECTS/ROLLER/frontend_select_car.c
@@ -105,7 +105,7 @@ static void frontend_car_select_black_palette(void)
 static void frontend_car_select_request_exit(void)
 {
   iFrontendCarExitFlag = -1;
-  if (eFrontendCurrentState == eFRONTEND_STATE_CAR_SELECT) {
+  if (frontend_current_state() == eFRONTEND_STATE_CAR_SELECT) {
     MenuRenderer *mr = GetMenuRenderer();
     menu_render_begin_fade(mr, 0, 32);
     iFrontendCarExitFading = 1;
@@ -439,7 +439,7 @@ void frontend_car_select_update(void)
     MenuRenderer *mr = GetMenuRenderer();
     if (!menu_render_fade_active(mr)) {
       iFrontendCarExitFading = 0;
-      eFrontendNextState = eFRONTEND_STATE_MAIN_MENU;
+      frontend_request_state(eFRONTEND_STATE_MAIN_MENU);
     }
     return;
   }
@@ -742,7 +742,7 @@ void frontend_car_select_exit(void)
   if (iFrontendCarOriginalCarSelection >= 0)
     Players_Cars[player1_car] = iFrontendCarOriginalCarSelection;
 
-  if (eFrontendCurrentState == eFRONTEND_STATE_CAR_SELECT)
+  if (frontend_current_state() == eFRONTEND_STATE_CAR_SELECT)
     frontend_menu_resume_from_child();
 }
 

--- a/PROJECTS/ROLLER/frontend_select_disk.c
+++ b/PROJECTS/ROLLER/frontend_select_disk.c
@@ -56,7 +56,7 @@ static void frontend_disk_select_black_palette(void)
 static void frontend_disk_select_request_exit(void)
 {
   iFrontendDiskExitFlag = -1;
-  if (eFrontendCurrentState == eFRONTEND_STATE_DISK_SELECT) {
+  if (frontend_current_state() == eFRONTEND_STATE_DISK_SELECT) {
     MenuRenderer *mr = GetMenuRenderer();
     menu_render_begin_fade(mr, 0, 32);
     iFrontendDiskExitFading = 1;
@@ -495,7 +495,7 @@ void frontend_disk_select_update(void)
     MenuRenderer *mr = GetMenuRenderer();
     if (!menu_render_fade_active(mr)) {
       iFrontendDiskExitFading = 0;
-      eFrontendNextState = eFRONTEND_STATE_MAIN_MENU;
+      frontend_request_state(eFRONTEND_STATE_MAIN_MENU);
     }
     return;
   }
@@ -517,7 +517,7 @@ void frontend_disk_select_exit(void)
     frontend_disk_select_black_palette();
   front_fade = 0;
 
-  if (eFrontendCurrentState == eFRONTEND_STATE_DISK_SELECT)
+  if (frontend_current_state() == eFRONTEND_STATE_DISK_SELECT)
     frontend_menu_resume_from_child();
 }
 

--- a/PROJECTS/ROLLER/frontend_select_players.c
+++ b/PROJECTS/ROLLER/frontend_select_players.c
@@ -610,7 +610,7 @@ static int frontend_players_net_slot_update(void)
 static void frontend_players_select_request_exit(void)
 {
   iFrontendPlayersExitFlag = -1;
-  if (eFrontendCurrentState == eFRONTEND_STATE_PLAYERS_SELECT) {
+  if (frontend_current_state() == eFRONTEND_STATE_PLAYERS_SELECT) {
     MenuRenderer *mr = GetMenuRenderer();
     menu_render_begin_fade(mr, 0, 32);
     iFrontendPlayersExitFading = 1;
@@ -810,7 +810,7 @@ void frontend_players_select_update(void)
     MenuRenderer *mr = GetMenuRenderer();
     if (!menu_render_fade_active(mr)) {
       iFrontendPlayersExitFading = 0;
-      eFrontendNextState = eFRONTEND_STATE_MAIN_MENU;
+      frontend_request_state(eFRONTEND_STATE_MAIN_MENU);
     }
     return;
   }
@@ -953,7 +953,7 @@ void frontend_players_select_exit(void)
   }
   front_fade = 0;
 
-  if (eFrontendCurrentState == eFRONTEND_STATE_PLAYERS_SELECT)
+  if (frontend_current_state() == eFRONTEND_STATE_PLAYERS_SELECT)
     frontend_menu_resume_from_child();
 }
 

--- a/PROJECTS/ROLLER/frontend_select_track.c
+++ b/PROJECTS/ROLLER/frontend_select_track.c
@@ -431,7 +431,7 @@ static void frontend_track_select_black_palette(void)
 static void frontend_track_select_request_exit(void)
 {
   iFrontendTrackExitFlag = -1;
-  if (eFrontendCurrentState == eFRONTEND_STATE_TRACK_SELECT) {
+  if (frontend_current_state() == eFRONTEND_STATE_TRACK_SELECT) {
     MenuRenderer *mr = GetMenuRenderer();
     menu_render_begin_fade(mr, 0, 32);
     iFrontendTrackExitFading = 1;
@@ -958,7 +958,7 @@ void frontend_track_select_update(void)
     MenuRenderer *mr = GetMenuRenderer();
     if (!menu_render_fade_active(mr)) {
       iFrontendTrackExitFading = 0;
-      eFrontendNextState = eFRONTEND_STATE_MAIN_MENU;
+      frontend_request_state(eFRONTEND_STATE_MAIN_MENU);
     }
     return;
   }
@@ -994,7 +994,7 @@ void frontend_track_select_exit(void)
   front_vga[3] = (tBlockHeader *)load_picture("carnames.bm");
   remove_frontendspeech();
 
-  if (eFrontendCurrentState == eFRONTEND_STATE_TRACK_SELECT)
+  if (frontend_current_state() == eFRONTEND_STATE_TRACK_SELECT)
     frontend_menu_resume_from_child();
 }
 

--- a/PROJECTS/ROLLER/frontend_select_type.c
+++ b/PROJECTS/ROLLER/frontend_select_type.c
@@ -285,7 +285,7 @@ static void frontend_type_select_black_palette(void)
 static void frontend_type_select_finish_exit(void)
 {
   iFrontendTypeExitFlag = -1;
-  if (eFrontendCurrentState == eFRONTEND_STATE_TYPE_SELECT) {
+  if (frontend_current_state() == eFRONTEND_STATE_TYPE_SELECT) {
     MenuRenderer *mr = GetMenuRenderer();
     menu_render_begin_fade(mr, 0, 32);
     iFrontendTypeExitFading = 1;
@@ -1108,7 +1108,7 @@ void frontend_type_select_update(void)
     MenuRenderer *mr = GetMenuRenderer();
     if (!menu_render_fade_active(mr)) {
       iFrontendTypeExitFading = 0;
-      eFrontendNextState = eFRONTEND_STATE_MAIN_MENU;
+      frontend_request_state(eFRONTEND_STATE_MAIN_MENU);
     }
     return;
   }
@@ -1129,7 +1129,7 @@ void frontend_type_select_exit(void)
   fre((void **)&front_vga[14]);
   front_fade = 0;
 
-  if (eFrontendCurrentState == eFRONTEND_STATE_TYPE_SELECT)
+  if (frontend_current_state() == eFRONTEND_STATE_TYPE_SELECT)
     frontend_menu_resume_from_child();
 }
 

--- a/PROJECTS/ROLLER/roller.c
+++ b/PROJECTS/ROLLER/roller.c
@@ -1885,7 +1885,7 @@ void UpdateSDL()
     UpdateSDLAudioEvents(e);
     if (e.type == SDL_EVENT_QUIT) {
       quit_game = 1;
-      eFrontendNextState = eFRONTEND_STATE_SHUTDOWN;
+      frontend_request_state(eFRONTEND_STATE_SHUTDOWN);
       continue;
     }
 #if defined(IS_WASM)
@@ -2205,7 +2205,7 @@ void UpdateSDL()
       (SDL_GetWindowFlags(s_pWindow) & SDL_WINDOW_MINIMIZED) != 0;
   bool bDebugOverlayVisible = debug_overlay_visible(s_pDebugOverlay);
   bool bApplyBgCap = g_iFpsBackground > 0 &&
-      (eFrontendCurrentState == eFRONTEND_STATE_PAUSE_OVERLAY ||
+      (frontend_current_state() == eFRONTEND_STATE_PAUSE_OVERLAY ||
        g_bShiftFrozen || bWindowMinimized || bDebugOverlayVisible);
   if (bApplyBgCap) {
     uint64 frameMs = 1000u / (uint64)g_iFpsBackground;

--- a/PROJECTS/ROLLER/rollerinput.c
+++ b/PROJECTS/ROLLER/rollerinput.c
@@ -1594,7 +1594,7 @@ static int InputMenuAnyButtonContext(void)
   if (intro || winner_mode)
     return 1;
 
-  switch (eFrontendCurrentState) {
+  switch (frontend_current_state()) {
     case eFRONTEND_STATE_WINNER_SCREEN:
     case eFRONTEND_STATE_RESULT_ROUNDUP:
     case eFRONTEND_STATE_RACE_RESULT:

--- a/PROJECTS/ROLLER/touch_ui.c
+++ b/PROJECTS/ROLLER/touch_ui.c
@@ -39,7 +39,7 @@ static int touch_ui_race_buttons_visible(void)
 #if defined(IS_ANDROID) || defined(IS_WASM)
   if (!ROLLERPhoneUIActive() || g_bSnapshotMode)
     return 0;
-  if (eFrontendCurrentState != eFRONTEND_STATE_RACING)
+  if (frontend_current_state() != eFRONTEND_STATE_RACING)
     return 0;
   if (frontend_on || game_req || intro || winner_mode || replaytype == 2)
     return 0;
@@ -59,7 +59,7 @@ static int touch_ui_esc_button_visible(void)
 #if defined(IS_ANDROID) || defined(IS_WASM)
   if (!ROLLERPhoneUIActive() || g_bSnapshotMode)
     return 0;
-  if (eFrontendCurrentState != eFRONTEND_STATE_RACING)
+  if (frontend_current_state() != eFRONTEND_STATE_RACING)
     return 0;
   if (frontend_on || game_req || intro || winner_mode)
     return 0;

--- a/tests/test_frontend_state_api.py
+++ b/tests/test_frontend_state_api.py
@@ -1,0 +1,34 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROLLER = ROOT / "PROJECTS" / "ROLLER"
+HEADER = ROLLER / "frontend.h"
+
+
+class FrontendStateApiContractTests(unittest.TestCase):
+    def test_header_exposes_fsm_backed_state_api(self) -> None:
+        header = HEADER.read_text(encoding="utf-8")
+
+        declarations = (
+            "eFrontendState frontend_current_state(void);",
+            "eFrontendState frontend_pending_state(void);",
+            "void frontend_request_state(eFrontendState eState);",
+        )
+        for declaration in declarations:
+            with self.subTest(declaration=declaration):
+                if declaration not in header:
+                    self.fail(f"missing frontend state API: {declaration}")
+
+    def test_legacy_state_globals_are_removed(self) -> None:
+        for path in ROLLER.glob("*.[ch]"):
+            source = path.read_text(encoding="utf-8")
+            for symbol in ("eFrontendCurrentState", "eFrontendNextState"):
+                with self.subTest(path=path.name, symbol=symbol):
+                    if symbol in source:
+                        self.fail(f"{symbol} remains in {path.name}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Stack
- Depends on #288

## Summary
- expose FSM-backed frontend current, pending, and request functions
- migrate frontend callers away from direct state globals
- remove the legacy state globals and synchronization bridge
- add a source contract for the public API and legacy-symbol removal

## Verification
- zig build test-fsm
- zig build
- python3 -m unittest tests.test_frontend_state_api tests.test_cmake_roller_core
- python3 tools/check_roller_core_manifest.py
- python3 tools/check_source_set_drift.py
- git diff --check

## Known unrelated full-suite failures
- missing docs/adr/0003-canonical-geometry-conventions.md
- missing FATDATA/TRACK3.TRK for editor_track_loader_test

## Review
Independent semantic review found no blockers. Residual risk: frontend wrapper behavior is covered by lower-level FSM tests and compilation, while the new frontend API test is a source contract rather than a linked integration test.